### PR TITLE
Feature/excavation license easting and northing system

### DIFF
--- a/coral/coral/media/js/views/components/map-editor-with-latlon.js
+++ b/coral/coral/media/js/views/components/map-editor-with-latlon.js
@@ -1,0 +1,1031 @@
+define([
+    'jquery',
+    'underscore',
+    'knockout',
+    'knockout-mapping',
+    'arches',
+    'uuid',
+    'geojson-extent',
+    'geojsonhint',
+    'togeojson',
+    'proj4',
+    'views/components/map',
+    'views/components/cards/select-feature-layers',
+    'views/components/datatypes/geojson-feature-collection',
+], function($, _, ko, koMapping, arches, uuid, geojsonExtent, geojsonhint, toGeoJSON, proj4, MapComponentViewModel, selectFeatureLayersFactory) {
+    var viewModel = function(params) {
+         
+        var self = this;
+        var padding = 40;
+        var drawFeatures;
+        
+        var resourceId = params.tile ? params.tile.resourceinstance_id : '';
+        if (this.widgets === undefined) { // could be [], so checking specifically for undefined
+            this.widgets = params.widgets || [];
+        }
+
+        this.geojsonWidgets = this.widgets.filter(function(widget){ return widget.datatype.datatype === 'geojson-feature-collection'; });
+        this.newNodeId = null;
+        this.featureLookup = {};
+        this.selectedFeatureIds = ko.observableArray();
+        this.geoJSONString = ko.observable();
+        this.draw = null;
+        this.selectSource = this.selectSource || ko.observable();
+        this.selectSourceLayer = this.selectSourceLayer || ko.observable();
+        this.drawAvailable = ko.observable(false);
+        this.bufferNodeId = ko.observable();
+        this.bufferDistance = ko.observable(0);
+        this.bufferUnits = ko.observable('m');
+        this.bufferResult = ko.observable();
+        this.bufferAddNew = ko.observable(false);
+        this.allowAddNew = this.card && this.card.canAdd() && this.tile !== this.card.newTile;
+
+        var selectSource = this.selectSource();
+        var selectSourceLayer = this.selectSourceLayer();
+        var selectFeatureLayers = selectFeatureLayersFactory(resourceId, selectSource, selectSourceLayer);
+
+        proj4.defs("WGS84", "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs")
+        proj4.defs("EPSG:29902","+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=1.000035 +x_0=200000 +y_0=250000 +a=6377340.189 +rf=299.3249646 +towgs84=482.5,-130.6,564.6,-1.042,-0.214,-0.631,8.15 +units=m +no_defs +type=crs");
+        this.source = new proj4.Proj('WGS84');    
+        this.dest = new proj4.Proj('EPSG:29902');
+
+        this.project = function (lat, long) {
+            let testpt = new proj4.Point(lat,long)
+            return proj4.transform(this.source,this.dest, testpt)
+        }
+
+        this.setSelectLayersVisibility = function(visibility) {
+            var map = self.map();
+            if (map) {
+                selectFeatureLayers.forEach(function(layer) {
+                    map.setLayoutProperty(
+                        layer.id,
+                        'visibility',
+                        visibility ? 'visible' : 'none'
+                    );
+                });
+            }
+        };
+
+
+        var sources = [];
+        for (var sourceName in arches.mapSources) {
+            if (Object.prototype.hasOwnProperty.call(arches.mapSources, sourceName)) {
+                sources.push(sourceName);
+            }
+        }
+        var updateSelectLayers = function() {
+            var source = self.selectSource();
+            var sourceLayer = self.selectSourceLayer();
+            selectFeatureLayers = sources.indexOf(source) > 0 ?
+                selectFeatureLayersFactory(resourceId, source, sourceLayer) :
+                [];
+            self.additionalLayers(
+                extendedLayers.concat(
+                    selectFeatureLayers,
+                    geojsonLayers
+                )
+            );
+        };
+        this.selectSource.subscribe(updateSelectLayers);
+        this.selectSourceLayer.subscribe(updateSelectLayers);
+
+        this.setDrawTool = function(tool) {
+            var showSelectLayers = (tool === 'select_feature');
+            self.setSelectLayersVisibility(showSelectLayers);
+            if (showSelectLayers) {
+                self.draw.changeMode('simple_select');
+                self.selectedFeatureIds([]);
+            } else {
+                if (tool) {
+                    self.draw.changeMode(tool);
+                    self.map().draw_mode = tool;
+                }
+            }
+        };
+
+        self.geojsonWidgets.forEach(function(widget) {
+            var id = ko.unwrap(widget.node_id);
+            self.featureLookup[id] = {
+                features: ko.computed(function() {
+                    var value = koMapping.toJS(self.tile.data[id]);
+                    if (value) return value.features;
+                    else return [];
+                }),
+                selectedTool: ko.observable(),
+                dropErrors: ko.observableArray()
+            };
+            self.featureLookup[id].selectedTool.subscribe(function(tool) {
+                if (self.draw) {
+                    if (tool === '') {
+                        self.draw.trash();
+                        self.draw.changeMode('simple_select');
+                    } else if (tool) {
+                        _.each(self.featureLookup, function(value, key) {
+                            if (key !== id) {
+                                value.selectedTool(null);
+                            }
+                        });
+                        self.newNodeId = id;
+                    }
+                    self.setDrawTool(tool);
+                }
+            });
+        });
+
+        this.selectedTool = ko.pureComputed(function() {
+            var tool;
+            _.find(self.featureLookup, function(value) {
+                var selectedTool = value.selectedTool();
+                if (selectedTool) tool = selectedTool;
+            });
+            return tool;
+        });
+
+        this.updateTiles = function() {
+            var featureCollection = self.draw.getAll();
+            _.each(self.featureLookup, function(value) {
+                value.selectedTool(null);
+            });
+            self.geojsonWidgets.forEach(function(widget) {
+                var id = ko.unwrap(widget.node_id);
+                var features = [];
+                featureCollection.features.forEach(function(feature){
+                    if (feature.properties.nodeId === id) features.push(feature);
+                });
+                if (ko.isObservable(self.tile.data[id])) {
+                    self.tile.data[id]({
+                        type: 'FeatureCollection',
+                        features: features
+                    });
+                } else {
+                    if (self.tile.data[id]) {
+                        self.tile.data[id].features(features);
+                    }
+                }
+            });
+        };
+
+        var getDrawFeatures = function() {
+            var drawFeatures = [];
+            self.geojsonWidgets.forEach(function(widget) {
+                var id = ko.unwrap(widget.node_id);
+                var featureCollection = koMapping.toJS(self.tile.data[id]);
+                if (featureCollection) {
+                    featureCollection.features.forEach(function(feature) {
+                        if (!feature.id) {
+                            feature.id = uuid.generate();
+                        }
+                        feature.properties.nodeId = id;
+                    });
+                    drawFeatures = drawFeatures.concat(featureCollection.features);
+                }
+            });
+            return drawFeatures;
+        };
+        drawFeatures = getDrawFeatures();
+
+        if (drawFeatures.length > 0) {
+            params.usePosition = false;
+            params.bounds = geojsonExtent({
+                type: 'FeatureCollection',
+                features: drawFeatures
+            });
+            params.fitBoundsOptions = { padding: {top: padding, left: padding + 200, bottom: padding, right: padding + 200} };
+        }
+
+        params.activeTab = 'editor';
+        params.sources = Object.assign({
+            "geojson-editor-data": {
+                "type": "geojson",
+                "data": {
+                    "type": "FeatureCollection",
+                    "features": []
+                }
+            }
+        }, params.sources);
+        var extendedLayers = [];
+        if (params.layers) {
+            extendedLayers = ko.unwrap(params.layers);
+        }
+        var geojsonLayers = [{
+            "id": "geojson-editor-polygon-fill",
+            "type": "fill",
+            "filter": ["==", "$type", "Polygon"],
+            "paint": {
+                "fill-color": "#3bb2d0",
+                "fill-outline-color": "#3bb2d0",
+                "fill-opacity": 0.1
+            },
+            "source": "geojson-editor-data"
+        },  {
+            "id": "geojson-editor-polygon-stroke-base",
+            "type": "line",
+            "filter": ["==", "$type", "Polygon"],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#fff",
+                "line-width": 4
+            },
+            "source": "geojson-editor-data"
+        },  {
+            "id": "geojson-editor-polygon-stroke",
+            "type": "line",
+            "filter": ["==", "$type", "Polygon"],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#3bb2d0",
+                "line-width": 2
+            },
+            "source": "geojson-editor-data"
+        }, {
+            "id": "geojson-editor-line",
+            "type": "line",
+            "filter": ["==", "$type", "LineString"],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#3bb2d0",
+                "line-width": 2
+            },
+            "source": "geojson-editor-data"
+        }, {
+            "id": "geojson-editor-point-point-stroke",
+            "type": "circle",
+            "filter": ["==", "$type", "Point"],
+            "paint": {
+                "circle-radius": 6,
+                "circle-opacity": 1,
+                "circle-color": "#fff"
+            },
+            "source": "geojson-editor-data"
+        }, {
+            "id": "geojson-editor-point",
+            "type": "circle",
+            "filter": ["==", "$type", "Point"],
+            "paint": {
+                "circle-radius": 5,
+                "circle-color": "#3bb2d0"
+            },
+            "source": "geojson-editor-data"
+        }];
+
+        params.layers = ko.observable(
+            extendedLayers.concat(
+                selectFeatureLayers,
+                geojsonLayers
+            )
+        );
+
+        MapComponentViewModel.apply(this, [params]);
+
+        this.deleteFeature = function(feature) {
+            if (self.draw) {
+                self.draw.delete(feature.id);
+                self.selectedFeatureIds(
+                    self.selectedFeatureIds().filter(function(id) {
+                        return id !== feature.id;
+                    })
+                );
+                self.updateTiles();
+            }
+        };
+
+        this.editFeature = function(feature) {
+            if (self.draw) {
+                self.draw.changeMode('simple_select', {
+                    featureIds: [feature.id]
+                });
+                self.selectedFeatureIds([feature.id]);
+                _.each(self.featureLookup, function(value) {
+                    value.selectedTool(null);
+                });
+            }
+        };
+
+        this.updateLayers = function(layers) {
+            var map = self.map();
+            var style = map.getStyle();
+            if (style) {
+                style.layers = self.draw ? layers.concat(self.draw.options.styles) : layers;
+                map.setStyle(style);
+            }
+        };
+
+        this.fitFeatures = function(features) {
+            var map = self.map();
+            var bounds = geojsonExtent({
+                type: 'FeatureCollection',
+                features: features
+            });
+            var camera = map.cameraForBounds(bounds, { padding: padding });
+            map.jumpTo(camera);
+        };
+
+        this.editGeoJSON = function(features, nodeId) {
+            var geoJSONString = JSON.stringify({
+                type: 'FeatureCollection',
+                features: features
+            }, null, '   ');
+            this.geoJSONString(geoJSONString);
+            self.newNodeId = nodeId;
+        };
+        this.geoJSONString.subscribe(function(geoJSONString) {
+            var map = self.map();
+            if (geoJSONString === undefined) {
+                setupDraw(map);
+            } else if (self.draw) {
+                map.removeControl(self.draw);
+                self.draw = undefined;
+                self.selectedFeatureIds([]);
+            }
+            self.setSelectLayersVisibility(false);
+        });
+        this.geoJSONErrors = ko.pureComputed(function() {
+            var geoJSONString = self.geoJSONString();
+            var hint = geojsonhint.hint(geoJSONString);
+            var errors = [];
+            hint.forEach(function(item) {
+                if (item.level !== 'message') {
+                    errors.push(item);
+                }
+            });
+            return errors;
+        }).extend({ rateLimit: 50 });
+        var geoJSONLayerData = ko.pureComputed(function() {
+            var geoJSONString = self.geoJSONString();
+            var geoJSONErrors = self.geoJSONErrors();
+            if (geoJSONErrors.length === 0) return JSON.parse(geoJSONString);
+            var fc = {
+                type: 'FeatureCollection',
+                features: []
+            };
+            if (self.bufferNodeId() && self.bufferResult()) {
+                fc.features.push(self.bufferResult());
+            }
+            return fc;
+        }).extend({ rateLimit: 100 });
+        geoJSONLayerData.subscribe(function(data) {
+            var map = self.map();
+            map.getSource('geojson-editor-data').setData(data);
+        });
+        this.updateGeoJSON = function() {
+            if (self.geoJSONErrors().length === 0) {
+                var geoJSON = JSON.parse(this.geoJSONString());
+                geoJSON.features.forEach(function(feature) {
+                    feature.id = uuid.generate();
+                    if (!feature.properties) feature.properties = {};
+                    feature.properties.nodeId = self.newNodeId;
+                });
+                if (ko.isObservable(self.tile.data[self.newNodeId])) {
+                    self.tile.data[self.newNodeId](geoJSON);
+                } else {
+                    self.tile.data[self.newNodeId].features(geoJSON.features);
+                }
+                self.geoJSONString(undefined);
+            }
+        };
+
+        var setupDraw = function(map) {
+            require(['mapbox-gl-draw'], (MapboxDraw) => {
+                var modes = MapboxDraw.modes;
+                modes.static = {
+                    onSetup: function() {
+                        this.setActionableState();
+                        return {};
+                    },
+                    toDisplayFeatures: function(state, geojson, display) {
+                        display(geojson);
+                    }
+                };
+                self.draw = new MapboxDraw({
+                    displayControlsDefault: false,
+                    modes: modes
+                });
+                map.addControl(self.draw);
+                self.draw.set({
+                    type: 'FeatureCollection',
+                    features: getDrawFeatures()
+                });
+                map.on('draw.create', function(e) {
+                    e.features.forEach(function(feature) {
+                        self.draw.setFeatureProperty(feature.id, 'nodeId', self.newNodeId);
+                    });
+                    self.updateTiles();
+                });
+                map.on('draw.update', function() {
+                    self.updateTiles();
+                    if (self.coordinateEditing()) {
+                        var editingFeature = self.draw.getSelected().features[0];
+                        if (editingFeature) updateCoordinatesFromFeature(editingFeature);
+                    }
+                    if (self.bufferNodeId()) self.updateBufferFeature();
+                });
+                map.on('draw.delete', self.updateTiles);
+                map.on('draw.modechange', function(e) {
+                    self.updateTiles();
+                    self.setSelectLayersVisibility(false);
+                    map.draw_mode = e.mode;
+                });
+                map.on('draw.selectionchange', function(e) {
+                    self.selectedFeatureIds(e.features.map(function(feature) {
+                        return feature.id;
+                    }));
+                    if (e.features.length > 0) {
+                        _.each(self.featureLookup, function(value) {
+                            value.selectedTool(null);
+                        });
+                    }
+                    self.setSelectLayersVisibility(false);
+                });
+
+                if (self.form) self.form.on('tile-reset', function() {
+                    var style = self.map().getStyle();
+                    if (style) {
+                        self.draw.set({
+                            type: 'FeatureCollection',
+                            features: getDrawFeatures()
+                        });
+                    }
+                    _.each(self.featureLookup, function(value) {
+                        if (value.selectedTool()) value.selectedTool('');
+                    });
+                });
+                if (self.draw) {
+                    self.drawAvailable(true);
+                }
+            });
+        };
+
+        if (this.provisionalTileViewModel) {
+            this.provisionalTileViewModel.resetAuthoritative();
+            this.provisionalTileViewModel.selectedProvisionalEdit.subscribe(function(val){
+                if (val) {
+                    var displayAll = function(){
+                        var featureCollection;
+                        for (var k in self.tile.data){
+                            if (self.featureLookup[k] && self.draw) {
+                                try {
+                                    featureCollection = self.draw.getAll();
+                                    featureCollection.features = ko.unwrap(self.featureLookup[k].features);
+                                    self.draw.set(featureCollection);
+                                } catch(e) {
+                                    //pass: TypeError in draw seems inconsequential.
+                                }
+                            }
+                        }
+                    };
+                    setTimeout(displayAll, 100);
+                }
+            });
+        }
+
+        this.map.subscribe(setupDraw);
+
+        self.map.subscribe(function(map) {
+            if (self.draw && !params.draw) {
+                params.draw = self.draw;
+            }
+            if (map && !params.map) {
+                params.map = map;
+            }
+        });
+
+        if (!params.additionalDrawOptions) {
+            params.additionalDrawOptions = [];
+        }
+
+        self.geojsonWidgets.forEach(function(widget) {
+            if (widget.config.geometryTypes) {
+                widget.drawTools = ko.pureComputed(function() {
+                    var options = [{
+                        value: '',
+                        text: ''
+                    }];
+                    options = options.concat(
+                        ko.unwrap(widget.config.geometryTypes).map(function(type) {
+                            var option = {};
+                            switch (ko.unwrap(type.id)) {
+                            case 'Point':
+                                option.value = 'draw_point';
+                                option.text = arches.translations.mapAddPoint;
+                                break;
+                            case 'Line':
+                                option.value = 'draw_line_string';
+                                option.text = arches.translations.mapAddLine;
+                                break;
+                            case 'Polygon':
+                                option.value = 'draw_polygon';
+                                option.text = arches.translations.mapAddPolygon;
+                                break;
+                            }
+                            return option;
+                        })
+                    );
+                    if (self.selectSource()) {
+                        options.push({
+                            value: "select_feature",
+                            text: self.selectText() || arches.translations.mapSelectDrawing
+                        });
+                    }
+                    options = options.concat(params.additionalDrawOptions);
+                    return options;
+                });
+            }
+        });
+
+        this.isFeatureClickable = function(feature) {
+            var tool = self.selectedTool();
+            if (tool && tool !== 'select_feature') return false;
+            return feature.properties.resourceinstanceid || self.isSelectable(feature);
+        };
+
+        self.isSelectable = function(feature) {
+            var selectLayerIds = selectFeatureLayers.map(function(layer) {
+                return layer.id;
+            });
+            return selectLayerIds.indexOf(feature.layer.id) >= 0;
+        };
+
+        var addSelectFeatures = function(features) {
+            var featureIds = [];
+            features.forEach(function(feature) {
+                feature.id = uuid.generate();
+                feature.properties = {
+                    nodeId: self.newNodeId
+                };
+                self.draw.add(feature);
+                featureIds.push(feature.id);
+            });
+            self.updateTiles();
+            if (self.popup) self.popup.remove();
+            self.draw.changeMode('simple_select', {
+                featureIds: featureIds
+            });
+            self.selectedFeatureIds(featureIds);
+            _.each(self.featureLookup, function(value) {
+                value.selectedTool(null);
+            });
+        };
+
+        self.selectFeature = function(feature) {
+            try {
+                var geometry = JSON.parse(feature.properties.geojson);
+                var newFeature = {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": geometry
+                };
+                addSelectFeatures([newFeature]);
+            } catch(e) {
+                $.getJSON(feature.properties.geojson, function(data) {
+                    addSelectFeatures(data.features);
+                });
+            }
+        };
+
+        var addFromGeoJSON = function(geoJSONString, nodeId) {
+            var hint = geojsonhint.hint(geoJSONString);
+            var errors = [];
+            hint.forEach(function(item) {
+                if (item.level !== 'message') {
+                    errors.push(item);
+                }
+            });
+            if (errors.length === 0) {
+                var geoJSON = JSON.parse(geoJSONString);
+                geoJSON.features = geoJSON.features.filter(function(feature) {
+                    return feature.geometry;
+                });
+                if (geoJSON.features.length > 0) {
+                    self.map().fitBounds(
+                        geojsonExtent(geoJSON),
+                        {
+                            padding: padding
+                        }
+                    );
+                    geoJSON.features.forEach(function(feature) {
+                        feature.id = uuid.generate();
+                        if (!feature.properties) feature.properties = {};
+                        feature.properties.nodeId = nodeId;
+                        self.draw.add(feature);
+                    });
+                    self.updateTiles();
+                }
+            }
+            return errors;
+        };
+
+        self.handleFiles = function(files, nodeId) {
+            var errors = [];
+            var promises = [];
+            for (var i = 0; i < files.length; i++) {
+                var extension = files[i].name.split('.').pop();
+                if (!['kml', 'json', 'geojson'].includes(extension)) {
+                    errors.push({
+                        message: 'File unsupported: "' + files[i].name + '"'
+                    });
+                } else {
+                    promises.push(new Promise(function(resolve) {
+                        var file = files[i];
+                        var extension = file.name.split('.').pop();
+                        var reader = new window.FileReader();
+                        reader.onload = function(e) {
+                            var geoJSON;
+                            if (['json', 'geojson'].includes(extension))
+                                geoJSON = JSON.parse(e.target.result);
+                            else
+                                geoJSON = toGeoJSON.kml(
+                                    new window.DOMParser()
+                                        .parseFromString(e.target.result, "text/xml")
+                                );
+                            resolve(geoJSON);
+                        };
+                        reader.readAsText(file);
+                    }));
+                }
+            }
+            Promise.all(promises).then(function(results) {
+                var geoJSON = {
+                    "type": "FeatureCollection",
+                    "features": results.reduce(function(features, geoJSON) {
+                        features = features.concat(geoJSON.features);
+                        return features;
+                    }, [])
+                };
+                errors = errors.concat(
+                    addFromGeoJSON(JSON.stringify(geoJSON), nodeId)
+                );
+                self.featureLookup[nodeId].dropErrors(errors);
+            });
+        };
+
+        self.dropZoneHandler = function(data, e) {
+            var nodeId = data.node.nodeid;
+            e.stopPropagation();
+            e.preventDefault();
+            var files = e.originalEvent.dataTransfer.files;
+            self.handleFiles(files, nodeId);
+            self.dropZoneLeaveHandler(data, e);
+        };
+
+        self.dropZoneOverHandler = function(data, e) {
+            e.stopPropagation();
+            e.preventDefault();
+            e.originalEvent.dataTransfer.dropEffect = 'copy';
+        };
+
+        self.dropZoneClickHandler = function(data, e) {
+            var fileInput = e.target.parentNode.querySelector('.hidden-file-input input');
+            var event = window.document.createEvent("MouseEvents");
+            event.initEvent("click", true, false);
+            fileInput.dispatchEvent(event);
+        };
+
+        self.dropZoneEnterHandler = function(data, e) {
+            e.target.classList.add('drag-hover');
+        };
+
+        self.dropZoneLeaveHandler = function(data, e) {
+            e.target.classList.remove('drag-hover');
+        };
+
+        self.dropZoneFileSelected = function(data, e) {
+            self.handleFiles(e.target.files, data.node.nodeid);
+        };
+        self.coordinateReferences = arches.preferredCoordinateSystems;
+        self.selectedCoordinateReference = ko.observable(self.coordinateReferences[0].proj4);
+        self.coordinates = ko.observableArray();
+        var geographic = '+proj=longlat +datum=WGS84 +no_defs", "default';
+        self.rawCoordinates = ko.computed(function() {
+            return self.coordinates().map(function(coords) {
+                var sourceCRS = self.selectedCoordinateReference();
+                return proj4(sourceCRS, geographic, [Number(coords[0]()), Number(coords[1]())]);
+            });
+        }).extend({ throttle: 100 });
+
+        self.eastingNorthing = ko.computed(function() {
+            return self.coordinates().map(function(coords) {
+                return self.project(coords[0](), coords[1]());
+            });
+        }).extend({ throttle: 100 });
+        
+        self.rawCoordinates.subscribe(function(rawCoordinates) {
+            var selectedFeatureId = self.selectedFeatureIds()[0];
+            if (self.coordinateEditing()) {
+                if (selectedFeatureId) {
+                    var drawFeatures = getDrawFeatures();
+                    drawFeatures.forEach(function(feature) {
+                        if (feature.id === selectedFeatureId) {
+                            if (feature.geometry.type === 'Polygon') {
+                                rawCoordinates.push(rawCoordinates[0]);
+                                feature.geometry.coordinates[0] = rawCoordinates;
+                            } else if (feature.geometry.type === 'Point')
+                                feature.geometry.coordinates = rawCoordinates[0];
+                            else
+                                feature.geometry.coordinates = rawCoordinates;
+                        }
+                        feature.geometry.epsg29909 = self.eastingNorthing()
+                    });
+                    self.draw.set({
+                        type: 'FeatureCollection',
+                        features: drawFeatures
+                    });
+                    self.updateTiles();
+                } else if (rawCoordinates.length >= self.minCoordinates()) {
+                    var coordinates = [];
+                    var geomType = self.coordinateGeomType();
+                    switch (geomType) {
+                    case 'Polygon':
+                        rawCoordinates.push(rawCoordinates[0]);
+                        coordinates = [rawCoordinates];
+                        epsg29909 = self.eastingNorthing()
+                        break;
+                    case 'Point':
+                        coordinates = rawCoordinates[0];
+                        epsg29909 = self.eastingNorthing()
+                        break;
+                    default:
+                        coordinates = rawCoordinates;
+                        epsg29909 = self.eastingNorthing()
+                        break;
+                    }
+                    addSelectFeatures([{
+                        type: "Feature",
+                        geometry: {
+                            type: geomType,
+                            coordinates: coordinates
+                        }
+                    }]);
+                }
+            }
+        });
+        self.showCoordinateFeature = function() {
+            var selectedFeatureIds = self.selectedFeatureIds();
+            var featureId = selectedFeatureIds[0];
+            if (featureId) {
+                var feature = self.draw.get(featureId);
+                self.fitFeatures([feature]);
+            }
+        };
+
+        self.coordinateEditing = ko.observable(false);
+        self.newX = ko.observable();
+        self.newY = ko.observable();
+        var newCoordinatePair = ko.computed(function() {
+            var x = self.newX();
+            var y = self.newY();
+            return [x, y];
+        });
+        self.focusLatestY = ko.observable(true);
+        var getNewCoordinatePair = function(coords) {
+            var newCoords = [
+                ko.observable(coords[0]),
+                ko.observable(coords[1])
+            ];
+            newCoords.forEach(function(value) {
+                value.subscribe(function(newValue) {
+                    if ([undefined, null, ""].includes(newValue)) value(0);
+                });
+            });
+            return newCoords;
+        };
+        newCoordinatePair.subscribe(function(coords) {
+            if (coords[0] && coords[1]) {
+                self.coordinates.push(getNewCoordinatePair(coords));
+                self.newX(undefined);
+                self.newY(undefined);
+                self.focusLatestY(true);
+            }
+        });
+        var updateCoordinatesFromFeature = function(feature) {
+            var sourceCoordinates = [];
+            if (feature.geometry.type === 'Polygon') {
+                sourceCoordinates = [];
+                for (var i = 0; i < feature.geometry.coordinates[0].length - 1; i++) {
+                    sourceCoordinates.push(feature.geometry.coordinates[0][i]);
+                }
+            } else if (feature.geometry.type === 'Point')
+                sourceCoordinates = [feature.geometry.coordinates];
+            else sourceCoordinates = feature.geometry.coordinates;
+            self.coordinateGeomType(feature.geometry.type);
+            self.coordinates(sourceCoordinates.map(function(coords) {
+                var newCoords = getNewCoordinatePair(coords);
+                transformCoordinatePair(newCoords, geographic);
+                return newCoords;
+            }));
+
+        };
+        var transformCoordinatePair = function(coords, sourceCRS) {
+            var targetCRS = self.selectedCoordinateReference();
+            var transformedCoordinates = proj4(sourceCRS, targetCRS, [Number(coords[0]()), Number(coords[1]())]);
+            coords[0](transformedCoordinates[0]);
+            coords[1](transformedCoordinates[1]);
+        };
+        var previousCRS = self.selectedCoordinateReference();
+        var transformCoordinates = function() {
+            var targetCRS = self.selectedCoordinateReference();
+            self.coordinates().forEach(function(coords) {
+                transformCoordinatePair(coords, previousCRS);
+            });
+            previousCRS = targetCRS;
+        };
+        self.selectedCoordinateReference.subscribe(transformCoordinates);
+
+        self.coordinateGeomType = ko.observable();
+        self.coordinateEditing.subscribe(function(editing) {
+            self.coordinateGeomType(null);
+            var selectedTool = self.selectedTool();
+            switch (selectedTool) {
+            case 'draw_point':
+                self.coordinateGeomType('Point');
+                break;
+            case 'draw_line_string':
+                self.coordinateGeomType('LineString');
+                break;
+            case 'draw_polygon':
+                self.coordinateGeomType('Polygon');
+                break;
+            default:
+                break;
+            }
+            var selectedFeatureIds = self.selectedFeatureIds();
+            var featureId = selectedFeatureIds[0];
+            self.focusLatestY(false);
+            self.coordinates([]);
+            self.newX(undefined);
+            self.newY(undefined);
+            if (editing) {
+                var selectConfig;
+                if (selectedFeatureIds.length > 0) {
+                    selectConfig = {
+                        featureIds: [featureId]
+                    };
+                    self.selectedFeatureIds([featureId]);
+                    var feature = self.draw.get(featureId);
+                    updateCoordinatesFromFeature(feature);
+                }
+                if (selectedTool) {
+                    self.draw.trash();
+                }
+                self.draw.changeMode('simple_select', selectConfig);
+                _.each(self.featureLookup, function(value) {
+                    value.selectedTool(null);
+                });
+            }
+        });
+        self.hideNewCoordinates = ko.computed(function() {
+            var geomType = self.coordinateGeomType();
+            var coordCount = self.coordinates().length;
+            return geomType === 'Point' && coordCount > 0;
+        });
+
+        self.minCoordinates = ko.computed(function() {
+            var geomType = self.coordinateGeomType();
+            var minCoordinates;
+            switch (geomType) {
+            case 'Point':
+                minCoordinates = 1;
+                break;
+            case 'LineString':
+                minCoordinates = 2;
+                break;
+            case 'Polygon':
+                minCoordinates = 3;
+                break;
+            default:
+                break;
+            }
+            return minCoordinates;
+        });
+
+        self.allowDeleteCoordinates = ko.computed(function() {
+            return self.coordinates().length > self.minCoordinates();
+        });
+
+        self.editCoordinates = function() {
+            self.coordinateEditing(true);
+        };
+
+        self.canEditCoordinates = ko.computed(function() {
+            var featureId = self.selectedFeatureIds()[0];
+            if (featureId) {
+                var feature = self.draw.get(featureId);
+                return ['Point', 'LineString', 'Polygon'].includes(feature.geometry.type);
+            } else {
+                var selectedTool = self.selectedTool();
+                return ['draw_point', 'draw_line_string', 'draw_polygon'].includes(selectedTool);
+            }
+        });
+
+        self.selectedFeatureIds.subscribe(function(ids) {
+            if (ids.length === 0) self.coordinateEditing(false);
+            else if (self.canEditCoordinates()) {
+                var feature = self.draw.get(ids[0]);
+                updateCoordinatesFromFeature(feature);
+            }
+        });
+
+        self.bufferFeature = ko.computed(function() {
+            return self.selectedFeatureIds()[0];
+        });
+        var getBufferFeature = function() {
+            var featureId = self.bufferFeature();
+            if (featureId) {
+                return self.draw.get(featureId);
+            }
+        };
+        self.bufferParams = ko.computed(function() {
+            var bufferFeature = getBufferFeature();
+            if (bufferFeature && self.bufferNodeId()) return {
+                "geometry": bufferFeature.geometry,
+                "buffer": {
+                    "width": parseFloat(self.bufferDistance()),
+                    "unit": self.bufferUnits()
+                }
+            };
+        });
+
+        self.bufferFeature.subscribe(function(bufferFeature) {
+            if (!bufferFeature) self.bufferNodeId(false);
+        });
+        self.updateBufferFeature = function() {
+            var bufferParams = self.bufferParams();
+            var bufferFeature = getBufferFeature();
+            if (bufferParams && bufferFeature) {
+                bufferParams.geometry = bufferFeature.geometry;
+                window.fetch(
+                    arches.urls.buffer +
+                    '?filter=' +
+                    JSON.stringify(bufferParams)
+                ).then(function(response) {
+                    if (response.ok) {
+                        return response.json();
+                    }
+                }).then(function(json) {
+                    var bufferFeature = getBufferFeature();
+                    self.bufferResult({
+                        type: 'Feature',
+                        id: uuid.generate(),
+                        geometry: json,
+                        properties: {
+                            nodeId: bufferFeature.properties.nodeId
+                        }
+                    });
+                });
+            } else self.bufferResult(undefined);
+
+        };
+        self.bufferParams.subscribe(self.updateBufferFeature);
+
+
+        if (self.card) {
+            self.card.map = self.map;
+        }
+
+        self.addBufferResult = function() {
+            var bufferResult = self.bufferResult();
+            if (self.bufferAddNew()) {
+                var dirty = ko.unwrap(self.tile.dirty);
+                var nodeId = self.bufferNodeId();
+                var addBufferResultAsNew = function() {
+                    var updateNewTile = self.card.selected.subscribe(function() {
+                        var fc = {
+                            "type": "FeatureCollection",
+                            "features": [bufferResult]
+                        };
+                        self.card.getNewTile().data[nodeId](fc);
+                        self.card.map.subscribe(function(map) {
+                            map.fitBounds(
+                                geojsonExtent(fc),
+                                {
+                                    duration: 0,
+                                    padding: padding
+                                }
+                            );
+                        });
+                        updateNewTile.dispose();
+                    });
+                    self.card.selected(true);
+                };
+                if (dirty) self.saveTile(addBufferResultAsNew);
+                else addBufferResultAsNew();
+            } else {
+                self.draw.add(bufferResult);
+                self.bufferNodeId(false);
+                self.updateTiles();
+                self.editFeature(bufferResult);
+                self.fitFeatures([bufferResult]);
+            }
+        };
+    };
+    return viewModel;
+});

