### PR TITLE
Fixed issues with CI not using the active branch name and resolved docker build errors

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -7,8 +7,10 @@ on:
       - bug/github-ci-not-using-current-branch-name
 
 env:
-  ARCHES_BASE: ghcr.io/flaxandteal/arches-base-7.5-dev:bug-coral_dockerfile_for_arches_7.4
-  ARCHES_POSTGIS: ghcr.io/flaxandteal/arches-postgis-7.5-dev:bug-coral_dockerfile_for_arches_7.4
+  # ARCHES_BASE: ghcr.io/flaxandteal/arches-base-7.5-dev:bug-coral_dockerfile_for_arches_7.4
+  # ARCHES_POSTGIS: ghcr.io/flaxandteal/arches-postgis-7.5-dev:bug-coral_dockerfile_for_arches_7.4
+  ARCHES_BASE: flaxandteal/arches_coral_base
+  ARCHES_POSTGIS: flaxandteal/arches_coral_postgres
   ARCHES_PROJECT: coral
 jobs:
   Build-Arches:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - bug/github-ci-not-using-current-branch-name
 
 env:
   ARCHES_BASE: ghcr.io/flaxandteal/arches-base-7.5-dev:bug-coral_dockerfile_for_arches_7.4

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - bug/github-ci-not-using-current-branch-name
 
 env:
   ARCHES_BASE: ghcr.io/flaxandteal/arches-base-7.5-dev:bug-coral_dockerfile_for_arches_7.4
@@ -201,11 +202,11 @@ jobs:
           TZ: "PST"
         ports:
           - '8000:8000'
-        # options: >-
-        #   --health-cmd "curl --fail http://localhost:8000/templates/views/components/language-switcher.htm || exit 1"
-        #   --health-interval 10s
-        #   --health-timeout 5s
-        #   --health-retries 1000
+        options: >-
+          --health-cmd "curl --fail http://localhost:8000/templates/views/components/language-switcher.htm || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 1000
   Build-Arches-Final:
     needs: [Build-Arches-Static, Build-Arches]
     runs-on: [self-hosted]

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -260,6 +260,7 @@ jobs:
             PROJECT_STATIC=${{ env.PROJECT_STATIC }}
             ARCHES_BASE=${{ env.ARCHES_BASE }}
             ARCHES_PROJECT=${{ env.ARCHES_PROJECT }}
+            VERSION=${{ steps.meta.outputs.version }}
   Test-Arches:
     runs-on: [self-hosted]
     needs: [Build-Arches-Final, Build-Arches, Build-Arches-Static]

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches:
       - develop
-      - bug/github-ci-not-using-current-branch-name
 
 env:
+  # Using the 7.5-bug version of the container is throwing an error for an
+  # undefined database column using the previous coral base and postgis seems
+  # to have avoided the problem. TODO: Investigate difference between the two
   # ARCHES_BASE: ghcr.io/flaxandteal/arches-base-7.5-dev:bug-coral_dockerfile_for_arches_7.4
   # ARCHES_POSTGIS: ghcr.io/flaxandteal/arches-postgis-7.5-dev:bug-coral_dockerfile_for_arches_7.4
+
   ARCHES_BASE: flaxandteal/arches_coral_base
   ARCHES_POSTGIS: flaxandteal/arches_coral_postgres
   ARCHES_PROJECT: coral

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -129,7 +129,6 @@ jobs:
             ARCHES_BASE=${{ env.ARCHES_BASE }}
             ARCHES_PROJECT=${{ env.ARCHES_PROJECT }}
             ARCHES_NAMESPACE_FOR_DATA_EXPORT=http://localhost:8000/
-            VERSION=${{ steps.meta.outputs.version }}
       - name: Record a project static image reference
         id: set-static
         run: |
@@ -260,7 +259,6 @@ jobs:
             PROJECT_STATIC=${{ env.PROJECT_STATIC }}
             ARCHES_BASE=${{ env.ARCHES_BASE }}
             ARCHES_PROJECT=${{ env.ARCHES_PROJECT }}
-            VERSION=${{ steps.meta.outputs.version }}
   Test-Arches:
     runs-on: [self-hosted]
     needs: [Build-Arches-Final, Build-Arches, Build-Arches-Static]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,25 +7,30 @@ ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
 COPY entrypoint.sh ${WEB_ROOT}/
 COPY ${ARCHES_PROJECT} ${WEB_ROOT}/${ARCHES_PROJECT}/
+# Install packages required to build the python libs, then remove them
+RUN set -ex \
+    && BUILD_DEPS=" \
+        libxslt-dev \
+        git ssh \
+        " \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends $BUILD_DEPS \
+    && (mkdir ~/.ssh && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts) # TODO: fix ckeditor yarn dep
 RUN . ../ENV/bin/activate \
     && pip install --upgrade pip \
     && pip install starlette-graphene3 \
