### PR TITLE
Feat/garden number generation

### DIFF
--- a/coral/functions/garden_number_function.py
+++ b/coral/functions/garden_number_function.py
@@ -1,0 +1,67 @@
+from arches.app.functions.base import BaseFunction
+from arches.app.models.tile import Tile
+from arches.app.models import models
+from coral.utils.garden_number import GardenNumber
+
+HERITAGE_ASSET_REFERENCES_NODEGROUP_ID = "e71df5cc-3aad-11ef-a2d0-0242ac120003"
+GARDEN_NUMBER_NODE_ID = "2c2d02fc-3aae-11ef-91fd-0242ac120003"
+
+GENERATED_GARDEN_NODEGROUP = "9b884c9c-49a4-11ef-8345-0242ac120007"
+GENERATED_GARDEN_NODE_ID = "bd85cca2-49a4-11ef-94a5-0242ac120007"
+
+ADDRESS_NODEGROUP_ID = "87d39b25-f44f-11eb-95e5-a87eeabdefba"
+COUNTY_NODE_ID = "8bfe714e-3ec2-11ef-9023-0242ac140007"
+
+details = {
+    "functionid": "2d0a0e51-0a20-443f-85cf-7ddc333c0cdd",
+    "name": "Garden Number",
+    "type": "node",
+    "description": "Will validate the generated garden number. Upon failing it will attempt to generate a replacement.",
+    "defaultconfig": {"triggering_nodegroups": [GENERATED_GARDEN_NODEGROUP]},
+    "classname": "GardenNumberFunction",
+    "component": "",
+}
+
+
+class GardenNumberFunction(BaseFunction):
+    def update_ha_references(self, ri_id, id):
+        references_tile = Tile.objects.filter(
+            resourceinstance_id=ri_id,
+            nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
+        ).first()
+
+        if not references_tile:
+            references_tile = Tile.get_blank_tile_from_nodegroup_id(
+                nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID, resourceid=ri_id
+            )
+
+        references_tile.data[GARDEN_NUMBER_NODE_ID] = id
+        references_tile.save()
+
+    def post_save(self, tile, request, context):
+        resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
+        id_number = tile.data.get(GENERATED_GARDEN_NODE_ID, None)
+
+        if not id_number:
+            return
+
+        county_tile = Tile.objects.filter(
+            resourceinstance_id=resource_instance_id,
+            nodegroup_id=ADDRESS_NODEGROUP_ID,
+        ).first()
+
+        county_name = models.Value.objects.filter(
+                valueid= county_tile.data.get(COUNTY_NODE_ID)
+            ).first()
+
+        gn = GardenNumber(county_name=county_name.value)
+
+        if gn.validate_id(id_number):
+            print("Garden Number is valid: ", id_number)
+            self.update_ha_references(resource_instance_id, id_number)
+            return
+
+        id_number = gn.generate_id_number(resource_instance_id)
+        self.update_ha_references(resource_instance_id, id_number)
+
+        return

