### PR TITLE
Fix admin permissions

### DIFF
--- a/coral/permissions/casbin.py
+++ b/coral/permissions/casbin.py
@@ -133,6 +133,7 @@ class CasbinPermissionFramework(ArchesStandardPermissionFramework):
         # (implicitly resource models) and map layers, but nothing else.
         for django_group in DjangoGroup.objects.all():
             group_key = self._subj_to_str(django_group)
+            self._enforcer.add_named_grouping_policy("g", group_key, f"dgn:{django_group.name}")
             nodegroups = {
                 nodegroup: set(perms)
                 for nodegroup, perms in
@@ -213,7 +214,6 @@ class CasbinPermissionFramework(ArchesStandardPermissionFramework):
             for group in user.groups.all():
                 group_key = self._subj_to_str(group)
                 self._enforcer.add_named_grouping_policy("g", user_key, group_key)
-                self._enforcer.add_named_grouping_policy("g", user_key, f"dgn:{group.name}")
 
         def _fill_set(st):
             set_key = self._obj_to_str(st)
@@ -902,7 +902,7 @@ class CasbinPermissionFramework(ArchesStandardPermissionFramework):
     @context_free
     def user_in_group_by_name(self, user, names):
         subj = self._subj_to_str(user)
-        roles = self._enforcer.get_roles_for_user(subj)
+        roles = self._enforcer.get_implicit_roles_for_user(subj)
         return any(f"dgn:{name}" in roles for name in names)
 
 from contextlib import contextmanager

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ requests_oauthlib
 python-docx
 
 
-git+https://github.com/flaxandteal/arches-orm@229050b75c0f3ab624350d57875a23e5e445e100
+git+https://github.com/flaxandteal/arches-orm@15c5523832e1051c60a9dde614739891c0c11ec9
 pika
 django-authorization
 casbin-django-orm-adapter


### PR DESCRIPTION
### What does this PR do?

Only warn (not error out the request) if a Django group or user that is attached to a resource instance is missing. This can happen for several reasons, and a nicer way of handling this (perhaps, like EmptyConcept...) would be good.

Additionally, this moves from caching Django Group names in Casbin by attaching the user to them, to instead making the spelt name a Casbin grouping about the UUID group name. This will be reset on rerunning `recalculate_table` but means that user-group membership can deal only with the UUIDs, and the spelt-out name will get/lose the user transitively.