### PR TITLE
Default deny

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -239,6 +239,8 @@ CACHES = {
     },
 }
 
+PERMISSION_FRAMEWORK = "arches_default_deny.ArchesDefaultDenyPermissionFramework"
+
 # Hide nodes and cards in a report that have no data
 HIDE_EMPTY_NODES_IN_REPORT = False
 


### PR DESCRIPTION
Switches the default permission model to be default-deny -- if a user does not explicitly have permissions on a resource, they cannot access it.