--- a/coral/coral/media/js/views/components/widgets/map-with-latlon.js
+++ b/coral/coral/media/js/views/components/widgets/map-with-latlon.js
@@ -1,0 +1,15 @@
+define([
+    'jquery',
+    'underscore',
+    'knockout',
+    'views/components/widgets/map',
+    'templates/views/components/widgets/map-with-latlon.htm',
+    'bindings/mapbox-gl',
+    'bindings/sortable'
+], function($, _, ko, MapViewModel, mapTemplate) {
+    ko.components.register('map-with-latlon-widget', {
+        viewModel: MapViewModel,
+        template: mapTemplate,
+    });
+    return MapViewModel;
+});

--- a/coral/coral/media/js/views/components/workflows/licensing-workflow/license-cover-letter.js
+++ b/coral/coral/media/js/views/components/workflows/licensing-workflow/license-cover-letter.js
@@ -13,11 +13,19 @@ define([
     this.relatedResources = ko.observableArray();
 
     this.configKeys = ko.observable({ placeholder: 0 });
+    this.textReady = ko.observable(true)
 
     _.extend(this, params.form);
 
     self.currentLanguage = ko.observable({ code: arches.activeLanguage });
 
+    this.template = ko.observable("licence-cover-letter")
+    this.templateOptions = ko.observable([
+      { text: 'Cover', id: 'licence-cover-letter' },
+      { text: 'Final Report', id: 'final-report-letter' },
+      { text: 'Extension', id: 'licence-extension-letter' }
+    ]);
+    
     self.loading = ko.observable(false);
     self.pageVm = params.pageVm;
     self.dirty(true);
@@ -83,7 +91,8 @@ define([
         },
         dates: {
           acknowledged: ko.observable(data?.dates?.acknowledged || ''),
-          received: ko.observable(data?.dates?.received || '')
+          received: ko.observable(data?.dates?.received || ''),
+          sendDate: ko.observable(data?.dates?.received || new Date().toLocaleDateString()),
         },
         addresses: {
           applicant: self.createAddressObject(data?.addresses?.applicant),
@@ -123,6 +132,7 @@ define([
     this.coverLetterData.selectedAddress.subscribe((selected) => {
       if (!selected) this.coverLetterData.selectedAddress('applicant');
     }, this);
+
     this.addressOptions = ko.observable([
       { text: 'Applicant', id: 'applicant' },
       { text: 'Company', id: 'company' },
@@ -132,22 +142,24 @@ define([
     this.textBody = ko.observable(
       self.getSavedValue('textBody') ||
         createTextObject(
-          'Further to your application on [Date], please find attached an Excavation License for the above mentioned location.'
+          `
+          <div>Dear [recipient]</div>
+          <div>Further to your application on [Date], please find attached an Excavation License for the above mentioned location.</div>
+          <br />
+          <div>Please note that under the terms of the Licence you must, on completion of the excavation, furnish:</div>
+          <br />
+          [conditions]
+          <br /><br />
+          <div><em>The Historic Environment Division operates an environmental management system to the requirements of ISO 14001 and would remind all parties of the need to comply with relevant environmental legislation. Legislation covers, but is not limited to, waste management issues, water pollution, air pollution and appropriate storage of materials.</em></div>
+          <br />
+          <div>The division has published an environmental good practice guide for archaeological excavations which may be found at:</div>
+          <br />
+          <a style="color: blue" href="url">https://www.communities-ni.gov.uk/publications/environmental-good-practice-guide-archaeological-excavations</a>
+          `
         )
     );
-    this.textPreview = ko.computed(
-      {
-        read: function () {
-          return createTextObject(
-            this.textBody().en.value.replace(
-              '[Date]',
-              self.coverLetterData.dates.acknowledged() || '[Date]'
-            )
-          );
-        }
-      },
-      this
-    );
+    
+    
 
     this.appDateOptions = ko.observable(['received', 'acknowledged']);
     this.selectedAppDate = ko.observable('received');
@@ -155,123 +167,172 @@ define([
     this.sendDateOptions = ko.observable(['today', 'decision', 'acknowledged']);
     this.selectedSendDate = ko.observable('today');
 
+    this.textPreview = ko.computed(
+      {
+        read: function () {
+          return createTextObject(
+            self.getTextValue(this.textBody()).replace(
+              '[Date]',
+              self.coverLetterData.dates[self.selectedAppDate()]() || '[Date]'
+            )
+          );
+        }
+      },
+      this
+    );
+
+    this.preview = function(textObject) {
+      if (typeof(textObject) === 'string') {
+        return textObject.replace(
+          '[Date]',
+          self.coverLetterData.dates[self.selectedAppDate()]() || '[Date]')
+        .replace('[recipient]', self.getTextValue(self.coverLetterData.recipientName()) || '[recipient]')
+        .replace('[site]', self.getTextValue(self.coverLetterData.siteName) || '[site]')
+        .replace('[site_address]', self.getTextValue(self.coverLetterData.addresses.site.fullAddress) || '')
+        .replace('[site_county]', self.getTextValue(self.coverLetterData.addresses.site.county) || '[site_county]')
+        .replace('[licence_no]', self.getTextValue(self.coverLetterData.licenseNumber) || '[licence_no]')
+        .replace('[send_date]',self.coverLetterData.dates.sendDate() || '[send_date]')
+        .replace('[cmref]',self.getTextValue(self.coverLetterData.cmReference())|| '[cmref]')
+        .replace('[decision_by]', self.getTextValue(self.coverLetterData.decisionBy) || '[decision_by]')
+        .replace('[Signature]', self.getTextValue(self.coverLetterData.decisionBy.name) || '[Signature]')
+        .replace('[senior_inspector]', self.getTextValue(self.coverLetterData.seniorInspectorName) ? 
+          "<span>pp</span><span>Senior Inspector: " +  self.getTextValue(self.coverLetterData.seniorInspectorName) + '</span></div>'
+          : "</span></div>")
+        .replace('[to_address]', self.toAddress())
+        .replace('[from_address]', self.fromAddressPreview())
+      }
+    }
+
+    self.fromAddress = ko.observable(
+      self.getSavedValue('fromAddress') ||
+      `<div style="width: 40%; border: 1px solid; text-align: left">
+      <div><span>Historic Environment Division</span></div>
+      <div><span>Ground Floor</span></div>
+      <div><span>NINE Lanyon Place</span></div>
+      <div><span>Town Parks</span></div>
+      <div><span>Belfast</span></div>
+      <div><span>BT1 3LP</span></div>
+      <div><span>Phone: 02890819414</span></div>
+      <div><span>Email: ExcavationsandReports@communities-ni.gov.uk</span></div>
+      <br />
+      <div><span>Our Ref: ${self.getTextValue(self.coverLetterData.cmReference) ? self.getTextValue(self.coverLetterData.cmReference) : '[cmref]'}</span></div>
+      <br />
+      <div><span>Date: [send_date]</div></span>
+      </div>`
+    )
+    // if (self.getTextValue(self.coverLetterData.licenseNumber)) {
+    //   result += `<span>Licence Number: ${self.getTextValue(
+    //     self.coverLetterData.licenseNumber
+    //   )}</span>`;
+    // }
     self.getAddressValue = (value) => {
       return self.getTextValue(
         self.coverLetterData.addresses[self.coverLetterData.selectedAddress()][value]
       );
     };
+    this.fromAddressPreview = ko.computed(
+      {
+        read: function () {
+          return self.fromAddress().replace(
+              '[send_date]',
+              self.coverLetterData.dates.sendDate() || '[send_date]'
+            ).replace(
+              '[cmref]',
+              self.getTextValue(self.coverLetterData.cmReference())|| '[cmref]'
+            )
+        }
+      },
+      this
+    );
 
-    self.header = ko.computed(() => {
-      let result = '<div>';
+    self.toAddress = ko.computed(() => {
+      let result = '<div style="width: 40%; height: fit-content; border: 1px solid;">';
+      if (self.getTextValue(self.coverLetterData.recipientName())){
+        result += `<div><span>${self.getTextValue(self.coverLetterData.recipientName())}</span></div>`
+      }
+      if (self.getTextValue(self.company())){
+        result += `<div><span>${self.getTextValue(self.company())}</span></div>`
+      }
       if (self.getAddressValue('buildingName')) {
-        result += `<span>${self.getAddressValue('buildingName')}</span>`;
+        result += `<div><span>${self.getAddressValue('buildingName')}</span></div>`;
       }
-      result += '</div><div>';
       if (self.getAddressValue('buildingNumber')) {
-        result += `<span>${self.getAddressValue('buildingNumber')}</span>`;
-      }
-      if (self.getAddressValue('buildingNumber') && self.getAddressValue('street')) {
-        result += `<span>, </span>`;
-      }
-      if (self.getAddressValue('street')) {
-        result += `<span>${self.getAddressValue('street')}</span>`;
-      }
-      if (self.getAddressValue('street') && self.getAddressValue('subStreet')) {
-        result += `<span>, </span>`;
+        result += `<div><span>${self.getAddressValue('buildingNumber')}, ${self.getAddressValue('streetName')}</span></div>`;
       }
       if (self.getAddressValue('subStreet')) {
-        result += `<span>${self.getAddressValue('subStreet')}</span>`;
+        result += `<div><span>${self.getAddressValue('buildingNumberSubSt') ? self.getAddressValue('buildingNumberSubSt') +', ' : ''}${self.getAddressValue('subStreet')}</span></div>`;
       }
-      if (self.getAddressValue('subStreet') && self.getAddressValue('buildingNumberSubSt')) {
-        result += `<span>, </span>`;
-      }
-      if (self.getAddressValue('buildingNumberSubSt')) {
-        result += `<span>${self.getAddressValue('buildingNumberSubSt')}</span>`;
-      }
-      result += '</div><div>';
       if (self.getAddressValue('city')) {
-        result += `<span>${self.getAddressValue('city')}</span>`;
-      }
-      if (self.getAddressValue('city') && self.getAddressValue('county')) {
-        result += `<span>, </span>`;
+        result += `<div><span>${self.getAddressValue('city')}</span></div>`;
       }
       if (self.getAddressValue('county')) {
-        result += `<span>${self.getAddressValue('county')}</span>`;
-      }
-      if (self.getAddressValue('county') && self.getAddressValue('postcode')) {
-        result += `<span>, </span>`;
+        result += `<div><span>${self.getAddressValue('county')}</span></div>`;
       }
       if (self.getAddressValue('postcode')) {
-        result += `<span>${self.getAddressValue('postcode')}</span>`;
+        result += `<div><span>${self.getAddressValue('postcode')}</span></div>`;
       }
       result += '</div>';
       return result;
     }, self);
 
+    this.headerText = ko.observable(`<div style="display: flex; align-items: end; width: 100%; flex-direction: column">
+    <img style="width: 30%" src="https://www.jobapplyni.com/image/logo-DfC-stacked.png" />
+    <div style="display: flex; justify-content: space-around; width: 100%">
+    [to_address][from_address]</div>`)
+
+    this.header = ko.computed(() => {
+      return self.getSavedValue('headerBody') ||
+      self.preview(this.headerText())
+    })
+
+    self.detailsText = ko.observable(
+      `<div style="display: flex; width: 100%; flex-direction: column">
+      <div><strong>APPLICATION FOR AN EXCAVATION LICENCE</strong><div>
+      <div><span><strong>Site: [site][site_address]</strong></span></div>
+      <div><span><strong>Licence Number: [licence_no]</strong></span></div></div>
+      <br />
+      `
+    )
     self.details = ko.computed(() => {
-      let result = '<div style="display: flex; width: 100%; flex-direction: column">';
-      if (self.getTextValue(self.coverLetterData.dates.acknowledged)) {
-        result += `<span>Date: ${self.getTextValue(
-          self.coverLetterData.dates.acknowledged
-        )}</span>`;
-      }
-      if (self.getTextValue(self.coverLetterData.cmReference)) {
-        result += `<span>CM Reference: ${self.getTextValue(
-          self.coverLetterData.cmReference
-        )}</span>`;
-      }
-      if (self.getTextValue(self.coverLetterData.licenseNumber)) {
-        result += `<span>License Number: ${self.getTextValue(
-          self.coverLetterData.licenseNumber
-        )}</span>`;
-      }
-      if (self.getTextValue(self.coverLetterData.siteName)) {
-        result += `<span>Site: ${self.getTextValue(self.coverLetterData.siteName)}</span>`;
-      }
-      result += '</div>';
-      return result;
-    }, self);
+      return self.preview(self.detailsText())
+    }
+    );
 
     self.body = ko.computed(() => {
-      let result =
-        '<div style="display: flex; width: 100%; flex-direction: column; margin: 24px 0 16px 0">';
-      if (self.getTextValue(self.coverLetterData.recipientName)) {
-        result += `<span>Dear: ${self.getTextValue(self.coverLetterData.recipientName)}</span>`;
-      }
-      result += `<span style="margin-top: 8px">${
-        self.getTextValue(self.textPreview) || 'Please enter information regarding the email!'
-      }</span>`;
-      result += '</div>';
+      // let result =
+      //   '<div style="display: flex; width: 100%; flex-direction: column; margin: 24px 0 16px 0">';
+      // if (self.getTextValue(self.coverLetterData.recipientName)) {
+      // }
+      // result += `<span style="margin-top: 8px">${
+      //   self.getTextValue(self.textPreview) || 'Please enter information regarding the email!'
+      // }</span>`;
+      // result += '</div>';
 
-      return result;
+      return self.preview(self.getTextValue(self.textBody()));
     }, self);
+
+    self.footerText = ko.observable(`
+    <div style="display: flex; width: 100%; flex-direction: column; margin: 24px 0 16px 0">
+    <span>Yours sincerely<br />
+    [Signature]
+    </span>
+    [senior_inspector]
+    `)
 
     self.footer = ko.computed(() => {
-      let result =
-        '<div style="display: flex; width: 100%; flex-direction: column; margin: 24px 0 16px 0">';
-      if (self.getTextValue(self.coverLetterData.seniorInspectorName)) {
-        result += `<span>Senior Inspector:  ${self.getTextValue(
-          self.coverLetterData.seniorInspectorName
-        )}</span>`;
-      }
-      result += `<span>Signed: ${
-        self.getTextValue(self.coverLetterData.decisionBy.name) || '[Signature]'
-      }</span>`;
-      result += '</div>';
-      return result;
-    }, self);
-
+      return self.preview(self.footerText())
+    })
+      
     self.letter = ko.computed(() => {
-      let result =
-        '<div style="display: flex; align-items: end; width: 100%; flex-direction: column">';
-      result += self.header();
-      result += self.details();
-      result += self.body();
-      result += self.footer();
-      result += '</div>';
+      let result = ''
+        result += self.header();
+        result += self.details();
+        result += self.body();
+        result += self.footer()
       return result;
     }, self);
 
+    
     params.form.save = async () => {
       if (ko.isObservable(self?.tile().data['72e0fc96-53d5-11ee-844f-0242ac130008'])) {
         self.tile().data['72e0fc96-53d5-11ee-844f-0242ac130008'](createTextObject(self.letter()));
@@ -338,7 +399,6 @@ define([
         arches.urls.resource_tiles.replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', resourceId)
       );
       const data = await tilesResponse.json();
-      console.log('Logging tilesResponse: ', tilesResponse, data.tiles);
       return data.tiles;
     };
 
@@ -393,6 +453,7 @@ define([
       }
     };
 
+    
     self.configureAddress = (
       tileData,
       addressee,
@@ -450,6 +511,7 @@ define([
           self.coverLetterData.hasAdditonalFiles(true);
         }
 
+
         const contacts = [
           self.getValueFromTiles(licenseTiles, '6d2924b6-5891-11ee-a624-0242ac120004'),
           self.getValueFromTiles(licenseTiles, '6d292f88-5891-11ee-a624-0242ac120004')
@@ -458,7 +520,6 @@ define([
           for (const contact of contacts) {
             for (const resource of contact.value) {
               const contactTiles = await self.fetchTileData(resource.resourceId);
-              console.log('contactTiles: ', contactTiles);
               if (self.hasNodeGroup(contactTiles, '4110f741-1a44-11e9-885e-000d3ab1e588')) {
                 // Name nodegroup of person
                 const applicantName = self.getValueFromTiles(
@@ -466,7 +527,6 @@ define([
                   '5f8ded26-7ef9-11ea-8e29-f875a44e0e11'
                 );
                 if (applicantName) {
-                  console.log('applicantName: ', applicantName);
                   self.coverLetterData.recipientName(applicantName.value);
                 }
                 self.configureAddress(contactTiles, 'applicant', {
@@ -489,7 +549,6 @@ define([
                   'e8431c61-8098-11ea-8b01-f875a44e0e11'
                 );
                 if (companyName) {
-                  console.log('companyName: ', companyName);
                   self.coverLetterData.companyName(companyName.value);
                 }
                 self.configureAddress(contactTiles, 'company', {
@@ -507,7 +566,6 @@ define([
               }
             }
           }
-          console.log('self.coverLetterData.addresses: ', self.coverLetterData.addresses);
         }
 
         const decisionByDate = self.getValueFromTiles(
@@ -515,7 +573,6 @@ define([
           '4c58921e-48cc-11ee-9081-0242ac140007'
         );
         if (decisionByDate) {
-          console.log('decisionByDate: ', decisionByDate);
           self.coverLetterData.decisionBy.date(decisionByDate.value);
         }
 
@@ -524,13 +581,11 @@ define([
           'f3dcbf02-48cb-11ee-9081-0242ac140007'
         );
         if (decisionBy?.value.length) {
-          console.log('decisionBy: ', decisionBy);
           const decisionByTiles = await self.fetchTileData(decisionBy.value[0].resourceId);
           const decisionByName = self.getValueFromTiles(
             decisionByTiles,
             '5f8ded26-7ef9-11ea-8e29-f875a44e0e11'
           );
-          console.log('decisionByName: ', decisionByName);
           self.coverLetterData.decisionBy.name(decisionByName.value);
         }
 
@@ -539,7 +594,6 @@ define([
           'a9f53f00-48b6-11ee-85af-0242ac140007'
         );
         if (associatedActivitys?.value.length) {
-          console.log('associatedActivitys: ', associatedActivitys);
           // Assuming only one activity has been assigned upto this point
           const activityTiles = await self.fetchTileData(associatedActivitys.value[0].resourceId);
           const siteName = self.getValueFromTiles(
@@ -581,7 +635,6 @@ define([
           '0a914884-48b4-11ee-90a8-0242ac140007'
         );
         if (acknowledgedDate) {
-          console.log('acknowledgedDate: ', acknowledgedDate);
           self.coverLetterData.dates.acknowledged(acknowledgedDate.value);
         }
 
@@ -590,11 +643,9 @@ define([
           '6b96c722-48c7-11ee-ba3a-0242ac140007'
         );
         if (receivedDate) {
-          console.log('receivedDate: ', receivedDate);
           self.coverLetterData.dates.received(receivedDate.value);
         }
 
-        console.log('coverLetterData: ', ko.toJS(self.coverLetterData));
       } catch (error) {
         console.error('Failed loading data for cover letter: ', error);
         /**
@@ -603,6 +654,112 @@ define([
       }
       self.loading(false);
     };
+    self.template.subscribe(temp => {
+      self.textReady(false)
+      if (temp === 'final-report-letter') {
+
+        self.textBody(
+          createTextObject(
+          `<br />
+          <div>Dear [recipient]</div>
+          <div>Thank you for your report and associated documentation which we received in this office regarding the above-mentioned excavation.</div>
+          <br />
+          <div>The report was deemed to be final on [report_approved] and it and the associated documentation have been passed to HERoNI for uploading to the map viewer.</div>
+          <br />
+          <div>I would like to thank you for your co-operation and can confirm that you have met all of Historic Environment Division's conditions associated with this licence.</div>
+          `)
+        )
+        self.detailsText(
+          `<div style="display: flex; width: 100%; flex-direction: column">
+            <div><strong>EXCAVATION REPORT FOR: [site][site_address]</strong></span></div>
+            <div><span><strong>Licence Number: [licence_no]</strong></span></div>
+          </div>
+          `
+        )
+        self.headerText(
+          `<div style="display: flex; align-items: end; width: 100%; flex-direction: column">
+           <img style="width: 30%" src="https://www.jobapplyni.com/image/logo-DfC-stacked.png" />
+           <div style="display: flex; justify-content: space-around; width: 100%">
+           [to_address][from_address]</div>`
+        )
+        self.footerText((`
+          <div style="display: flex; width: 100%; flex-direction: column; margin: 24px 0 16px 0">
+          <span>Yours sincerely<br />
+          [Signature]
+          </span>
+          [senior_inspector]`)
+        )
+      } else if (temp === 'licence-cover-letter'){
+        self.textBody(
+          createTextObject(
+          `<div>Dear [recipient]</div>
+          <div>Further to your application on [Date], please find attached an Excavation License for the above mentioned location.</div>
+          <br />
+          <div>Please note that under the terms of the Licence you must, on completion of the excavation, furnish:</div>
+          <br />
+          [conditions]
+          <br /><br />
+          <div><em>The Historic Environment Division operates an environmental management system to the requirements of ISO 14001 and would remind all parties of the need to comply with relevant environmental legislation. Legislation covers, but is not limited to, waste management issues, water pollution, air pollution and appropriate storage of materials.</em></div>
+          <br />
+          <div>The division has published an environmental good practice guide for archaeological excavations which may be found at:</div>
+          <br />
+          <a style="color: blue" href="url">https://www.communities-ni.gov.uk/publications/environmental-good-practice-guide-archaeological-excavations</a>
+          `)
+        )
+        self.detailsText(
+          `<div style="display: flex; width: 100%; flex-direction: column">
+          <div><strong>APPLICATION FOR AN EXCAVATION LICENCE</strong><div>
+          <div><span><strong>Site: [site][site_address]</strong></span></div>
+          <div><span><strong>Licence Number: [licence_no]
+          </strong></span></div></div>
+          <br />
+        `)
+
+
+        self.footerText((`
+          <div style="display: flex; width: 100%; flex-direction: column; margin: 24px 0 16px 0">
+          <span>Yours sincerely<br />
+          [Signature]
+          </span>
+          [senior_inspector]
+          `)
+        )
+        self.headerText(
+          `<div style="display: flex; align-items: end; width: 100%; flex-direction: column">
+           <img style="width: 30%" src="https://www.jobapplyni.com/image/logo-DfC-stacked.png" />
+           <div style="display: flex; justify-content: space-around; width: 100%">
+           [to_address][from_address]</div>`
+        )
+          } else if (temp === 'licence-extension-letter') {
+            self.textBody(
+              createTextObject(
+              `<div>The Department for Communities for Northern Ireland (hereinafter referred to as “the Department”), in exercise of its power under Section 41 of the above-mentioned Order, hereby extends the license of <strong>[recipient]</strong>  (hereinafter referred to as “the Licensee”) to dig or excavate for purposes of archaeological evaluation in or under part of the Townland (town) of <strong>[town]</strong> in the County of <strong>[county]</strong> being the archaeological site or reputed site known as <strong>[site]</strong>  for a further period of <strong>[duration], commencing on [valid_from] and ceasing on [valid_to].</strong></div>
+              <br />
+              <div><strong>All conditions stated in the original Licence are applicable to this Extension. In addition, the Department also requires that:</strong></div>
+              <br />
+              <div><strong>In advance of commencement of further archaeological works under this licence, the licensee must inform the Department of the start date of the excavation, name of the licensee / director, licence number, contact phone number for the licensee / director, reason for excavation, and likely duration.</strong></div>
+              `)
+            )
+
+            self.detailsText(`<br /><br />`)
+
+            self.headerText(`<div style="width: 100%; border: solid; text-align: center;">
+                <div><strong>DEPARTMENT FOR COMMUNITIES</strong></div>
+                  <br />
+                <div><strong><em>Historic Monuments and Archaeological Objects (Northern Ireland) Order 1995</em></strong></div>
+                  <br />
+                <div><strong>extension of licence to excavate for archaeological purposes</strong></div>
+                </div>
+              `)
+
+            self.footerText(`
+            <div> <span style="width: 20ch;"> Authorised Officer </span><span><u>[Signature]</u></span></div>
+            <div> <span style="width: 20ch; padding-right: 7ch"> Dated this </span><span><u>[send_date]</u></span></div>
+            <div> <span style="width: 20ch; padding-right: 2ch"> Licence Number </span><span><u>[licence_no]</u></span></div>
+            `)
+          }
+      self.textReady(true)
+    })
 
     if (!params.form.savedData()?.['tileId']) {
       // Run fetch prefill data if there hasn't previously been a saved letter

--- a/coral/coral/pkg/graphs/resource_models/Activity.json
+++ b/coral/coral/pkg/graphs/resource_models/Activity.json
@@ -164,7 +164,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Associated Digital Files"
                     },
@@ -328,7 +328,7 @@
                     "instructions": {
                         "en": "Enter the resource name and its respective type."
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Activity Names"
                     },
@@ -484,7 +484,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "External Cross References"
                     },
@@ -524,7 +524,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Activity Archive Material"
                     },
@@ -819,7 +819,7 @@
                     "instructions": {
                         "en": "Used to record the postal address of a resource."
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Addresses"
                     },
@@ -846,7 +846,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Location Descriptions"
                     },
@@ -904,7 +904,7 @@
                     "instructions": {
                         "en": "Administrative, geopolitical areas, localities, and other areas (e.g.: Research or zoning areas)  "
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Localities/Administrative Areas"
                     },
@@ -931,7 +931,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Location Data"
                     },
@@ -965,7 +965,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Associated Monuments, Areas and Artefacts"
                     },
@@ -1067,7 +1067,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "System Reference Numbers"
                     },
@@ -1101,7 +1101,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Associated Activities"
                     },
@@ -5755,7 +5755,7 @@
                     "node_id": "a5419248-f121-11eb-86a9-a87eeabdefba",
                     "sortorder": 0,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000007"
+                    "widget_id": "b96d9bc9-34c2-413c-9d88-b879f7a335da"
                 },
                 {
                     "card_id": "a5416b36-f121-11eb-be10-a87eeabdefba",
@@ -10338,7 +10338,7 @@
                     },
                     "function_id": "60000000-0000-0000-0000-000000000001",
                     "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "id": "7541b4cd-fa17-4a99-98ad-53db781bdc76"
+                    "id": "73cf5c16-0335-4414-8970-c878e08154f0"
                 },
                 {
                     "config": {
@@ -10354,12 +10354,12 @@
                     },
                     "function_id": "317a318b-792b-4de3-bea9-e4212850431f",
                     "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "id": "b51f8a22-c263-4966-809f-c21f98facf92"
+                    "id": "f4a74dec-fe15-4fab-ba3a-94075a885e89"
                 }
             ],
             "graphid": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
             "iconclass": "fa fa-cogs",
-            "is_editable": true,
+            "is_editable": false,
             "isresource": true,
             "jsonldcontext": null,
             "name": {
@@ -17706,8 +17706,8 @@
             "publication": {
                 "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
                 "notes": null,
-                "publicationid": "0855fb7c-6106-11ee-a51d-0242ac120003",
-                "published_time": "2023-10-02T09:28:23.261",
+                "publicationid": "61ca3cc8-6e8e-11ee-98c3-0242ac120007",
+                "published_time": "2023-10-19T14:47:10.012",
                 "user_id": 1
             },
             "relatable_resource_model_ids": [],

--- a/coral/coral/settings.py
+++ b/coral/coral/settings.py
@@ -316,7 +316,7 @@ GRAPH_MODEL_CACHE_TIMEOUT = None
 
 OAUTH_CLIENT_ID = ''  #'9JCibwrWQ4hwuGn5fu2u1oRZSs9V6gK8Vu8hpRC4'
 
-APP_VERSION = '0.4.2'
+APP_VERSION = '0.5.2'
 APP_TITLE = 'HED | Heritage Data Management'
 COPYRIGHT_TEXT = 'All Rights Reserved.'
 COPYRIGHT_YEAR = '2022-'

--- a/coral/coral/settings.py
+++ b/coral/coral/settings.py
@@ -316,7 +316,7 @@ GRAPH_MODEL_CACHE_TIMEOUT = None
 
 OAUTH_CLIENT_ID = ''  #'9JCibwrWQ4hwuGn5fu2u1oRZSs9V6gK8Vu8hpRC4'
 
-APP_VERSION = '0.3.2'
+APP_VERSION = '0.4.2'
 APP_TITLE = 'HED | Heritage Data Management'
 COPYRIGHT_TEXT = 'All Rights Reserved.'
 COPYRIGHT_YEAR = '2022-'

--- a/coral/coral/templates/views/components/widgets/cover-letter-widget.htm
+++ b/coral/coral/templates/views/components/widgets/cover-letter-widget.htm
@@ -11,11 +11,12 @@
     <h5 class="summary-value" data-bind="text: label"></h5>
     <!-- /ko -->
     <div class="col-xs-12">
+      
       <div
         style="
           border: 5px solid #eee;
           padding: 10px;
-          max-width: 500px;
+          max-width: 800px;
           width: 100%;
           box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
         "

--- a/coral/coral/templates/views/components/widgets/map-widget-editor-with-latlon.htm
+++ b/coral/coral/templates/views/components/widgets/map-widget-editor-with-latlon.htm
@@ -1,0 +1,227 @@
+{% extends "views/components/map.htm" %}
+{% load i18n %}
+
+{% block tabs %}
+<div class="workbench-card-sidebar-tab" data-bind="click: function() {
+    toggleTab('editor');
+}, css: {
+    'active': activeTab() === 'editor'
+}">
+    <i class="fa fa-pencil"></i>
+    <span data-bind="text: $root.translations.edit"></span>
+</div>
+{{ block.super }}
+{% endblock tabs %}
+
+{% block sidepanel %}
+<!-- ko foreach: { data: [$data], as: 'self' } -->
+<!--ko if: activeTab() === 'editor' -->
+    <div class="workbench-card-sidepanel-header-container">
+        <h4 class="workbench-card-sidepanel-header" data-bind="click: hideSidePanel, text: label"></h4>
+    </div>
+    <div class="workbench-card-sidepanel-border"></div>
+
+    <div>
+        <div class="new-provisional-edit-card-container">
+            <!-- ko if: geoJSONString() !== undefined -->
+            <div class="card">
+                <div class="geojson-editor" data-bind="codemirror: {
+                    value: geoJSONString,
+                    mode: { name: 'javascript', json: true },
+                    lineNumbers: true
+                }"></div>
+                <div>
+                    <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: function () {
+                        geoJSONString(undefined);
+                    }">
+                        <span data-bind="text: $root.translations.cancel"></span>
+                    </button>
+                    <button class="btn btn-shim btn-labeled btn-lg fa fa-plus btn-mint" data-bind="css: {
+                        disabled: geoJSONErrors().length !== 0
+                    }, click: updateGeoJSON">
+                        <span data-bind="text: $root.translations.updateFeatures"></span>
+                    </button>
+                </div>
+                <!-- ko if: geoJSONErrors().length !== 0 -->
+                <div class="geojson-error-list">
+                    <span data-bind="text: $root.translations.geojsonErrors"></span>
+                    <ul>
+                        <!-- ko foreach: geoJSONErrors() -->
+                        <li data-bind="text: message"></li>
+                        <!-- /ko-->
+                    </ul>
+                </div>
+                <!-- /ko-->
+            </div>
+            <!-- /ko-->
+
+            {% include 'views/components/coordinate-editor.htm' %}
+
+            {% include 'views/components/buffer-editor.htm' %}
+
+            <div class="card" data-bind="visible: geoJSONString() === undefined && !coordinateEditing() && !bufferNodeId()">
+                <div class="row widget-wrapper">
+                    <div class="form-group">
+                        <div class="col-xs-12">
+                            <div class="map-card-feature-list">
+                                <div class="add-new-feature">
+                                    <select 
+                                        data-bind="
+                                            placeholder: $root.translations.addANewFeature + '...',
+                                            value: self.featureLookup[widget.node_id()].selectedTool,
+                                            valueAllowUnset: true,
+                                            options: widget.drawTools,
+                                            optionsText: 'text',
+                                            optionsValue: 'value',
+                                            chosen: {
+                                                'width': '100%',
+                                                'disable_search_threshold': 10,
+                                                'allow_single_deselect': true
+                                            }
+                                        "
+                                    ></select>
+                                </div>
+                                    <div class="map-data-drop-area" data-bind="event: {
+                                        dragover: dropZoneOverHandler,
+                                        drop: dropZoneHandler,
+                                        click: dropZoneClickHandler,
+                                        dragenter: dropZoneEnterHandler,
+                                        dragleave: dropZoneLeaveHandler,
+                                        dragend: dropZoneLeaveHandler
+                                    }">
+                                    <span data-bind="text: $root.translations.dragGeoJsonKml"></span>
+                                </div>
+                                <div class="hidden-file-input">
+                                    <input type="file" accept=".json,.geojson,.kml" data-bind="event: {
+                                        change: self.dropZoneFileSelected
+                                    }"/>
+                                </div>
+                                <!-- ko if: self.featureLookup[widget.node_id()].dropErrors().length !== 0 -->
+                                <div class="geojson-error-list">
+                                    <a href="javascript: void(0);" data-bind="click:function () {
+                                        self.featureLookup[widget.node_id()].dropErrors([]);
+                                    }">
+                                        <i class="fa fa-close"></i>
+                                    </a>
+                                    <span data-bind="text: $root.translations.followingErrorsOccurred"></span>
+                                    <ul>
+                                        <!-- ko foreach: self.featureLookup[widget.node_id()].dropErrors() -->
+                                        <li data-bind="text: message"></li>
+                                        <!-- /ko-->
+                                    </ul>
+                                </div>
+                                <!-- /ko-->
+                                <table class="table">
+                                    <tbody>
+                                        <!-- ko foreach: {data: self.featureLookup[widget.node_id()].features, as: 'feature'} -->
+                                        <tr class="map-card-feature-item" data-bind="css: {'active': self.selectedFeatureIds().indexOf(feature.id) >= 0}, click: function() { self.fitFeatures([feature]) }">
+                                            <td>
+                                                <span class="map-card-feature-name" data-bind="text: feature.geometry.type"></span>
+                                                <!-- ko if: feature.geometry.type === "Point" -->
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Lat: </strong>' +'<span>' + ' ' + feature.geometry.coordinates[0] + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Long: </strong>' +'<span>' + ' ' + feature.geometry.coordinates[1] + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Easting: </strong>' +'<span>' + ' ' + $parent.project(feature.geometry.coordinates[0], feature.geometry.coordinates[1]).x + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Northing: </strong>' +'<span>' + ' ' + $parent.project(feature.geometry.coordinates[0], feature.geometry.coordinates[1]).y + '</span>'"></span>
+
+
+                                                <!-- /ko -->
+                                                <!-- ko if: feature.geometry.type === "Polygon"-->
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Lat: </strong>' +'<span>' + ' ' + feature.geometry.coordinates[0].map(x => x[0]).reduce((partialSum, a) => partialSum + a, 0) / feature.geometry.coordinates[0].length + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Long: </strong>' +'<span>' + ' ' + feature.geometry.coordinates[0].map(x => x[1]).reduce((partialSum, a) => partialSum + a, 0) / feature.geometry.coordinates[0].length + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Easting: </strong>' +'<span>' + ' ' + $parent.project(feature.geometry.coordinates[0].map(x => x[0]).reduce((partialSum, a) => partialSum + a, 0) / feature.geometry.coordinates[0].length, feature.geometry.coordinates[0].map(x => x[1]).reduce((partialSum, a) => partialSum + a, 0) / feature.geometry.coordinates[0].length).x + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Northing: </strong>' +'<span>' + ' ' + $parent.project(feature.geometry.coordinates[0].map(x => x[1]).reduce((partialSum, a) => partialSum + a, 0) / feature.geometry.coordinates[0].length, feature.geometry.coordinates[0].map(x => x[1]).reduce((partialSum, a) => partialSum + a, 0) / feature.geometry.coordinates[0].length).y + '</span>'"></span>
+                                                <!-- /ko -->
+                                                <!-- ko if: feature.geometry.type === "LineString"-->
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Lat: </strong>' +'<span>' + ' ' + feature.geometry.coordinates[0][0] + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Long: </strong>' +'<span>' + ' ' + feature.geometry.coordinates[0][1] + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Easting: </strong>' +'<span>' + ' ' + $parent.project(feature.geometry.coordinates[0][0], feature.geometry.coordinates[0][1]).x + '</span>'"></span>
+                                                <br />
+                                                <span class="map-card-feature-name" data-bind="html: '<strong>Northing: </strong>' +'<span>' + ' ' + $parent.project(feature.geometry.coordinates[0][0], feature.geometry.coordinates[0][1]).y + '</span>'"></span>
+
+                                                <!-- /ko -->
+                                            </td>
+                                            <td class="map-card-feature-tool">
+                                                <a href="javascript:void(0);" data-bind="click: function() { self.editFeature(feature) }, clickBubble: false">
+                                                    <i class="fa fa-pencil map-card-feature-edit"></i>
+                                                    <span data-bind="text: $root.translations.edit"></span>
+                                                </a>
+                                            </td>
+                                            <td class="map-card-feature-tool">
+                                                <a href="javascript:void(0);" data-bind="click: function() { self.deleteFeature(feature) }, clickBubble: false">
+                                                    <i class="fa fa-trash map-card-feature-delete"></i>
+                                                    <span data-bind="text: $root.translations.delete"></span>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        <!-- /ko -->
+                                    </tbody>
+                                </table>
+                                <div class="map-card-zoom-tool">
+                                    <a href="javascript:void(0);" data-bind="click: function() {
+                                        self.editGeoJSON(self.featureLookup[widget.node_id()].features(), widget.node_id());
+                                    }">
+                                        <i class="fa fa-pencil map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.editGeoJson"></span>
+                                    </a>
+                                    |
+                                    <!-- ko if: canEditCoordinates() -->
+                                    <a href="javascript:void(0);" data-bind="click: function() {
+                                        self.coordinateEditing(true);
+                                    }">
+                                        <i class="fa fa-list map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.editCoordinates"></span>
+                                    </a>
+                                    <!-- /ko -->
+                                    <!-- ko if: !canEditCoordinates() -->
+                                    <span>
+                                        <i class="fa fa-list map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.editCoordinates"></span>
+                                    </span>
+                                    <!-- /ko -->
+                                    |
+                                    <!-- ko if: self.bufferFeature() -->
+                                    <a href="javascript:void(0);" data-bind="click: function() {
+                                        self.bufferNodeId(widget.node_id());
+                                    }">
+                                        <i class="fa fa-list map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.addBuffer"></span>
+                                    </a>
+                                    <!-- /ko -->
+                                    <!-- ko if: !self.bufferFeature() -->
+                                    <span>
+                                        <i class="fa fa-list map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.addBuffer"></span>
+                                    </span>
+                                    <!-- /ko -->
+                                    <!-- ko if: self.featureLookup[widget.node_id()].features().length > 0 -->
+                                    |
+                                    <a href="javascript:void(0);" data-bind="click: function() {
+                                        self.fitFeatures(self.featureLookup[widget.node_id()].features());
+                                    }">
+                                        <i class="fa fa-search map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.zoomToAll"></span>
+                                    </a>
+                                    <!-- /ko -->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+<!--/ko -->
+<!--/ko -->
+{{ block.super }}
+{% endblock sidepanel %}

--- a/coral/coral/templates/views/components/widgets/map-with-latlon.htm
+++ b/coral/coral/templates/views/components/widgets/map-with-latlon.htm
@@ -1,0 +1,82 @@
+{% extends "views/components/cards/default.htm" %}
+{% load i18n %}
+
+{% block form %}
+{% include 'views/components/widgets/map-widget-editor-with-latlon.htm' %}
+{% endblock form %}
+
+{% block config %}
+<div>
+    <div class="node-config-item">
+        <label class="control-label" for="">
+            <span data-bind="text: $root.translations.selectDrawingsMapSource"></span>
+        </label>
+        <input type="text" data-bind="textInput: selectSource" class="form-control input-md widget-input">
+    </div>
+    <div class="node-config-item">
+        <label class="control-label" for="">
+            <span data-bind="text: $root.translations.selectDrawingsMapSourceLayer"></span>
+        </label>
+        <input type="text" data-bind="textInput: selectSourceLayer" class="form-control input-md widget-input">
+    </div>
+    <div class="node-config-item">
+        <label class="control-label" for="">
+            <span data-bind="text: $root.translations.selectDrawingsText"></span>
+        </label>
+        <input type="text" data-bind="textInput: selectText" class="form-control input-md widget-input">
+    </div>
+    <div class="node-config-item">
+        <div class="control-label">
+            <span data-bind="text: $root.translations.mapCenterLongitude"></span>
+        </div>
+        <div class="col-xs-12 pad-no crud-widget-container">
+            <input 
+                type="number" 
+                id="" 
+                class="form-control input-md widget-input" 
+                data-bind="
+                    attr: {placeholder: $root.translations.longitudeXCoordinate},
+                    value: centerX, 
+                    valueUpdate: 'keyup'
+                "
+            >
+        </div>
+    </div>
+    <div class="node-config-item">
+        <div class="control-label">
+            <span data-bind="text: $root.translations.mapCenterLatitude"></span>
+        </div>
+        <div class="col-xs-12 pad-no crud-widget-container">
+            <input 
+                type="number" 
+                id="" 
+                class="form-control input-md widget-input" 
+                data-bind="
+                    attr: {placeholder: $root.translations.latitudeYCoordinate},
+                    value: centerY, 
+                    valueUpdate: 'keyup'
+                "
+            >
+        </div>
+    </div>
+    <div class="node-config-item">
+        <div class="control-label">
+            <span data-bind="text: $root.translations.defaultZoom"></span>
+        </div>
+        <div class="col-xs-12 pad-no crud-widget-container">
+            <input 
+                type="number" 
+                min=1 
+                max=20
+                id="" 
+                class="form-control input-md widget-input" 
+                data-bind="
+                    attr: {placeholder: $root.translations.zoomLevel},
+                    value: zoom, 
+                    valueUpdate: 'keyup'
+                "
+            >
+        </div>
+    </div>
+</div>
+{% endblock config %}

--- a/coral/coral/templates/views/components/workflows/licensing-workflow/license-cover-letter.htm
+++ b/coral/coral/templates/views/components/workflows/licensing-workflow/license-cover-letter.htm
@@ -6,6 +6,32 @@
     <div class="row widget-wrapper">
       <div
         data-bind="component: {
+          name: 'domain-radio-widget',
+          node: {
+            'config': {
+              'options': templateOptions,
+            },
+          },
+          params: {
+            node: {
+            'config': {
+              'options': templateOptions,
+              },
+              'configKeys': configKeys
+            },
+            config: {
+              'label': 'Selected Template',
+              'options': templateOptions,
+            },
+            value: template,
+            loading: loading,
+            form: $data,
+            pageVm: $root
+          }
+      }"
+      ></div>
+      <div
+        data-bind="component: {
           name: 'text-widget',
           params: {
               config: {
@@ -216,7 +242,7 @@
                 },
             },
             config: {
-                'label': 'Acknowledged/Send Date',
+                'label': 'Acknowledged Date',
                 'maxDate': '',
                 'minDate': '',
                 'viewMode': 'days',
@@ -224,6 +250,32 @@
                 'defaultValue': ''
             },
             value: coverLetterData.dates.acknowledged,
+            loading: loading,
+            form: $data,
+            pageVm: $root
+        }
+      }"
+      ></div>
+    </div>
+    <div class="row widget-wrapper">
+      <div
+        data-bind="component: {
+        name: 'datepicker-widget',
+        params: {
+            node: {
+                config: {
+                    'dateFormat': 'DD-MM-YYYY',
+                },
+            },
+            config: {
+                'label': 'Send Date',
+                'maxDate': '',
+                'minDate': '',
+                'viewMode': 'days',
+                'dateFormat': 'DD-MM-YYYY',
+                'defaultValue': ''
+            },
+            value: coverLetterData.dates.sendDate,
             loading: loading,
             form: $data,
             pageVm: $root
@@ -391,6 +443,7 @@
         }"
       ></div>
     </div>
+    <!-- ko if: textReady -->
     <div class="row widget-wrapper">
       <div
         data-bind="component: {
@@ -408,6 +461,7 @@
         }"
       ></div>
     </div>
+    <!-- /ko -->
   </div>
   <div class="card-component" style="width: 100%">
     <div class="row widget-wrapper">
@@ -494,12 +548,14 @@
         </div>
         <!-- FOOTER -->
         <div style="display: flex; width: 100%; flex-direction: column">
+          
+          <span
+            data-bind="text: 'Yours sincerely \n ' + (getTextValue(signed) || 'Signature required!')"
+          ></span>
           <!-- ko if: getTextValue(seniorInspector) -->
+          <span>pp</span>
           <span data-bind="text: 'Senior Inspector: ' + getTextValue(seniorInspector)"></span>
           <!-- /ko -->
-          <span
-            data-bind="text: 'Signed: ' + (getTextValue(signed) || 'Signature required!')"
-          ></span>
         </div>
       </div>
       {% endcomment %}

--- a/coral/coral/widgets/map-with-latlon.json
+++ b/coral/coral/widgets/map-with-latlon.json
@@ -1,0 +1,9 @@
+{
+  "widgetid": "b96d9bc9-34c2-413c-9d88-b879f7a335da",
+  "name": "map-with-latlon-widget",
+  "component": "views/components/widgets/map-with-latlon",
+  "defaultconfig": {"zoom": 0, "pitch": 0.0, "basemap": "streets", "bearing": 0.0, "centerX": 0, "centerY": 0, "maxZoom": 20, "minZoom": 0, "rerender": true, "defaultValue": "", "featureColor": "#FF0000", "geometryTypes": [{"id": "Point", "text": "Point"}, {"id": "Line", "text": "Line"}, {"id": "Polygon", "text": "Polygon"}], "overlayConfigs": [], "overlayOpacity": 0.0, "geocodeProvider": "10000000-0000-0000-0000-010000000000", "geocoderVisible": true, "defaultValueType": "", "featureLineWidth": 1, "featurePointSize": 3, "geocodePlaceholder": "Search"},
+  "helptext": null,
+  "datatype": "geojson-feature-collection"
+}
+    


### PR DESCRIPTION
Tested and it works, allowing us to choose whether or not a card should show lat lon and easting/northings.

Still only works using the default card so the card has to be set to use the map-with-latlon-widget as default.
If it's default you can still revert to the old map by using map-widget as the component name in the <workflow_name>-workflow.js

There is a model change to remove the term BNG from the node labels since we are no longer using the british national grid.