### PR TITLE
Fix: curatorial not showing correct open list

### DIFF
--- a/coral/plugins/open-workflow.json
+++ b/coral/plugins/open-workflow.json
@@ -110,7 +110,8 @@
       {
         "slug": "curatorial-workflow",
         "name": "Curatorial Inspection",
-        "graphIds": ["076f9381-7b00-11e9-8d6b-80000b44d1d9"]
+        "graphIds": ["8d41e49e-a250-11e9-9eab-00224800b26d"],
+        "searchString": "/search/resources?paging-filter=1&resource-type-filter=[{\"graphid\":\"8d41e49e-a250-11e9-9eab-00224800b26d\",\"inverted\":false}]&sort-results=asc&advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CIN\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
       }
     ]
   },


### PR DESCRIPTION
Test:

Click curatorial inspection workflow from workflows page. Be redirected to open curatorial page. Start new curatorial to get one into the system. After you have that check it is the only thing shown in the select box on the open curatorial page. Also create other consultations like planning to check their prefix CON doesn't appear, only CIN should appear.