+    && pip install python-docx \
     && pip install starlette-context
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets \
-    && pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt
+    && pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:
 
 COPY settings_docker.py ${WEB_ROOT}/arches/arches/
 RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root
-
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules yarn add -D babel-loader html-loader clean-webpack-plugin webpack-cli mini-css-extract-plugin stylelint-webpack-plugin eslint-webpack-plugin css-loader postcss-loader sass-loader raw-loader ttf-loader file-loader url-loader webpack-dev-server)
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules yarn install -D)
-
-RUN chgrp -R arches ../../ENV && chmod -R g=rwx ../../ENV
-
+RUN yarn install
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 ENTRYPOINT ../entrypoint.sh
 CMD run_arches

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN . ../ENV/bin/activate \
     && pip install starlette-context
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets \
-    && pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:
+    && pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt
 
 COPY settings_docker.py ${WEB_ROOT}/arches/arches/
 RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-ARG VERSION
+ARG PROJECT_BASE
 ARG ARCHES_PROJECT=coral
 ARG ARCHES_BASE=flaxandteal/arches_coral_base
 ARG WEB_ROOT=/web_root
@@ -44,7 +44,7 @@ ENV DJANGO_DEBUG=False \
 RUN useradd arches && mkdir -p /static_root && chown -R arches /static_root
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 
-FROM flaxandteal/arches_${ARCHES_PROJECT}:${VERSION} as arches_dynamic
+FROM $PROJECT_BASE as arches_dynamic
 FROM arches_static_cache as arches
 ARG WEB_ROOT=/web_root
 ARG STATIC_ROOT=/static_root
@@ -61,7 +61,7 @@ RUN ${WEB_ROOT}/entrypoint.sh init_yarn_components
 RUN (echo "\nSTATIC_ROOT='${STATIC_ROOT}'" >> ${WEB_ROOT}/arches/arches/settings_docker.py) && echo $STATIC_ROOT 
 RUN (echo "\nARCHES_NAMESPACE_FOR_DATA_EXPORT='${ARCHES_NAMESPACE_FOR_DATA_EXPORT}'" >> ${WEB_ROOT}/arches/arches/settings_docker.py) && echo $STATIC_ROOT
 
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules yarn add -D babel-loader html-loader clean-webpack-plugin webpack-cli mini-css-extract-plugin stylelint-webpack-plugin eslint-webpack-plugin css-loader postcss-loader sass-loader raw-loader ttf-loader file-loader url-loader)
+#RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules yarn add -D babel-loader html-loader clean-webpack-plugin webpack-cli mini-css-extract-plugin stylelint-webpack-plugin eslint-webpack-plugin css-loader postcss-loader sass-loader raw-loader ttf-loader file-loader url-loader)
 
 RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules yarn install -D)
 RUN /bin/bash -c ". ../ENV/bin/activate;\

--- a/Dockerfile.static-py
+++ b/Dockerfile.static-py
@@ -1,9 +1,9 @@
 ARG VERSION
 ARG ARCHES_PROJECT
 ARG WEB_ROOT=/web_root
-FROM flaxandteal/arches_${ARCHES_PROJECT}_static:$VERSION as arches_static
+FROM flaxandteal/arches_${ARCHES_PROJECT}_static:${VERSION} as arches_static
 
-FROM flaxandteal/arches_${ARCHES_PROJECT}:$VERSION as arches
+FROM flaxandteal/arches_${ARCHES_PROJECT}:${VERSION} as arches
 
 COPY --from=arches_static /usr/share/nginx/webpack-stats.json ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 COPY --from=arches_static /usr/share/nginx/html ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build

--- a/Dockerfile.static-py
+++ b/Dockerfile.static-py
@@ -1,9 +1,10 @@
-ARG VERSION
+ARG PROJECT_BASE
+ARG PROJECT_STATIC
 ARG ARCHES_PROJECT
 ARG WEB_ROOT=/web_root
-FROM flaxandteal/arches_${ARCHES_PROJECT}_static:${VERSION} as arches_static
+FROM $PROJECT_STATIC as arches_static
 
-FROM flaxandteal/arches_${ARCHES_PROJECT}:${VERSION} as arches
+FROM $PROJECT_BASE as arches
 
 COPY --from=arches_static /usr/share/nginx/webpack-stats.json ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 COPY --from=arches_static /usr/share/nginx/html ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build


### PR DESCRIPTION
I have had to use the old arches coral base for the CI to work correctly. I would like to get back and investigate the reason the 7.5 bug fix build of coral arches is throwing a database column missing error when deployed.