### PR TITLE
Feat(#2095): add target date, address details and team assignments to summary

### DIFF
--- a/coral/media/js/views/components/workflows/assign-consultation-workflow/pc-summary.js
+++ b/coral/media/js/views/components/workflows/assign-consultation-workflow/pc-summary.js
@@ -25,118 +25,109 @@ define([
       planningRef: {
         label: 'Planning Reference',
         nodegroupId: 'b4974044-c768-11ee-a945-0242ac180006',
-        renderNodeIds: [{nodeId: 'b4974a58-c768-11ee-a945-0242ac180006', label: 'Reference'}]
+        renderNodeIds: [{ nodeId: 'b4974a58-c768-11ee-a945-0242ac180006', label: 'Reference' }]
       },
       cmRef: {
         label: 'CM Reference',
         nodegroupId: '9d158534-c768-11ee-a945-0242ac180006',
-        renderNodeIds: [{nodeId: '9d15ac44-c768-11ee-a945-0242ac180006', label: 'Reference'}]
+        renderNodeIds: [{ nodeId: '9d15ac44-c768-11ee-a945-0242ac180006', label: 'Reference' }]
       },
       difReceivedDate: {
         label: 'DIF Received Date',
         nodegroupId: '04492152-c769-11ee-82c4-0242ac180006',
-        renderNodeIds: [{nodeId: '04494bbe-c769-11ee-82c4-0242ac180006', label: 'Date'}]
+        renderNodeIds: [{ nodeId: '04494bbe-c769-11ee-82c4-0242ac180006', label: 'Date' }]
       },
       applicationType: {
         label: 'Application Type',
         nodegroupId: '54de6acc-8895-11ea-9067-f875a44e0e11',
-        renderNodeIds: [{nodeId: '54de6acc-8895-11ea-9067-f875a44e0e11', label: 'Type'}]
+        renderNodeIds: [{ nodeId: '54de6acc-8895-11ea-9067-f875a44e0e11', label: 'Type' }]
+      },
+      targetDate: {
+        label: 'Target Date',
+        nodegroupId: 'a5e15f5c-51a3-11eb-b240-f875a44e0e11',
+        renderNodeIds: [{ nodeId: '06adec44-69b7-11ee-908a-0242ac120002', label: 'Date' }]
       },
       hierarchy: {
         label: 'Hierarchy',
         nodegroupId: '0dd6ccb8-cffe-11ee-8a4e-0242ac180006',
-        renderNodeIds: [{nodeId: '0dd6ccb8-cffe-11ee-8a4e-0242ac180006', label: 'Type'}]
+        renderNodeIds: [{ nodeId: '0dd6ccb8-cffe-11ee-8a4e-0242ac180006', label: 'Type' }]
       },
       classificationType: {
         label: 'Classification Type',
         nodegroupId: '86caf026-c76c-11ee-bf7c-0242ac180006',
-        renderNodeIds: [{nodeId: '86caf026-c76c-11ee-bf7c-0242ac180006', label: 'Type'}]
+        renderNodeIds: [{ nodeId: '86caf026-c76c-11ee-bf7c-0242ac180006', label: 'Type' }]
       },
       developmentType: {
         label: 'Development Type',
         nodegroupId: '73fdfe62-8895-11ea-a058-f875a44e0e11',
-        renderNodeIds: [{nodeId: '73fdfe62-8895-11ea-a058-f875a44e0e11', label: 'Type'}]
+        renderNodeIds: [{ nodeId: '73fdfe62-8895-11ea-a058-f875a44e0e11', label: 'Type' }]
       },
       contacts: {
         label: 'Contacts',
         nodegroupId: '4ea4a189-184f-11eb-b45e-f875a44e0e11',
-        renderNodeIds: ['4ea4a192-184f-11eb-a0d6-f875a44e0e11', '4ea4a19a-184f-11eb-aef8-f875a44e0e11', '4ea4c884-184f-11eb-b64d-f875a44e0e11']
+        renderNodeIds: [
+          '4ea4a192-184f-11eb-a0d6-f875a44e0e11',
+          '4ea4a19a-184f-11eb-aef8-f875a44e0e11',
+          '4ea4c884-184f-11eb-b64d-f875a44e0e11'
+        ]
       },
       consultationDates: {
         label: 'Date Consulted',
         nodegroupId: '40eff4c9-893a-11ea-ac3a-f875a44e0e11',
-        renderNodeIds: [{nodeId: '40eff4cd-893a-11ea-b0cc-f875a44e0e11', label: 'Date'}]
+        renderNodeIds: [{ nodeId: '40eff4cd-893a-11ea-b0cc-f875a44e0e11', label: 'Date' }]
       },
       consultationDescriptions: {
         label: 'Application Reason',
         nodegroupId: '82f8a163-951a-11ea-b58e-f875a44e0e11',
-        renderNodeIds: [{nodeId: '82f8a166-951a-11ea-bdad-f875a44e0e11', label: 'Description'}]
+        renderNodeIds: [{ nodeId: '82f8a166-951a-11ea-bdad-f875a44e0e11', label: 'Description' }]
       },
       proposal: {
         label: 'Proposal',
         nodegroupId: '1b0e15e9-8864-11ea-b5f3-f875a44e0e11',
-        renderNodeIds: [{nodeId: '1b0e15ec-8864-11ea-8493-f875a44e0e11', label: 'Description'}]
+        renderNodeIds: [{ nodeId: '1b0e15ec-8864-11ea-8493-f875a44e0e11', label: 'Description' }]
       },
-      // name: {
-      //   label: 'Heritage Asset Name',
-      //   nodegroupId: 'ae8896cd-e16f-44db-97c7-ea412534e3e3',
-      //   renderNodeIds: [{nodeId: '987c6b22-42a3-4d76-a683-d3588f5cf7e2', label: 'Name'}]
-      // },
-      // monumentType: {
-      //   label: 'Monument Type',
-      //   nodegroupId: '8b94df3e-233f-11ef-89fe-0242ac1a0006',
-      //   renderNodeIds: [{nodeId: '8b94df3e-233f-11ef-89fe-0242ac1a0006', label: 'Type'}]
-      // },
-      // historicalPeriod: {
-      //   label: 'Historical Period',
-      //   nodegroupId: '6b701e04-1f3d-11ef-bf79-0242ac150006',
-      //   renderNodeIds: [{nodeId: '6b701e04-1f3d-11ef-bf79-0242ac150006', label: 'Type'}]
-      // },
-      // addressesTownland: {
-      //   label: 'Townland',
-      //   nodegroupId: '38dad285-9014-4c7b-ad81-b0562038ebf2',
-      //   renderNodeIds: ['1db0ed52-3521-11ef-850f-0242ac120003']
-      // },
-      // descriptions: {
-      //   label: 'Description',
-      //   nodegroupId: '050b959f-c4d8-4a2b-a704-94cc3e00d7ca',
-      //   renderNodeIds: [
-      //     '1afcb89e-fe8f-463b-bc76-cd2b5e241616',
-      //     '2f4a6ae8-2244-4e6f-83ff-652158a245cf'
-      //   ]
-      // }
+      addressDetails: {
+        label: 'Address Details',
+        nodegroupId: '083e14f2-ca61-11ee-afca-0242ac180006',
+        renderNodeIds: [
+          { nodeId: '083e6c90-ca61-11ee-afca-0242ac180006', label: 'Full Address' },
+          { nodeId: '083e8f4a-ca61-11ee-afca-0242ac180006', label: 'Street' },
+          { nodeId: '083f8ad0-ca61-11ee-afca-0242ac180006', label: 'Town or City' },
+          { nodeId: '083fafe2-ca61-11ee-afca-0242ac180006', label: 'County' },
+          { nodeId: '083f8f26-ca61-11ee-afca-0242ac180006', label: 'Postcode' }
+        ]
+      },
+      council: {
+        label: 'Council',
+        nodegroupId: '69500360-d7c5-11ee-a011-0242ac120006',
+        renderNodeIds: [{ nodeId: '69500360-d7c5-11ee-a011-0242ac120006', label: 'Selection' }]
+      },
+      areaNames: {
+        label: 'Localities/Administrative Areas',
+        nodegroupId: '083dc93e-ca61-11ee-afca-0242ac180006',
+        renderNodeIds: [
+          { nodeId: '083f0db2-ca61-11ee-afca-0242ac180006', label: 'Area Type' },
+          { nodeId: '083ea3ae-ca61-11ee-afca-0242ac180006', label: 'Area Name' }
+        ]
+      },
+      locationDescrition: {
+        label: 'Location Description',
+        nodegroupId: '083e1bb4-ca61-11ee-afca-0242ac180006',
+        renderNodeIds: [{ nodeId: '083eae58-ca61-11ee-afca-0242ac180006', label: 'Description' }]
+      },
+      assignment: {
+        label: 'Assignment',
+        nodegroupId: 'dc9bfb24-cfd9-11ee-8cc1-0242ac180006',
+        renderNodeIds: [
+          { nodeId: '6b8f5866-2f0d-11ef-b37c-0242ac140006', label: 'Team' },
+          { nodeId: 'fbdd2304-cfda-11ee-8cc1-0242ac180006', label: 'Re-Assigned To' },
+          { nodeId: '50d15bec-cfda-11ee-8cc1-0242ac180006', label: 'Assigned To' }
+        ]
+      }
     };
-
-    // this.coverLetterHtml = ko.observable();
 
     this.getData = async () => {
       await this.renderResourceIds(this.resourceid, this.consultationNodes);
-
-      // let digitalFileResourceIds = this.getResourceIds(this.licenseNodes.id, 'digitalFiles');
-
-      // await this.renderResourceIds(
-      //   this.getResourceIds(this.licenseNodes.id, 'associatedActivities'),
-      //   this.activityNodes
-      // );
-      // await this.renderResourceIds(
-      //   this.getResourceIds(this.activityNodes.id, 'associatedActivities'),
-      //   this.activityNodes
-      // );
-
-      // digitalFileResourceIds = [
-      //   ...digitalFileResourceIds,
-      //   ...this.getResourceIds(this.activityNodes.id, 'digitalFiles')
-      // ];
-
-      // await this.renderResourceIds(digitalFileResourceIds, this.digitalFilesNodes);
-
-      // this.coverLetterHtml(
-      //   this.getDisplayValue(
-      //     this.licenseNodes.id,
-      //     'coverLetter',
-      //     '72e0fc96-53d5-11ee-844f-0242ac130008'
-      //   )
-      // );
 
       console.log('PC Summary: ', this.renderedNodegroups());
     };

--- a/coral/views/open_workflow.py
+++ b/coral/views/open_workflow.py
@@ -399,14 +399,14 @@ class OpenWorkflow(View):
                     resourceinstance_id=digital_object_resource_id,
                     nodegroup_id=DIGITAL_OBJECT_NODEGROUP_ID,
                 ).first()
-
-                component_data = {
-                    "nodegroupId": nodegroup_id,
-                    "resourceInstanceId": digital_object_resource_id,
-                    "tileId": str(digital_object_file_tile.tileid),
-                    "tileData": json.dumps(digital_object_file_tile.data),
-                }
-                self.workflow_component_data[data_lookup_id] = {"value": component_data}
+                if digital_object_file_tile:
+                    component_data = {
+                        "nodegroupId": nodegroup_id,
+                        "resourceInstanceId": digital_object_resource_id,
+                        "tileId": str(digital_object_file_tile.tileid),
+                        "tileData": json.dumps(digital_object_file_tile.data),
+                    }
+                    self.workflow_component_data[data_lookup_id] = {"value": component_data}
                 continue
 
             if not len(tiles):


### PR DESCRIPTION
**Description**

Add additional data to the summary pages on HM and HB response workflows

**Test**
- Fill out all fields of a planning consultation. Assign it to both teams on the action step
- Goto HM 
- Check Summary has all the fields explained in the ticket
- After add new assigned to and re-assigned to
- Double check they now appear on the summary page
- Next do the same onto the HB workflow