### PR TITLE
Fix (Taiga #2022 | Enforcement): Pre-populated Date Not Saving

### DIFF
--- a/coral/media/js/views/components/widgets/datepicker.js
+++ b/coral/media/js/views/components/widgets/datepicker.js
@@ -105,10 +105,7 @@ define([
     if (self.form && this.defaultValue() === 'Date of Data Entry') {
       if (this.value() === 'Date of Data Entry') {
         const today = new Date();
-        self.value(today.toLocaleDateString('en-CA')); //"en-CA" formats the date in the desired format YYYY-MM-DD
-        const tileData = JSON.parse(self.tile._tileData());
-        tileData[this.node.id] = today.toLocaleDateString('en-CA');
-        self.tile._tileData(koMapping.toJSON(tileData));
+        this.value(today.toLocaleDateString('en-CA')); //"en-CA" formats the date in the desired format YYYY-MM-DD
       }
     }
     


### PR DESCRIPTION
### Description
The 'Flagged Date' was populating on load but not triggering the save and continue. And not saving when additional data was passed into the step.

Removed the update to the tile data of the datepicker and let the save and continue handle the saving of the data.

### Test
Update widgets
Updated webpack
Open an enforcement - Date should be populated with today's date and the save and continue button should be visible
Hit save and the date should show in the summary page
Check the resource instance that the date has saved correctly