### PR TITLE
Fix(#21115): Add Gardens Description to Many

### DIFF
--- a/coral/media/js/viewmodels/workflow-step.js
+++ b/coral/media/js/viewmodels/workflow-step.js
@@ -144,7 +144,7 @@ define([
               workflowComponentAbstractId: workflowComponentAbstractId,
               isValidComponentPath: config.workflow.isValidComponentPath,
               getDataFromComponentPath: config.workflow.getDataFromComponentPath,
-              title: config.title,
+              title: workflowComponentAbtractData?.manyTitle || config.title,
               isStepSaving: self.isStepSaving,
               locked: self.locked,
               lockExternalStep: self.lockExternalStep,

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -138,6 +138,7 @@
                   "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11",
                   "semanticName": "Descriptions"
                 },
+                "manyTitle": "Descriptions",
                 "tilesManaged": "many",
                 "componentName": "default-card",
                 "uniqueInstanceName": "1b9b874c-313d-4b45-ae55-ba0440819507"

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -138,7 +138,7 @@
                   "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11",
                   "semanticName": "Descriptions"
                 },
-                "tilesManaged": "one",
+                "tilesManaged": "many",
                 "componentName": "default-card",
                 "uniqueInstanceName": "1b9b874c-313d-4b45-ae55-ba0440819507"
               }

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=4, minor=19, patch=0)
+APP_VERSION = semantic_version.Version(major=4, minor=19, patch=1)
 
 GROUPINGS = {
     "groups": {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=4, minor=18, patch=0)
+APP_VERSION = semantic_version.Version(major=4, minor=19, patch=0)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
### Description
Update the Descriptions tile to a many tile to allow for multiple descriptions to be saved
Update the title that is shown on the many input box to match the node group

### Test
- Run coral reload
- Update webpack
- Start a new add garden
- Navigate to Heritage Asset Details
- Add a new type and description
- Hit Add
- Add a second
- Save and continue
- Check the resource to see if the descriptions saved