### PR TITLE
Feat (#2144): Add IHR Number Validation

### DIFF
--- a/coral/functions/ihr_validation_function.py
+++ b/coral/functions/ihr_validation_function.py
@@ -22,19 +22,16 @@ details = {
 
 
 class IHRValidationFunction(BaseFunction):
-    # [x] check that the format is correct - regex
-    # [x] return error if not
-    # [ ] check if there is an existing tile with the same name
-    # [ ] return error if this already exists
     def save(self, tile, request, context):
         input_ihr_tile = tile.data.get(IHR_NUMBER_NODE_ID, None)
 
         if not input_ihr_tile:
             return
+        
         input_ihr_string = input_ihr_tile.get("en").get("value")
-        print(input_ihr_string)
+
         is_valid = self.is_valid_format(input_ihr_string) if input_ihr_string else False
-        print(is_valid)
+
         if not is_valid:
             raise ValueError("The IHR Number format is incorrect please format as 00000:000:00")
 

--- a/coral/functions/ihr_validation_function.py
+++ b/coral/functions/ihr_validation_function.py
@@ -1,0 +1,57 @@
+from arches.app.functions.base import BaseFunction
+from coral.utils.ha_number import HaNumber
+from arches.app.models.tile import Tile
+import re
+import logging
+import pdb
+
+logger = logging.getLogger(__name__)
+
+HERITAGE_ASSET_REFERENCES_NODEGROUP_ID = "e71df5cc-3aad-11ef-a2d0-0242ac120003"
+IHR_NUMBER_NODE_ID = "1de9abf0-3aae-11ef-91fd-0242ac120003"
+
+details = {
+    "functionid": "ea081ee0-6796-480c-bba4-2b8daaac660f",
+    "name": "IHR Number Validation",
+    "type": "node",
+    "description": "Will validate the input IHR number for correct format and duplicates",
+    "defaultconfig": {"triggering_nodegroups": [HERITAGE_ASSET_REFERENCES_NODEGROUP_ID]},
+    "classname": "IHRValidationFunction",
+    "component": "",
+}
+
+
+class IHRValidationFunction(BaseFunction):
+    # [x] check that the format is correct - regex
+    # [x] return error if not
+    # [ ] check if there is an existing tile with the same name
+    # [ ] return error if this already exists
+    def save(self, tile, request, context):
+        input_ihr_tile = tile.data.get(IHR_NUMBER_NODE_ID, None)
+
+        if not input_ihr_tile:
+            return
+        input_ihr_string = input_ihr_tile.get("en").get("value")
+        print(input_ihr_string)
+        is_valid = self.is_valid_format(input_ihr_string) if input_ihr_string else False
+        print(is_valid)
+        if not is_valid:
+            raise ValueError("The IHR Number format is incorrect please format as 00000:000:00")
+
+        ihr_string_query = {
+            f"data__{IHR_NUMBER_NODE_ID}__icontains": input_ihr_string,
+        }
+        
+        existing_tile = Tile.objects.filter(
+            nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
+            **ihr_string_query,
+        ).first()
+
+        if existing_tile:
+            raise ValueError("This IHR number has already been saved, please check your input")       
+
+
+    def is_valid_format(self, ihr_number):
+        pattern = r'^\d{5}:\d{3}:\d{2}$'
+        return bool(re.match(pattern, ihr_number))
+        

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -21326,6 +21326,16 @@
                 {
                     "config": {
                         "triggering_nodegroups": [
+                            "e71df5cc-3aad-11ef-a2d0-0242ac120003"
+                        ]
+                    },
+                    "function_id": "ea081ee0-6796-480c-bba4-2b8daaac660f",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "id": "93ded95b-f37e-4b8d-be29-932341fab38e"
+                },
+                {
+                    "config": {
+                        "triggering_nodegroups": [
                             "676d47f9-9c1c-11ea-9aa0-f875a44e0e11",
                             "e71df5cc-3aad-11ef-a2d0-0242ac120003",
                             "ce85b994-3f5f-11ef-b9b0-0242ac140006",


### PR DESCRIPTION
### Description
This adds validation to the IHR input field.
It will check that the string has the format 00000:000:00 and if not it will display an error message
It will also check for any existing entries in the database and throw an error if true

### Test
- Register the IHR Validation Function
- Reload the monument model
- Start an add IHR workflow
- Save and Continue to the Asset Details page
- Enter a random string eg. 'test'
- Should receive a warning error that the incorrect format is being used for the IHR
- Enter the correct format eg. 12345:123:12
- Should save successfully and show in the model resource
- After saving, start a new add ihr
- Enter the same number you previously entered
- Should throw an error that the IHR number has already been used