--- a/coral/media/js/views/components/plugins/workflow-builder-loader.js
+++ b/coral/media/js/views/components/plugins/workflow-builder-loader.js
@@ -17,6 +17,7 @@ define([
   'views/components/workflows/fmw-workflow/calculate-composite-score',
   'views/components/workflows/generate-ha-number',
   'views/components/workflows/generate-smr-number',
+  'views/components/workflows/generate-garden-number',
   'views/components/workflows/heritage-asset-designation-workflow/ha-summary',
   'views/components/workflows/heritage-asset-designation-workflow/start-remap-and-merge',
   'views/components/workflows/assign-consultation-workflow/pc-summary',

--- a/coral/media/js/views/components/workflows/generate-garden-number.js
+++ b/coral/media/js/views/components/workflows/generate-garden-number.js
@@ -9,15 +9,12 @@ define([
   ], function (_, ko, koMapping, uuid, arches, CardComponentViewModel, template) {
     function viewModel(params) {
       CardComponentViewModel.apply(this, [params]);
-      console.log('generate-garden-number: ', this.tiles());
   
       this.gardenNumber = ko.observable('');
   
       this.ADDRESS_NODEGROUP = "87d39b25-f44f-11eb-95e5-a87eeabdefba"
       this.COUNTY_NODE_ID = '8bfe714e-3ec2-11ef-9023-0242ac140007';
-      this.GENERATED_GARDEN_NODE_ID = 'bb3860284-4414-11ef-ac80-0242ac120002';
-      console.log("URL TEST", arches.urls.resource_tiles.replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', this.tile.resourceinstance_id) + `?nodeid=${this.COUNTY_NODEGROUP}` )
-      console.log("tile data", this.tile)
+      this.GENERATED_GARDEN_NODE_ID = 'bd85cca2-49a4-11ef-94a5-0242ac120007';
 
       this.selectedCounty = ko.observable();
       this.errorMessage = "No county has been selected"
@@ -42,7 +39,6 @@ define([
           const countyName = tile.data[this.COUNTY_NODE_ID]
           if (countyName) {
             this.selectedCounty(countyName)
-            console.log("county Name", this.selectedCounty())
           }
         }
       }
@@ -53,7 +49,7 @@ define([
   
       this.generateGardenNumber = async () => {
         if (!this.selectedCounty) return;
-        console.log("I'm working!")
+
         params.pageVm.loading(true);
         const data = {
           resourceInstanceId: this.tile.resourceinstance_id,
@@ -69,15 +65,18 @@ define([
             console.log(response, status, error);
           }
         });
+
         if (ko.isObservable(this.tile.data[this.GENERATED_GARDEN_NODE_ID])) {
           this.tile.data[this.GENERATED_GARDEN_NODE_ID]({
             en: {
+              direction: "ltr",
               value: response.gardenNumber
             }
           });
         } else {
           this.tile.data[this.GENERATED_GARDEN_NODE_ID] = {
             en: {
+              direction: "ltr",
               value: response.gardenNumber
             }
           };

--- a/coral/media/js/views/components/workflows/generate-garden-number.js
+++ b/coral/media/js/views/components/workflows/generate-garden-number.js
@@ -1,0 +1,97 @@
+define([
+    'underscore',
+    'knockout',
+    'knockout-mapping',
+    'uuid',
+    'arches',
+    'viewmodels/card-component',
+    'templates/views/components/workflows/generate-garden-number.htm'
+  ], function (_, ko, koMapping, uuid, arches, CardComponentViewModel, template) {
+    function viewModel(params) {
+      CardComponentViewModel.apply(this, [params]);
+      console.log('generate-garden-number: ', this.tiles());
+  
+      this.gardenNumber = ko.observable('');
+  
+      this.ADDRESS_NODEGROUP = "87d39b25-f44f-11eb-95e5-a87eeabdefba"
+      this.COUNTY_NODE_ID = '8bfe714e-3ec2-11ef-9023-0242ac140007';
+      this.GENERATED_GARDEN_NODE_ID = 'bb3860284-4414-11ef-ac80-0242ac120002';
+      console.log("URL TEST", arches.urls.resource_tiles.replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', this.tile.resourceinstance_id) + `?nodeid=${this.COUNTY_NODEGROUP}` )
+      console.log("tile data", this.tile)
+
+      this.selectedCounty = ko.observable();
+      this.errorMessage = "No county has been selected"
+
+      this.fetchCountyTile = async () => {
+        try {
+          const response = await window.fetch(
+            arches.urls.resource_tiles.replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', this.tile.resourceinstance_id) + `?nodeid=${this.ADDRESS_NODEGROUP}` 
+          )
+          const data = await response.json()
+          return data.tiles[0];
+        } catch (error) {
+          console.error(error)
+          return null
+        }
+        
+      }
+
+      this.getCountyName = async () => {
+        const tile = await this.fetchCountyTile()
+        if (tile) {
+          const countyName = tile.display_values.find(object => object.nodeid === this.COUNTY_NODE_ID).value
+          if (countyName) {
+            this.selectedCounty(countyName)
+          }
+        }
+      }
+
+      this.hasSelectedCounty = ko.computed(() => {
+        return !!this.selectedCounty();
+      }, this);
+  
+      this.generateGardenNumber = async () => {
+        if (!this.selectedCounty) return;
+        console.log("I'm working!")
+      //   params.pageVm.loading(true);
+      //   const data = {
+      //     resourceInstanceId: this.tile.resourceinstance_id,
+      //     selectedCountyId: this.tile.data[this.COUNTY_NODE_ID]()
+      //   };
+      //   const response = await $.ajax({
+      //     type: 'POST',
+      //     url: '/generate-garden-number',
+      //     dataType: 'json',
+      //     data: JSON.stringify(data),
+      //     context: this,
+      //     error: (response, status, error) => {
+      //       console.log(response, status, error);
+      //     }
+      //   });
+      //   if (ko.isObservable(this.tile.data[this.GENERATED_GARDEN_NODE_ID])) {
+      //     this.tile.data[this.GENERATED_GARDEN_NODE_ID]({
+      //       en: {
+      //         value: response.gardenNumber
+      //       }
+      //     });
+      //   } else {
+      //     this.tile.data[this.GENERATED_GARDEN_NODE_ID] = {
+      //       en: {
+      //         value: response.gardenNumber
+      //       }
+      //     };
+      //   }
+      //   params.pageVm.loading(false);
+      };
+
+      this.getCountyName()
+    }
+  
+    ko.components.register('generate-garden-number', {
+      viewModel: viewModel,
+      template: template
+    });
+  
+    return viewModel;
+  });
+  

--- a/coral/media/js/views/components/workflows/generate-garden-number.js
+++ b/coral/media/js/views/components/workflows/generate-garden-number.js
@@ -36,12 +36,13 @@ define([
         
       }
 
-      this.getCountyName = async () => {
+      this.getCountyID = async () => {
         const tile = await this.fetchCountyTile()
         if (tile) {
-          const countyName = tile.display_values.find(object => object.nodeid === this.COUNTY_NODE_ID).value
+          const countyName = tile.data[this.COUNTY_NODE_ID]
           if (countyName) {
             this.selectedCounty(countyName)
+            console.log("county Name", this.selectedCounty())
           }
         }
       }
@@ -53,38 +54,38 @@ define([
       this.generateGardenNumber = async () => {
         if (!this.selectedCounty) return;
         console.log("I'm working!")
-      //   params.pageVm.loading(true);
-      //   const data = {
-      //     resourceInstanceId: this.tile.resourceinstance_id,
-      //     selectedCountyId: this.tile.data[this.COUNTY_NODE_ID]()
-      //   };
-      //   const response = await $.ajax({
-      //     type: 'POST',
-      //     url: '/generate-garden-number',
-      //     dataType: 'json',
-      //     data: JSON.stringify(data),
-      //     context: this,
-      //     error: (response, status, error) => {
-      //       console.log(response, status, error);
-      //     }
-      //   });
-      //   if (ko.isObservable(this.tile.data[this.GENERATED_GARDEN_NODE_ID])) {
-      //     this.tile.data[this.GENERATED_GARDEN_NODE_ID]({
-      //       en: {
-      //         value: response.gardenNumber
-      //       }
-      //     });
-      //   } else {
-      //     this.tile.data[this.GENERATED_GARDEN_NODE_ID] = {
-      //       en: {
-      //         value: response.gardenNumber
-      //       }
-      //     };
-      //   }
-      //   params.pageVm.loading(false);
+        params.pageVm.loading(true);
+        const data = {
+          resourceInstanceId: this.tile.resourceinstance_id,
+          selectedCountyId: this.selectedCounty()
+        };
+        const response = await $.ajax({
+          type: 'POST',
+          url: '/generate-garden-number',
+          dataType: 'json',
+          data: JSON.stringify(data),
+          context: this,
+          error: (response, status, error) => {
+            console.log(response, status, error);
+          }
+        });
+        if (ko.isObservable(this.tile.data[this.GENERATED_GARDEN_NODE_ID])) {
+          this.tile.data[this.GENERATED_GARDEN_NODE_ID]({
+            en: {
+              value: response.gardenNumber
+            }
+          });
+        } else {
+          this.tile.data[this.GENERATED_GARDEN_NODE_ID] = {
+            en: {
+              value: response.gardenNumber
+            }
+          };
+        }
+        params.pageVm.loading(false);
       };
 
-      this.getCountyName()
+      this.getCountyID()
     }
   
     ko.components.register('generate-garden-number', {

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -32,6 +32,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "a1746b73-2e4f-4f3d-8fa6-365afdd4380a",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "is_editable": true,
+                    "name": {
+                        "en": "Generated Garden Reference"
+                    },
+                    "nodegroup_id": "628e9694-4fda-11ef-8e01-0242ac120003",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "042cca2e-3b50-4091-8bd4-8c4ffd2cd1f8",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -14980,6 +15007,24 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "a9eeba97-34d4-424e-99cc-586f6b3c626f",
+                    "edgeid": "a4bca986-2884-46ec-a138-34b0ee310d38",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "rangenode_id": "628e9694-4fda-11ef-8e01-0242ac120003"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "628e9694-4fda-11ef-8e01-0242ac120003",
+                    "edgeid": "ac5af9bd-ab35-4554-8001-ca1231b380d0",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "7e402272-4fda-11ef-a8cc-0242ac120003"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "0132f890-1f4c-11ef-ac74-0242ac150006",
                     "edgeid": "3642ac0f-3893-497f-ba93-25b21dfca6e4",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
@@ -21251,6 +21296,12 @@
                 {
                     "cardinality": "1",
                     "legacygroupid": null,
+                    "nodegroupid": "628e9694-4fda-11ef-8e01-0242ac120003",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
                     "nodegroupid": "0132f890-1f4c-11ef-ac74-0242ac150006",
                     "parentnodegroup_id": null
                 },
@@ -21749,6 +21800,52 @@
                     "nodegroup_id": "38dad285-9014-4c7b-ad81-b0562038ebf2",
                     "nodeid": "5c865d99-b9c2-43c8-11ba-e77948afa21d",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "generated_historic_parks_and_garden",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Generated Historic Parks and Garden",
+                    "nodegroup_id": "628e9694-4fda-11ef-8e01-0242ac120003",
+                    "nodeid": "7e402272-4fda-11ef-a8cc-0242ac120003",
+                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "generated_garden_reference",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Generated Garden Reference",
+                    "nodegroup_id": "628e9694-4fda-11ef-8e01-0242ac120003",
+                    "nodeid": "628e9694-4fda-11ef-8e01-0242ac120003",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -2299,6 +2299,35 @@
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
+                    "card_id": "10f14bcc-4307-422d-afdf-417f6b9eac38",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Generated Historic Parks and Garden",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Auto-generated field"
+                        },
+                        "uneditable": true,
+                        "width": "100%%"
+                    },
+                    "id": "9406facd-dca0-43d2-a705-0e96e42b245a",
+                    "label": {
+                        "en": "Generated Historic Parks and Garden"
+                    },
+                    "node_id": "bd85cca2-49a4-11ef-94a5-0242ac120007",
+                    "sortorder": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
                     "card_id": "346001be-d23e-11ee-9ae7-0242ac180006",
                     "config": {
                         "defaultValue": "b81d4b16-0633-4d7a-b4b2-5c2d3e2e782e",

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -140,6 +140,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "10f14bcc-4307-422d-afdf-417f6b9eac38",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "is_editable": false,
+                    "name": {
+                        "en": "Generated Garden Reference"
+                    },
+                    "nodegroup_id": "9b884c9c-49a4-11ef-8345-0242ac120007",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "126bfd36-dbc3-11ee-8835-0242ac120006",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -15072,6 +15099,24 @@
                     "rangenode_id": "8bfe714e-3ec2-11ef-9023-0242ac140007"
                 },
                 {
+                    "description": null,
+                    "domainnode_id": "9b884c9c-49a4-11ef-8345-0242ac120007",
+                    "edgeid": "fb0149c4-3113-420f-9439-8901b15cd785",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "bd85cca2-49a4-11ef-94a5-0242ac120007"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "076f9380-7b00-11e9-88c8-80000b44d1d9",
+                    "edgeid": "92d61c2d-a534-4e00-b473-3473ab523cfb",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "rangenode_id": "9b884c9c-49a4-11ef-8345-0242ac120007"
+                },
+                {
                     "domainnode_id": "a05d0dd0-1f4b-11ef-ac74-0242ac150006",
                     "edgeid": "3642ac0f-3893-497f-ba93-25b21dfca6e4",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
@@ -21303,6 +21348,16 @@
                 },
                 {
                     "config": {
+                        "triggering_nodegroups": [
+                            "9b884c9c-49a4-11ef-8345-0242ac120007"
+                        ]
+                    },
+                    "function_id": "2d0a0e51-0a20-443f-85cf-7ddc333c0cdd",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "id": "bfcf28c3-90f6-49f6-8836-3f4351c714a5"
+                },
+                {
+                    "config": {
                         "descriptor_types": {
                             "description": {
                                 "nodegroup_id": "ba342e69-b554-11ea-a027-f875a44e0e11",
@@ -21378,6 +21433,12 @@
                     "cardinality": "1",
                     "legacygroupid": null,
                     "nodegroupid": "0532349a-1f5d-11ef-a340-0242ac150006",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
+                    "nodegroupid": "9b884c9c-49a4-11ef-8345-0242ac120007",
                     "parentnodegroup_id": null
                 },
                 {
@@ -21882,6 +21943,52 @@
                     "nodeid": "8bfe714e-3ec2-11ef-9023-0242ac140007",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "generated_garden_reference",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Generated Garden Reference",
+                    "nodegroup_id": "9b884c9c-49a4-11ef-8345-0242ac120007",
+                    "nodeid": "9b884c9c-49a4-11ef-8345-0242ac120007",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "generated_historic_parks_and_garden_n1",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Generated Historic Parks and Garden",
+                    "nodegroup_id": "9b884c9c-49a4-11ef-8345-0242ac120007",
+                    "nodeid": "bd85cca2-49a4-11ef-94a5-0242ac120007",
+                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -21999,7 +21999,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "generated_historic_parks_and_garden_n1",
+                    "alias": "generated_historic_parks_and_garden",
                     "config": {
                         "en": ""
                     },

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -53,23 +53,6 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['12645f4a-6638-4f80-b020-c7dd7f886163'][0]['resourceid']['resourceInstanceId']",
                   "hiddenNodes": [
-                    "1de9abf0-3aae-11ef-91fd-0242ac120003",
-                    "250002fe-3aae-11ef-91fd-0242ac120003",
-                    "158e1ed2-3aae-11ef-a2d0-0242ac120003"
-                  ],
-                  "nodegroupid": "e71df5cc-3aad-11ef-a2d0-0242ac120003",
-                  "semanticName": "Heritage Asset References",
-                  "labels": [["Historic Parks and Gardens", "Historic Parks & Gardens Number"]]
-                },
-                "tilesManaged": "one",
-                "componentName": "default-card-util",
-                "uniqueInstanceName": "garden-heritage-asset-references"
-              },
-              {
-                "parameters": {
-                  "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                  "resourceid": "['start-step']['12645f4a-6638-4f80-b020-c7dd7f886163'][0]['resourceid']['resourceInstanceId']",
-                  "hiddenNodes": [
                     "676d47fc-9c1c-11ea-b5b0-f875a44e0e11",
                     "676d47fd-9c1c-11ea-9d73-f875a44e0e11"
                   ],

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -327,11 +327,7 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['12645f4a-6638-4f80-b020-c7dd7f886163'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "86c19e92-3ea7-11ef-818b-0242ac140006",
-                  "hiddenNodes": [
-                    "b46b5bba-3ec2-11ef-bb61-0242ac140006",
-                    "86c19e92-3ea7-11ef-818b-0242ac140006"
-                  ]
+                  "nodegroupid": "9b884c9c-49a4-11ef-8345-0242ac120007"
                 },
                 "tilesManaged": "one",
                 "componentName": "generate-garden-number",

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -322,6 +322,20 @@
                 "tilesManaged": "one",
                 "componentName": "default-card",
                 "uniqueInstanceName": "fdbda47e-fbe4-4254-9df6-d619b7f984c6"
+              },
+              {
+                "parameters": {
+                  "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                  "resourceid": "['start-step']['12645f4a-6638-4f80-b020-c7dd7f886163'][0]['resourceid']['resourceInstanceId']",
+                  "nodegroupid": "86c19e92-3ea7-11ef-818b-0242ac140006",
+                  "hiddenNodes": [
+                    "b46b5bba-3ec2-11ef-bb61-0242ac140006",
+                    "86c19e92-3ea7-11ef-818b-0242ac140006"
+                  ]
+                },
+                "tilesManaged": "one",
+                "componentName": "generate-garden-number",
+                "uniqueInstanceName": "b2679d02-cabb-40a8-8f61-8d97d4454923"
               }
             ]
           }

--- a/coral/templates/views/components/workflows/generate-garden-number.htm
+++ b/coral/templates/views/components/workflows/generate-garden-number.htm
@@ -1,0 +1,473 @@
+{% load i18n %}
+<!-- ko foreach: { data: [$data], as: 'self' } -->
+
+<!-- ko if: state === 'editor-tree' && self.card.model.visible() -->
+{% block editor_tree %}
+<li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.tiles().length > 0 && card.expanded()), 'jstree-closed' : (card.tiles().length > 0 && !card.expanded()), 'jstree-leaf': card.tiles().length === 0, 'hide-background': !self.showGrid()}, scrollTo: card.scrollTo, container: '.resource-editor-tree'">
+    <i class="jstree-icon" role="presentation" data-bind="click: function(){card.expanded(!card.expanded())}, css: {'jstree-ocl': self.showGrid}"></i>
+    <a class="jstree-anchor" href="#" tabindex="-1" data-bind="css:{'filtered': card.highlight(), 'jstree-clicked': card.selected, 'child-selected': card.isChildSelected(), 'func-node': card.isFuncNode(),'unsaved-edit': card.isDirty() === true}, event: {
+        mousedown: function(d, e) {
+            e.stopPropagation();
+            self.card.canAdd() ? self.card.selected(true) : self.card.tiles()[0].selected(true);
+        }
+    }">
+        <!-- ko if: !self.card.isFuncNode() -->
+        <i class="fa fa-file-o" role="presentation" data-bind="css:{'filtered': self.card.highlight(), 'has-provisional-edits fa-file': self.card.doesChildHaveProvisionalEdits()}"></i>
+        <!-- /ko -->
+        <!-- ko if: self.card.isFuncNode() -->
+        <i class="fa fa-code" role="presentation" data-bind="css:{'filtered': self.card.highlight(), 'has-provisional-edits fa-file': self.card.doesChildHaveProvisionalEdits()}"></i>
+        <!-- /ko -->
+        <span style="padding-right: 5px;" data-bind="text: self.card.model.name"></span>
+        <!-- ko if: self.card.canAdd() -->
+        <i class="fa fa-plus-circle add-new-tile" role="presentation" data-bind="css:{'jstree-clicked': self.card.selected}, click: function(){self.card.showForm(true);}, clickBubble: false" data-toggle="tooltip" data-original-title="$root.translations.addGnu"></i>
+        <!-- /ko -->
+    </a>
+    <ul class="jstree-children" aria-expanded="true">
+        <div data-bind="sortable: {
+            data: self.card.tiles,
+            options: {
+                start: self.startDrag
+            },
+            beforeMove: self.beforeMove,
+            afterMove: self.card.reorderTiles
+        }">
+            <li role="treeitem" class="jstree-node" data-bind="css: {'jstree-open': (cards.length > 0 && expanded), 'jstree-closed' : (cards.length > 0 && !expanded()), 'jstree-leaf': cards.length === 0, 'hide-background': !self.showGrid()}, event: {'dragstart': function () { console.log('dragging...') }}">
+                <i class="jstree-icon" role="presentation" data-bind="click: function(){expanded(!expanded())}, css: {'jstree-ocl': self.showGrid}"></i>
+                <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function () { self.form.selection($data);}, css:{'jstree-clicked': selected, 'child-selected': isChildSelected(), 'filtered-leaf': card.highlight(), 'unsaved-edit': !!$data.dirty()}">
+                    <i class="fa " role="presentation" data-bind="css:{'has-provisional-edits': doesChildHaveProvisionalEdits() || $data.hasprovisionaledits(),'fa-pencil':$data.dirty()===true,'fa-file':!$data.dirty()}"></i>
+                    <strong style="margin-right: 10px;">
+                        {% block editor_tree_node_content %}
+                        <!-- ko if: self.card.widgets().length > 0 && self.card.widgets()[0].visible -->
+                        <span data-bind="text: self.card.widgets()[0].label || self.card.model.name"></span>:
+                        <div style="display: inline;" data-bind="component: {
+                            name: self.form.widgetLookup[self.card.widgets()[0].widget_id()].name,
+                            params: {
+                                tile: $data,
+                                node: self.form.nodeLookup[card.widgets()[0].node_id()],
+                                config: self.form.widgetLookup[card.widgets()[0].widget_id()].config,
+                                label: self.form.widgetLookup[card.widgets()[0].widget_id()].label,
+                                inResourceEditor: self.inResourceEditor,
+                                value: $data.data[card.widgets()[0].node_id()],
+                                type: 'resource-editor',
+                                state: 'display_value',
+                                disabled: !self.card.isWritable && !self.preview
+                            }
+                        }"></div>
+                        <!-- /ko -->
+                        <!-- ko if: self.card.widgets().length === 0 || !self.card.widgets()[0].visible -->
+                        <span data-bind="text: self.card.model.name"></span>
+                        <!-- /ko -->
+                        {% endblock editor_tree_node_content %}
+                    </strong>
+                </a>
+                <!-- ko if: cards.length > 0 && self.card.expanded() -->
+                <ul class="jstree-children" aria-expanded="true" data-bind="foreach: {
+                        data: cards,
+                        as: 'card'
+                    }">
+                    <!-- ko component: {
+                        name: self.form.cardComponentLookup[self.card.model.component_id()].componentname,
+                        params: {
+                            state: 'editor-tree',
+                            card: card,
+                            tile: null,
+                            loading: self.loading,
+                            form: self.form,
+                            pageVm: $root
+                        }
+                    } --> <!-- /ko -->
+                </ul>
+                <!-- /ko -->
+            </li>
+        </div>
+    </ul>
+</li>
+{% endblock editor_tree %}
+<!-- /ko -->
+
+<!-- ko if: state === 'designer-tree' -->
+{% block designer_tree %}
+<li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': ((card.cards().length > 0 || card.widgets().length > 0) && card.expanded()), 'jstree-closed' : ((card.cards().length > 0 || card.widgets().length > 0) && !card.expanded()), 'jstree-leaf': card.cards().length === 0 && card.widgets().length === 0, 'hide-background': !self.showGrid()}, scrollTo: card.scrollTo, container: '.designer-card-tree'">
+    <i class="jstree-icon" role="presentation" data-bind="click: function(){card.expanded(!card.expanded())}, css: {'jstree-ocl': self.showGrid}"></i>
+    <a class="jstree-anchor" href="#" tabindex="-1" data-bind="css:{'filtered': card.highlight(), 'jstree-clicked': card.selected, 'child-selected': card.isChildSelected(), 'func-node': card.isFuncNode()}, click: function () { card.selected(true) },">
+        <i class="fa fa-file-o" role="presentation"></i>
+        <span data-bind="text: card.model.name"></span>
+        <!-- ko if: card.showIds -->
+        <span style="font-weight:bold" data-bind="text: ': ' + card.model.nodegroup_id()"></span>
+        <!-- /ko -->
+    </a>
+    <!-- ko if: (card.cards().length > 0 || card.widgets().length > 0) && card.expanded()  -->
+    <ul class="jstree-children card-designer-tree" aria-expanded="true">
+        <div data-bind="sortable: {
+                data: card.widgets,
+                as: 'widget',
+                beforeMove: self.beforeMove,
+                afterMove: function() { card.model.save() }
+            }">
+            <li role="treeitem" class="jstree-node jstree-leaf" data-bind="css: {
+                    'jstree-last': $index() === (card.widgets().length - 1) && $parent.card.cards().length === 0, 'hide-background': !self.showGrid()
+                }">
+                <i class="jstree-icon" role="presentation" data-bind="css: {'jstree-ocl': self.showGrid}"></i>
+                <a class="jstree-anchor" href="#" tabindex="-1" data-bind="click: function() { widget.selected(true) }, css:{'jstree-clicked': widget.selected, 'hover': widget.hovered}, event: { mouseover: function(){ widget.hovered(true) }, mouseout: function(){ widget.hovered(null) } }">
+                    <i data-bind="css: widget.datatype.iconclass" role="presentation"></i>
+                    <strong style="margin-right: 10px;" >
+                        <span data-bind="text: !!(widget.label()) ? widget.label() : widget.node.name"></span>
+                        <!-- ko if: $parent.showIds -->
+                        <span style="font-weight:bold" data-bind="text: ': ' + (!!(widget.label()) ? widget.node.nodeid : '')"></span>
+                        <!-- /ko -->
+                    </strong>
+                </a>
+            </li>
+        </div>
+        <div data-bind="sortable: {
+                data: card.cards,
+                as: 'childCard',
+                beforeMove: self.beforeMove,
+                afterMove: function() {
+                    card.reorderCards();
+                }
+            }">
+            <div data-bind="css: {
+                    'jstree-last': ($index() === ($parent.card.cards().length - 1))
+                }">
+                <!-- ko component: {
+                        name: self.form.cardComponentLookup[childCard.model.component_id()].componentname,
+                        params: {
+                        state: 'designer-tree',
+                        card: childCard,
+                        tile: null,
+                        loading: self.loading,
+                        form: self.form,
+                        pageVm: $root,
+                        showIds: childCard.showIds
+                    }
+                } --> <!-- /ko -->
+            </div>
+        </div>
+    </ul>
+    <!-- /ko -->
+</li>
+{% endblock designer_tree %}
+<!-- /ko -->
+
+
+<!-- ko if: state === 'permissions-tree' -->
+{% block permissions_tree %}
+<li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': ((card.cards().length > 0 || card.widgets().length > 0) && card.expanded()), 'jstree-closed' : ((card.cards().length > 0 || card.widgets().length > 0) && !card.expanded()), 'jstree-leaf': card.cards().length === 0 && card.widgets().length === 0, 'hide-background': !self.showGrid()}">
+    <i class="jstree-icon" role="presentation" data-bind="click: function(){card.expanded(!card.expanded())}, css: {'jstree-ocl': self.showGrid}"></i>
+    <a class="jstree-anchor permissions-card" href="#" tabindex="-1" data-bind="css:{'jstree-clicked': card.selected, 'child-selected': card.isChildSelected(), 'filtered': card.highlight()}, click: function () { card.selectChildCards() },">
+        <i class="fa fa-file-o" role="presentation"></i>
+        <span style="padding-right: 5px;" data-bind="text: card.model.name">
+        </span>
+        <span class="node-permissions">
+            <!-- ko if: card.perms -->
+            <!-- ko foreach: card.perms() -->
+            <i class="node-permission-icon" data-bind="css: $data.icon"></i>
+            <!-- /ko -->
+            <!-- /ko -->
+        </span>
+    </a>
+    <!-- ko if: (card.cards().length > 0 || card.widgets().length > 0) && card.expanded() -->
+    <ul class="jstree-children card-designer-tree" aria-expanded="true">
+        {% block designer_tree_widgets %}
+        <div data-bind="sortable: {
+                data: card.widgets,
+                as: 'widget',
+                beforeMove: self.beforeMove,
+                afterMove: function() { card.model.save() }
+            }">
+            <li role="treeitem" class="jstree-node jstree-leaf" data-bind="css: {
+                    'jstree-last': $index() === (card.widgets().length - 1) && $parent.card.cards().length === 0,
+                    'hide-background': !self.showGrid()
+                }">
+                <i class="jstree-icon" role="presentation" data-bind="css: {'jstree-ocl': self.showGrid}"></i>
+                <a class="jstree-anchor permissions-widget" href="#" tabindex="-1">
+                    <i class="fa fa-file" role="presentation" ></i>
+                    <strong style="margin-right: 10px;" >
+                        <span data-bind="text: !!(widget.label()) ? widget.label() : widget.node.name"></span>
+                    </strong>
+                </a>
+            </li>
+        </div>
+        {% endblock designer_tree_widgets %}
+        {% block designer_tree_cards %}
+        <div data-bind="foreach: {
+                data: card.cards,
+                as: 'card'
+            }">
+            <div data-bind="css: {
+                    'jstree-last': ($index() === ($parent.card.cards().length - 1))
+                }">
+                <!-- ko component: {
+                    name: self.form.cardComponentLookup[card.model.component_id()].componentname,
+                    params: {
+                    state: 'permissions-tree',
+                    card: card,
+                    tile: null,
+                    loading: self.loading,
+                    form: self.form,
+                    multiselect: true,
+                    pageVm: $root
+                }
+            } --> <!-- /ko -->
+            </div>
+        </div>
+        {% endblock designer_tree_cards %}
+    </ul>
+    <!-- /ko -->
+</li>
+{% endblock permissions_tree %}
+<!-- /ko -->
+
+
+<!-- ko if: state === 'form' -->
+{% block form %}
+<div class="card-component" data-bind="css: card.model.cssclass">
+
+    <!-- ko if: reviewer && provisionalTileViewModel.selectedProvisionalEdit() -->
+    <div class="edit-message-container provisional-editor">
+        <span data-bind="text: $root.translations.showingEditsBy"></span>
+        <span class="edit-message-container-user" data-bind="text: provisionalTileViewModel.selectedProvisionalEdit().username() + '.'"></span>
+        <!-- ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
+        <a class="reset-authoritative" href='' data-bind="click: function(){provisionalTileViewModel.resetAuthoritative();}">
+            <span data-bind="text: $root.translations.returnToApprovedEdits"></span>
+        </a>
+        <!-- /ko-->
+        <!-- ko if: provisionalTileViewModel.selectedProvisionalEdit().isfullyprovisional -->
+            <span data-bind="text: $root.translations.newProvisionalContribution"></span>
+        <!-- /ko-->
+    </div>
+    <!-- /ko-->
+
+    <!-- ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 && !provisionalTileViewModel.selectedProvisionalEdit()-->
+    <div class="edit-message-container approved">
+        <div>
+            <span data-bind="text: $root.translations.showingRecentApprovedEdits"></span>
+        </div>
+    </div>
+    <!-- /ko-->
+
+
+
+    <div class="new-provisional-edit-card-container">
+        <!-- ko if: reviewer && provisionalTileViewModel.provisionaledits().length > 0 -->
+        <!-- ko if: !provisionalTileViewModel.tileIsFullyProvisional() -->
+        <div class='new-provisional-edits-list'>
+            <div class='new-provisional-edits-header'>
+                <div class='new-provisional-edits-title'>
+                    <span data-bind="text: $root.translations.provisionalEdits"></span>
+                </div>
+                <div 
+                    class="btn btn-shim btn-danger btn-labeled btn-xs fa fa-trash new-provisional-edits-delete-all" 
+                    style="padding: 3px;" 
+                    data-bind="click: function(){provisionalTileViewModel.deleteAllProvisionalEdits()}"
+                >
+                    <span data-bind="text: $root.translations.deleteAllEdits"></span>
+                </div>
+            </div>
+            <!-- ko foreach: { data: provisionalTileViewModel.provisionaledits(), as: 'pe' } -->
+            <div class='new-provisional-edit-entry' data-bind="css: {'selected': pe === $parent.provisionalTileViewModel.selectedProvisionalEdit()}, click: function(){$parent.provisionalTileViewModel.selectProvisionalEdit(pe)}">
+                <div class='title'>
+                    <div class='field'>
+                        <span data-bind="text : pe.username"></span>
+                    </div>
+                    <a href='' class='field fa fa-times-circle new-delete-provisional-edit' data-bind="click : function(){$parent.provisionalTileViewModel.rejectProvisionalEdit(pe)}"></a>
+                </div>
+                <div class="field timestamp">
+                    <span data-bind="text : pe.displaydate">@</span>
+                    <span data-bind="text : pe.displaytimestamp"></span>
+                </div>
+            </div>
+            <!-- /ko -->
+        </div>
+        <!-- /ko-->
+        <!-- /ko-->
+
+
+        <div class="card">
+            {% block form_header %}
+            <div style="display: flex;">
+                <h4 class="card-title" data-bind="text: card.model.name()"></h4>
+
+                <!-- ko if: card.model.helpenabled -->
+                <span>
+                    <a data-bind="click: function () {card.model.get('helpactive')(true) }" style="cursor:pointer;"> 
+                        <span data-bind="text: $root.translations.help"></span>
+                        <i class="fa fa-question-circle"></i>
+                    </a>
+                </span>
+                <!-- /ko -->
+            </div>
+            <!-- ko if: card.model.instructions -->
+            <h5 class="card-instructions" data-bind="text: card.model.instructions"></h5>
+            <!-- /ko -->
+
+            <!-- ko if: card.isFuncNode && card.isFuncNode()  -->
+            <h4 class="is-function-node" data-bind="text: card.isFuncNode()"></h4>
+            <!-- /ko -->
+
+            {% endblock form_header %}
+            <!-- ko if: card.showSummary() === false -->
+            <!-- ko if: card.widgets().length > 0 -->
+            {% block form_widgets %}
+            <form class="widgets" style="margin-bottom: 20px;">
+                <div data-bind="foreach: {
+                        data:card.widgets, as: 'widget'
+                    }">
+                    <div data-bind='component: {
+                        name: self.form.widgetLookup[widget.widget_id()].name,
+                        params: {
+                            widget: widget,
+                            formData: self.tile.formData,
+                            tile: self.tile,
+                            form: self.form,
+                            config: widget.configJSON,
+                            label: widget.label(),
+                            inResourceEditor: self.inResourceEditor,
+                            value: self.tile.data[widget.node_id()],
+                            node: self.form.nodeLookup[widget.node_id()],
+                            expanded: self.expanded,
+                            graph: self.form.graph,
+                            type: "resource-editor",
+                            disabled: !self.card.isWritable && !self.preview
+                        }
+                    }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
+                }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}
+            }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible'></div>
+                </div>
+                <div style="color: #880000; margin-left:0.5rem" data-bind="text: errorMessage, visible: !hasSelectedCounty()"></div>
+                <div class="row widget-wrapper">
+                    <button
+                        data-bind="click: () => generateGardenNumber(), disable: !hasSelectedCounty()"
+                        class="btn btn-success"
+                    >
+                        <span>Generate Historic Parks & Garden Number</span>
+                    </button>
+                </div>
+            </form>
+            {% endblock form_widgets %}
+            <!-- /ko -->
+            <!-- ko if: showChildCards -->
+            {% block form_cards %}
+            <ul class="card-summary-section" data-bind="css: {disabled: !tile.tileid}">
+                <!-- ko foreach: { data: tile.cards, as: 'card' } -->
+                <li class="card-summary" data-bind="visible: card.model.visible()">
+                    <a href="javascript:void(0)" data-bind="click: function () {
+                        if (card.parent.tileid) {
+                            card.canAdd() ? card.selected(true) : card.tiles()[0].selected(true);
+                        }
+                    }">
+                        <h4 class="card-summary-name" style='color: #2f527a'>
+                            <span data-bind="text: card.model.name"></span>
+                            <i class="fa fa-plus-circle card-summary-add" data-bind="click: function(){$parent.createParentAndChild($parent.tile, card)}"></i>
+                        </h4>
+                    </a>
+                    <ul class="tile-summary-item" data-bind="foreach: {
+                            data: card.tiles,
+                            as: 'tile'
+                        }">
+                        <li class="tile-summary">
+                            <a href="#" data-bind="click: function () { tile.selected(true) }">
+                                <!-- ko if: card.widgets().length > 0 -->
+                                <span data-bind="text: card.widgets()[0].label || card.model.name" class="tile-summary-label"></span>:
+                                <div style="display: inline;" data-bind="component: {
+                                    name: self.form.widgetLookup[card.widgets()[0].widget_id()].name,
+                                    params: {
+                                        tile: tile,
+                                        node: self.form.nodeLookup[card.widgets()[0].node_id()],
+                                        config: self.form.widgetLookup[card.widgets()[0].widget_id()].config,
+                                        inResourceEditor: self.inResourceEditor,
+                                        label: self.form.widgetLookup[card.widgets()[0].widget_id()].label,
+                                        value: tile.data[card.widgets()[0].node_id()],
+                                        type: 'resource-editor',
+                                        state: 'display_value'
+                                    }
+                                }"></div>
+                                <!-- /ko -->
+                                <!-- ko if: card.widgets().length === 0 -->
+                                <span data-bind="text: card.model.name"></span>
+                                <!-- /ko -->
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+                <!-- /ko -->
+            </ul>
+            {% endblock form_cards %}
+            <!-- /ko -->
+            {% block form_buttons %}
+            <div class="install-buttons">
+                <!-- ko if: tile.tileid && self.deleteTile -->
+                <button 
+                    class="btn btn-shim btn-labeled btn-lg fa fa-trash" 
+                    data-bind="click: self.deleteTile, css: {disabled: (!card.isWritable && !self.preview), 'btn-warning': card.isWritable }"
+                >
+                    <span data-bind="text: $root.translations.deleteThisRecord"></span>
+                </button>
+                <!-- /ko -->
+
+                <!-- ko if: tile.dirty() -->
+                    <!-- ko if: provisionalTileViewModel && !provisionalTileViewModel.tileIsFullyProvisional() && card.isWritable -->
+                    <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: tile.reset">
+                        <span data-bind="text: $root.translations.cancelEdit"></span>
+                    </button>
+                    <!-- /ko -->
+
+                    <!-- ko if: tile.tileid -->
+                    <button class="btn btn-shim btn-labeled btn-lg fa fa-plus" data-bind="click: self.saveTile, css: {disabled: (!card.isWritable && !self.preview), 'btn-mint': card.isWritable }">
+                        <span data-bind="text: $root.translations.saveEdit"></span>
+                    </button>
+                    <!-- /ko -->
+                <!-- /ko -->
+                
+                <!-- ko if: !tile.tileid && !showChildCards() -->
+                <button class="btn btn-shim btn-labeled btn-lg fa fa-plus" data-bind="click: self.saveTile, css: {disabled: (!card.isWritable && !self.preview), 'btn-mint': card.isWritable }">
+                    <span data-bind="text: $root.translations.add"></span>
+                </button>
+                <!-- /ko -->
+            </div>
+            {% endblock form_buttons %}
+            <!-- /ko -->
+            <!-- ko if: card.showSummary() === true -->
+            {% block card_summary %}
+            {% include 'views/components/cards/default-card-report.htm' %}
+            <button class="btn btn-shim btn-labeled btn-lg fa fa-plus btn-primary" data-bind="click: function(){card.showForm(true)}">
+                <span data-bind="text: $root.translations.new"></span>
+            </button>
+            {% endblock card_summary %}
+            <!-- /ko -->
+
+            <aside id="card-help-panel" class="card-help-panel" style="display: none;" data-bind="visible: card.model.get('helpactive')">
+                <div class="relative">
+                    <a id="add-basemap-wizard-help-close" href="#" class="help-close fa fa-times fa-lg" style="" data-bind="click: function () { card.model.get('helpactive')(false) }"></a>
+                </div>
+                <div id="add-basemap-wizard-help-content">
+                    <div>
+                        <div class="panel-heading">
+                            <h3 class="panel-title help-panel-title" style="">
+                                <span data-bind="html: card.model.get('helptitle')"></span>
+                            </h3>
+                        </div>
+                        <div class="panel-body" style="padding: 10px 10px 15px 10px;" data-bind="html: card.model.get('helptext')">
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </div>
+</div>
+{% endblock form %}
+<!-- /ko -->
+
+<!-- ko if: state === 'report' && card.model.visible() -->
+{% block report %}
+{% include 'views/components/cards/default-card-report.htm' %}
+{% endblock report %}
+<!-- /ko -->
+
+<!-- ko if: state === 'config' -->
+{% block config %}
+{% endblock config %}
+<!-- /ko -->
+
+<!-- /ko -->

