### PR TITLE
Add GeoJSON ORM datatype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,11 @@ requests_oauthlib
 python-docx
 
 
-git+https://github.com/flaxandteal/arches-orm@15c5523832e1051c60a9dde614739891c0c11ec9
+git+https://github.com/flaxandteal/arches-orm@af63310bb6a19abf0a96f0847c4b4f5bae6a4808
 pika
 django-authorization
 casbin-django-orm-adapter
 cachetools
 websockets
+
+geojson


### PR DESCRIPTION
### What does this PR do?

It adds a GeoJSON datatype, that allows for JSON to be set into the geomtery field. This means the API supports GeoJSON.