### PR TITLE
On-demand resets

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -56,6 +56,8 @@ WEBPACK_LOADER = {
 CASBIN_MODEL = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'permissions', 'casbin.conf')
 CASBIN_RELOAD_QUEUE = os.getenv("CASBIN_RELOAD_QUEUE", "reloadQueue")
 
+CORAL_UPGRADE_WINDOW_FILE = os.getenv("CORAL_UPGRADE_WINDOW_FILE", "")
+
 DAUTHZ = {
     # DEFAULT Dauthz enforcer
     "DEFAULT": {


### PR DESCRIPTION
### What does this PR do?

Adds a remote call to launch a database reset.

***How do we prevent accident resets?***: this only functions if it finds an upgrade window file, which must be added to the Flux repo as a mountable configmap. It lists windows, so we can extend it and so approve database resets by PR, with each window requiring a tuple: start time, end time and a window-specific "lock" password that must be encrypted by the same Arches instance. The reset command takes only one argument, a separately encrypted password (command for encrypting this is a nice-to-have) which is checked against any matching window.

If the window-password matches a (the) current upgrade window, then an upgrade will be triggered on the worker.

### How to review?

Walk through the documented steps on dev, and ensure a full reset is completed without error.

### Who can review?

@taylorn01 @OwenGalvia 