--- a/coral/templates/views/components/workflows/workflow-component-abstract.htm
+++ b/coral/templates/views/components/workflows/workflow-component-abstract.htm
@@ -35,7 +35,7 @@
                     data-bind="{
                         click: addOrUpdateTile,
                         text: tileLoadedInEditor() ? 'Save' : 'Add'
-                    }"
+or                    }"
                 ></button>
             </div>
         <!-- /ko -->

--- a/coral/urls.py
+++ b/coral/urls.py
@@ -17,6 +17,7 @@ from coral.views.dashboard import Dashboard
 from coral.views.file_template import FileTemplateView
 from coral.views.ha_number import HaNumberView
 from coral.views.smr_number import SmrNumberView
+from coral.views.garden_number import GardenNumberView
 
 
 uuid_regex = settings.UUID_REGEX
@@ -74,6 +75,7 @@ urlpatterns = [
     #
     re_path(r"^generate-ha-number", HaNumberView.as_view(), name="generate_ha_number"),
     re_path(r"^generate-smr-number", SmrNumberView.as_view(), name="generate_smr_number"),
+    re_path(r"^generate-garden-number", GardenNumberView.as_view(), name="generate_garden_number"),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 

--- a/coral/utils/garden_number.py
+++ b/coral/utils/garden_number.py
@@ -1,0 +1,142 @@
+from arches.app.models.tile import Tile
+from django.db.models import Max
+import logging
+
+logger = logging.getLogger(__name__)
+
+HERITAGE_ASSET_REFERENCES_NODEGROUP_ID = "e71df5cc-3aad-11ef-a2d0-0242ac120003"
+GARDEN_NUMBER_NODE_ID = "2c2d02fc-3aae-11ef-91fd-0242ac120003"
+
+
+class GardenNumber:
+    def __init__(self, county_name):
+        logger.info("Initialising GardenNumber")
+        self.county_name = county_name
+
+        self.county_abbreviation = None
+        if not self.county_name:
+            logger.error("County name is not provided")
+            raise ValueError("County name is not provided")
+
+        try:
+            self.county_abbreviation = self.abbreviate_county(self.county_name)
+        except ValueError as e:
+            logger.error("Failed to abbreviate the county name: %s", e)
+            raise
+
+    def id_number_format(self, index):
+        return f"{self.county_abbreviation}:{str(index).zfill(3)}"
+    
+    def abbreviate_county(self, name):
+        abbreviations = {
+            "Antrim": "ANT",
+            "Armagh": "ARM",
+            "Down": "DOW",
+            "Fermanagh": "FER",
+            "Londonderry": "LDY",
+            "Tyron": "TYR"
+        }
+        abbreviation = abbreviations.get(name, None)
+        if abbreviation is None:
+            raise ValueError(f"Abbreviation for county name '{name}' not found")
+        return abbreviation
+        
+    def get_latest_id_number(self, resource_instance_id=None):
+        latest_id_number_tile = None
+        try:
+            id_number_generated = {
+                f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_name,
+            }
+            query_result = Tile.objects.filter(
+                nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
+                **id_number_generated,
+            )
+            if resource_instance_id:
+                query_result.exclude(resourceinstance_id=resource_instance_id)
+            query_result = query_result.annotate(
+                most_recent=Max("resourceinstance__createdtime")
+            )
+            query_result = query_result.order_by("-most_recent")
+            latest_id_number_tile = query_result.first()
+        except Exception as e:
+            logger.error("Failed querying for previous ID number tile: %s", e)
+            raise e
+
+        if not latest_id_number_tile:
+            return
+
+        latest_id_number = (
+            latest_id_number_tile.data.get(GARDEN_NUMBER_NODE_ID).get("en").get("value")
+        )
+
+        logger.info("Previous ID number: %s", latest_id_number)
+        id_number_parts = latest_id_number.split(":")
+        return {"index": int(id_number_parts[1])}
+
+    def generate_id_number(self, resource_instance_id=None, attempts=0):
+        if attempts >= 5:
+            raise Exception(
+                "After 5 attempts, it wasn't possible to generate an ID that was unique!"
+            )
+
+        def retry():
+            nonlocal attempts, resource_instance_id
+            attempts += 1
+            return self.generate_id_number(resource_instance_id, attempts)
+
+        if resource_instance_id:
+            id_number_tile = None
+            try:
+                generated_id_query = {
+                    f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_name,
+                }
+                id_number_tile = Tile.objects.filter(
+                    resourceinstance_id=resource_instance_id,
+                    nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
+                    **generated_id_query,
+                ).first()
+            except Exception as e:
+                logger.error("Failed checking if ID number tile already exists: %s", e)
+                return retry()
+
+            if id_number_tile:
+                logger.info("A ID number has already been created for this resource")
+                return
+
+        latest_id_number = None
+        try:
+            latest_id_number = self.get_latest_id_number(resource_instance_id)
+        except Exception as e:
+            print("Failed getting the previously used ID number: %s", e)
+            return retry()
+
+        if latest_id_number:
+            next_number = latest_id_number["index"] + 1
+            id_number = self.id_number_format(next_number)
+        else:
+            # If there is no latest resource to work from we know
+            # this is the first ever created
+            id_number = self.id_number_format(1)
+
+        passed = self.validate_id(id_number)
+        if not passed:
+            return retry()
+
+        logger.info("ID number is unique, ID number: %s", id_number)
+        return id_number
+
+    def validate_id(self, id_number):
+        try:
+            # Runs a query searching for an identical ID value
+            id_number_tile = Tile.objects.filter(
+                nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
+                data__contains={
+                    GARDEN_NUMBER_NODE_ID: {"en": {"direction": "ltr", "value": id_number}}
+                },
+            ).first()
+            if id_number_tile:
+                return False
+        except Exception as e:
+            logger.error("Failed validating ID number: %s", e)
+            return False
+        return True

--- a/coral/utils/garden_number.py
+++ b/coral/utils/garden_number.py
@@ -45,7 +45,7 @@ class GardenNumber:
         latest_id_number_tile = None
         try:
             id_number_generated = {
-                f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_name,
+                f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_abbreviation,
             }
             query_result = Tile.objects.filter(
                 nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
@@ -88,7 +88,7 @@ class GardenNumber:
             id_number_tile = None
             try:
                 generated_id_query = {
-                    f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_name,
+                    f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_abbreviation
                 }
                 id_number_tile = Tile.objects.filter(
                     resourceinstance_id=resource_instance_id,

--- a/coral/utils/garden_number.py
+++ b/coral/utils/garden_number.py
@@ -34,7 +34,7 @@ class GardenNumber:
             "Down": "DOW",
             "Fermanagh": "FER",
             "Londonderry": "LDY",
-            "Tyron": "TYR"
+            "Tyrone": "TYR"
         }
         abbreviation = abbreviations.get(name, None)
         if abbreviation is None:
@@ -127,13 +127,21 @@ class GardenNumber:
 
     def validate_id(self, id_number):
         try:
-            # Runs a query searching for an identical ID value
-            id_number_tile = Tile.objects.filter(
+            if isinstance(id_number, dict):
+                id_number_tile = Tile.objects.filter(
                 nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
                 data__contains={
-                    GARDEN_NUMBER_NODE_ID: {"en": {"direction": "ltr", "value": id_number}}
+                    GARDEN_NUMBER_NODE_ID: id_number
                 },
             ).first()
+            else:
+            # Runs a query searching for an identical ID value
+                id_number_tile = Tile.objects.filter(
+                    nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
+                    data__contains={
+                        GARDEN_NUMBER_NODE_ID: {"en": {"direction": "ltr", "value": id_number}}
+                    },
+                ).first()
             if id_number_tile:
                 return False
         except Exception as e:

--- a/coral/utils/garden_number.py
+++ b/coral/utils/garden_number.py
@@ -111,7 +111,7 @@ class GardenNumber:
             return retry()
 
         if latest_id_number:
-            next_number = latest_id_number["index"] + 1
+            next_number = latest_id_number["index"] + attempts + 1
             id_number = self.id_number_format(next_number)
         else:
             # If there is no latest resource to work from we know
@@ -119,6 +119,7 @@ class GardenNumber:
             id_number = self.id_number_format(1)
 
         passed = self.validate_id(id_number)
+
         if not passed:
             return retry()
 

--- a/coral/views/garden_number.py
+++ b/coral/views/garden_number.py
@@ -39,20 +39,15 @@ class GardenNumberView(View):
                 return JSONResponse(
                     {
                         "message": "Historic Parks and Garden has already been generated",
-                        "haNumber": id,
+                        "gardenNumber": id,
                     }
                 )
             
         self.county_name = ""
 
         if county_tile:
-            county_id = Tile.objects.filter(
-                    resourceinstance_id = resource_instance_id,
-                    nodegroup_id = ADDRESS_NODEGROUP_ID
-                ).first()
-
             county_name_tile = models.Value.objects.filter(
-                valueid= county_id.data.get(COUNTY_NODE_ID)
+                valueid= county_tile.data.get(COUNTY_NODE_ID)
             ).first()
 
             self.county_name = county_name_tile.value

--- a/coral/views/garden_number.py
+++ b/coral/views/garden_number.py
@@ -1,0 +1,66 @@
+from django.views.generic import View
+import json
+from arches.app.models.tile import Tile
+from arches.app.utils.response import JSONResponse
+from coral.utils.garden_number import GardenNumber
+from arches.app.models import models
+
+
+HERITAGE_ASSET_REFERENCES_NODEGROUP_ID = "e71df5cc-3aad-11ef-a2d0-0242ac120003"
+COUNTY_NODEGROUP_ID = "87d3ff2a-f44f-11eb-9951-a87eeabdefba"
+ADDRESS_NODEGROUP_ID = "87d39b25-f44f-11eb-95e5-a87eeabdefba"
+GARDEN_NUMBER_NODE_ID = "2c2d02fc-3aae-11ef-91fd-0242ac120003"
+COUNTY_NODE_ID = "8bfe714e-3ec2-11ef-9023-0242ac140007"
+
+
+
+class GardenNumberView(View):
+    def post(self, request):
+        data = json.loads(request.body.decode("utf-8"))
+        resource_instance_id = data.get("resourceInstanceId")
+
+        if resource_instance_id:
+            references_tile = Tile.objects.filter(
+                resourceinstance_id=resource_instance_id,
+                nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
+            ).first()
+            county_tile = Tile.objects.filter(
+                resourceinstance_id=resource_instance_id,
+                nodegroup_id=ADDRESS_NODEGROUP_ID,
+            ).first()
+
+            if references_tile and references_tile.data.get(GARDEN_NUMBER_NODE_ID, None):
+                id = (
+                    references_tile.data.get(GARDEN_NUMBER_NODE_ID, None)
+                    .get("en")
+                    .get("value")
+                )
+                print("Historic Parks and Garden Number has already been generated: ", id)
+                return JSONResponse(
+                    {
+                        "message": "Historic Parks and Garden has already been generated",
+                        "haNumber": id,
+                    }
+                )
+            
+        self.county_name = ""
+
+        if county_tile:
+            county_id = Tile.objects.filter(
+                    resourceinstance_id = resource_instance_id,
+                    nodegroup_id = ADDRESS_NODEGROUP_ID
+                ).first()
+
+            county_name_tile = models.Value.objects.filter(
+                valueid= county_id.data.get(COUNTY_NODE_ID)
+            ).first()
+
+            self.county_name = county_name_tile.value
+
+        else:
+            raise ValueError("No county was found")
+
+        gn = GardenNumber(county_name=self.county_name)
+        garden_number = gn.generate_id_number(resource_instance_id)
+
+        return JSONResponse({"message": "Generated ID", "gardenNumber": garden_number})


### PR DESCRIPTION
### Description
This adds the garden number generation field

#### UI Changes
The garden number field has been removed from the Heritage Asset Details page
A generated field and a button have been added to the finish page

The system has been set up to use the county field to generate an incrementing number once the button has been clicked.

### Test
#### Setup
- register the function garden_number_function
- reload the HA model
- restart containers
- make webpack
- make manage CMD="coral reload"

- open add garden
- save HA number
- Heritage Asset Details page first field should be site name and no historic gardens field should be visible
- Navigate to Finish
- Generate should be visible and disabled with a warning that you need to select county
- Navigate to Locations
- Select a county from the drop down and save
- Navigate to the finish
- Click generate
- A generated number should appear in relation to the county
- Save and complete the workflow
- Navigate to search
- You should be able to see your garden with the generated number as the display name

#### Alt tests
- Click the generate number several times before saving and save, it should still save and show in search
- Click save and continue and then save and complete, it should still show the generated name in search
- Open to add garden workflows at the same time
- Run through the above process but do not save
- It should generate the same number in the box for both
- Save one
- Check it shows in search
- Save the second
- It should show in the search as an incremented number