### PR TITLE
fix(Flag for Enforcement Workflow): Save even if bad recent resources found, e.g. from before a reset [#1712]

### DIFF
--- a/coral/media/js/views/components/plugins/open-workflow.js
+++ b/coral/media/js/views/components/plugins/open-workflow.js
@@ -140,7 +140,12 @@ define([
 
       const validate = (resourceId) =>
         new Promise(async (resolve, reject) => {
-          const tiles = await this.fetchTileData(resourceId);
+          let tiles = [];
+          try {
+            tiles = await this.fetchTileData(resourceId);
+          } catch (error) {
+            console.error(error);
+          };
           if (!tiles.length) {
             removeWorkflows.push(resourceId);
           }

--- a/coral/plugins/open-workflow.json
+++ b/coral/plugins/open-workflow.json
@@ -67,7 +67,8 @@
           "65b1be1a-dfa4-49cf-a736-a1a88c0bb289"
         ],
         "setupFunction": "setupMonumentRevision",
-        "disableStartNew": true
+        "disableStartNew": true,
+        "hideRecents": true
       },
       {
         "slug": "fmw-inspection-workflow",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=4, minor=14, patch=11)
+APP_VERSION = semantic_version.Version(major=4, minor=14, patch=12)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/plugins/open-workflow.htm
+++ b/coral/templates/views/components/plugins/open-workflow.htm
@@ -1,3 +1,4 @@
+<!-- ko if: !workflow()?.hideRecents -->
 <div style="margin: 15px; white-space: nowrap; max-width: 200px; width: 100%">
   <h5>Recently opened</h5>
   <!-- ko if: !recentlyOpenedResources().length -->
@@ -22,6 +23,7 @@
   </div>
   <!-- /ko -->
 </div>
+<!-- /ko -->
 <div class="card-component" style="width: 100%">
   <div class="row widget-wrapper">
     <h4 data-bind="text: workflow().name"></h4>


### PR DESCRIPTION
### What does this PR do?

Prevents an error being thrown if a resource in the local cache is no longer available (for example, due to a reset).

### How to review?

This is trickier - it was originally seen after a DB reset but it should be sufficient to test by deleting the resource after doing the workflow.

### Who can review?

@taylorn01 to confirm the fix. @hristiyanadeliyska or Jana to test on dev & UAT.