### PR TITLE
Feat (#2123 & # #2124) Add deadline warning message Planning Dashboard

### DIFF
--- a/coral/media/css/dashboard.css
+++ b/coral/media/css/dashboard.css
@@ -1,0 +1,10 @@
+.flex-center{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+.title-info-margin {
+    margin: 1rem 1rem 0 1rem
+}

--- a/coral/media/css/project.css
+++ b/coral/media/css/project.css
@@ -1,4 +1,6 @@
 @import url(report_templates.css);
+@import url(dashboard.css);
+
 .workflow-panel.navbarclosed {
     min-width: 50px;
     width: 50px;

--- a/coral/templates/views/components/plugins/dashboard.htm
+++ b/coral/templates/views/components/plugins/dashboard.htm
@@ -59,6 +59,12 @@
                     <h3 id="f1-name" class="panel-title library-card-panel-title" style="font-weight: bold; font-size: 1.4rem">
                       <span data-bind="text: $data.displayname"></span>
                     </h3>
+                    <!-- ko if: $data.deadlinemessage -->
+                      <div class="flex-center title-info-margin">
+                        <div><strong data-bind="text: $data.deadlinemessage"></strong></div>
+                        <i style="color: rgb(197, 2, 2); margin-left: 1rem" class="fa fa-exclamation-circle"></i>
+                      </div>
+                    <!-- /ko -->
                   </div>
                   <div class="dashboard-card-columns">
                     <div>

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -3,7 +3,7 @@ from django.http import JsonResponse
 from arches_orm.wkrm import WELL_KNOWN_RESOURCE_MODELS
 from arches_orm.adapter import admin
 from django.core.paginator import Paginator
-from datetime import datetime
+from datetime import datetime, timezone
 from collections import defaultdict 
 from django.core.cache import cache
 import json
@@ -210,8 +210,12 @@ class Dashboard(View):
 
         if date_entered:
             date_entered = datetime.strptime(date_entered, "%Y-%m-%dT%H:%M:%S.%f%z").strftime("%d-%m-%Y")
+
+        deadline_message = None
         if deadline:
-            deadline = datetime.strptime(deadline, "%Y-%m-%dT%H:%M:%S.%f%z").strftime("%d-%m-%Y")           
+            deadline_date = datetime.strptime(deadline, "%Y-%m-%dT%H:%M:%S.%f%z")
+            deadline_message = self.create_deadline_message(deadline_date)
+            deadline = deadline_date.strftime("%d-%m-%Y")
 
         resource_data = {
             'id': str(consultation.id),
@@ -221,9 +225,26 @@ class Dashboard(View):
             'hierarchy_type': self.convert_id_to_string(hierarchy_type),
             'date': date_entered,
             'deadline': deadline,
+            'deadlinemessage': deadline_message,
             'address': address,
             'responseslug': 'assign-consultation-workflow'
         }
         return resource_data
+    
+    def create_deadline_message(self, date):
+        message = None
+        date_now = datetime.now(timezone.utc)
+        difference = (date.date() - date_now.date()).days
+
+        if difference < 0:
+            message = "Overdue"
+        elif difference == 0:
+            message = "Due Today"
+        elif difference <= 3:
+            day_word = "day" if difference == 1 else "days"
+            message = f"{difference} {day_word} until due"
+
+        return message
+
 
         


### PR DESCRIPTION
## Description
Added in a message that checks how far from the deadline the task is.
It will display 'Overdue' when the deadline has passed
Will display a countdown from 3 days when the deadline is getting closer

## test
- Rebuild containers
- make webpack
- create a new user and add them to the planning admin group
- you will need to make them a super user in the admin panel for testing
- log in as admin in incognito window in order to change the consultation dates
- as admin create a new consultation and set the target date as today
- set the status to open
- log in as the planning admin user
- navigate to the dashboard
- the consultation should be visible
- It should say Due Today in the top right corner
- As admin change the date so that it is overdue and the message should change to overdue
- Change it to 3 days time and the message should reflect
- Repeat for 2 days and 1 day
