### PR TITLE
fix: change revision graph uuid to string and change damage type to c…

### DIFF
--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -28943,7 +28943,7 @@
                     "config": {
                         "rdmCollection": "9881e48c-95f1-42da-bc55-76a6b6f34f22"
                     },
-                    "datatype": "concept-list",
+                    "datatype": "concept",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,

--- a/coral/views/monument_revision_remap.py
+++ b/coral/views/monument_revision_remap.py
@@ -17,7 +17,7 @@ class RemapMonumentToRevision(View):
         data = json.loads(request.body.decode("utf-8"))
         target_resource_id = data.get("targetResourceId")
         resource = Resource.objects.filter(pk=target_resource_id).first()
-        if (MONUMENT_REVISION_GRAPH_ID == resource.graph.graphid):
+        if (MONUMENT_REVISION_GRAPH_ID == str(resource.graph.graphid)):
             return JSONResponse({
                 "message": "This resource is already a revision",
                 "started" : False


### PR DESCRIPTION
Change the uuid to a string when comparing the graphs to check for a revision
Change the damage type on a monument revision to concept to allow the heritage asset types page to open