### PR TITLE
Fix: auto genereate id edit page rendering

### DIFF
--- a/coral/media/js/views/components/widgets/auto-generate-id-widget.js
+++ b/coral/media/js/views/components/widgets/auto-generate-id-widget.js
@@ -22,12 +22,16 @@ define([
 
       const self = this;
 
-      self.prefixStatic = params.config().prefix;
+      self.prefixStatic = ko.isObservable(params.config) ?  params.config()?.prefix : params.config?.prefix;
       if (self.form?.componentData?.parameters?.prefix) {
         self.prefixStatic = self.form?.componentData?.parameters?.prefix
       }
 
       self.currentLanguage = ko.observable({ code: arches.activeLanguage });
+
+      self.enDisplayValue = ko.computed(() => {
+        return ko.unwrap(ko.unwrap(this.displayValue)[ko.unwrap(arches.activeLanguage)]['value']);
+      }, self);
 
       self.idValue = ko.observable();
 

--- a/coral/templates/views/components/widgets/auto-generate-id-widget.htm
+++ b/coral/templates/views/components/widgets/auto-generate-id-widget.htm
@@ -36,7 +36,7 @@
 
 <!-- ko if: !configForm  && state === 'display_value' -->
 {% block display_value %}
-<span data-bind="text: displayValue && displayValue() && currentLanguage() && displayValue()[currentLanguage().code] && displayValue()[currentLanguage().code]['value'] ? displayValue()[currentLanguage().code]['value'] : '' || $root.translations.none"></span>
+<span data-bind="text: enDisplayValue() || $root.translations.none"></span>
 {% endblock display_value %}
 <!-- /ko -->
 
@@ -44,7 +44,7 @@
 <!-- ko if: !ko.unwrap(hideEmptyNodes) || ko.unwrap(hideEmptyNodes) === true && displayValue() -->
 {% block report %}
 <dt data-bind="text: label"></dt>
-<dd data-bind="text: displayValue() && currentLanguage() && displayValue()[currentLanguage().code] && displayValue()[currentLanguage().code]['value'] ? displayValue()[currentLanguage().code]['value'] : $root.translations.none"></dd>
+<dd data-bind="text: enDisplayValue() || $root.translations.none"></dd>
 {% endblock report %}
 <!-- /ko -->
 <!-- /ko -->


### PR DESCRIPTION
On edit page params.config is not available and the language display value look up is messy and was returning a stringified object