### PR TITLE
Fix (Taiga #2114 | add-monument-workflow | add-garden-workflow | add-building-workflow | add-IHR-workflow): citation is bibliographic source

### DIFF
--- a/coral/plugins/add-building-workflow.json
+++ b/coral/plugins/add-building-workflow.json
@@ -106,6 +106,16 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['51d184d9-269c-4562-a29b-3ef9a7aa3d3a'][0]['resourceid']['resourceInstanceId']",
+                  "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
+                },
+                "tilesManaged": "many",
+                "componentName": "default-card-util",
+                "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
+              },
+              {
+                "parameters": {
+                  "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                  "resourceid": "['start-step']['51d184d9-269c-4562-a29b-3ef9a7aa3d3a'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "aa629840-d23e-11ee-9ae7-0242ac180006",
                   "hiddenNodes": [
                     "aa62a736-d23e-11ee-9ae7-0242ac180006",

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -115,6 +115,16 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['12645f4a-6638-4f80-b020-c7dd7f886163'][0]['resourceid']['resourceInstanceId']",
+                  "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
+                },
+                "tilesManaged": "many",
+                "componentName": "default-card-util",
+                "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
+              },
+              {
+                "parameters": {
+                  "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                  "resourceid": "['start-step']['12645f4a-6638-4f80-b020-c7dd7f886163'][0]['resourceid']['resourceInstanceId']",
                   "hiddenNodes": [
                     "ba345579-b554-11ea-9232-f875a44e0e11"
                   ],

--- a/coral/plugins/add-ihr-workflow.json
+++ b/coral/plugins/add-ihr-workflow.json
@@ -112,18 +112,11 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['f100407e-3c79-459d-bf91-21b4358c17f6'][0]['resourceid']['resourceInstanceId']",
-                  "hiddenNodes": [
-                    "a1d4ee9a-efc5-11eb-a6e5-a87eeabdefba",
-                    "a1d4ee9e-efc5-11eb-9ad7-a87eeabdefba",
-                    "a1d50310-efc5-11eb-964d-a87eeabdefba",
-                    "a1d5030c-efc5-11eb-890d-a87eeabdefba",
-                    "a1d50312-efc5-11eb-bde1-a87eeabdefba"
-                  ],
                   "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
                 },
-                "tilesManaged": "one",
-                "componentName": "default-card",
-                "uniqueInstanceName": "ab9bd0eb-2214-4e22-9dc1-610c4d134d63"
+                "tilesManaged": "many",
+                "componentName": "default-card-util",
+                "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
               }
             ]
           }

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -135,17 +135,9 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['768652bb-5228-438f-8b98-31ed24f0315c'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba",
-                  "hiddenNodes": [
-                    "a1d4ee9e-efc5-11eb-9ad7-a87eeabdefba",
-                    "a1d50310-efc5-11eb-964d-a87eeabdefba",
-                    "a1d5030c-efc5-11eb-890d-a87eeabdefba",
-                    "a1d50312-efc5-11eb-bde1-a87eeabdefba",
-                    "a1d502ba-efc5-11eb-a36a-a87eeabdefba",
-                    "a1d4ee9a-efc5-11eb-a6e5-a87eeabdefba"
-                  ],
                   "labels": [["Bibliographic Source", "Citation"]]
                 },
-                "tilesManaged": "one",
+                "tilesManaged": "many",
                 "componentName": "default-card-util",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
               },

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -134,8 +134,7 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['768652bb-5228-438f-8b98-31ed24f0315c'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba",
-                  "labels": [["Bibliographic Source", "Citation"]]
+                  "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
                 },
                 "tilesManaged": "many",
                 "componentName": "default-card-util",

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -136,13 +136,14 @@
                   "resourceid": "['start-step']['768652bb-5228-438f-8b98-31ed24f0315c'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba",
                   "hiddenNodes": [
-                    "a1d4ee93-efc5-11eb-b117-a87eeabdefba",
                     "a1d4ee9e-efc5-11eb-9ad7-a87eeabdefba",
                     "a1d50310-efc5-11eb-964d-a87eeabdefba",
                     "a1d5030c-efc5-11eb-890d-a87eeabdefba",
-                    "a1d50312-efc5-11eb-bde1-a87eeabdefba"
+                    "a1d50312-efc5-11eb-bde1-a87eeabdefba",
+                    "a1d502ba-efc5-11eb-a36a-a87eeabdefba",
+                    "a1d4ee9a-efc5-11eb-a6e5-a87eeabdefba"
                   ],
-                  "labels": [["Comment", "Citation"]]
+                  "labels": [["Bibliographic Source", "Citation"]]
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",


### PR DESCRIPTION
[Taiga #2114](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2114?milestone=400251)

Has not been confirmed if this is how hed want it done.

PR had asked us to change the "Citation" field on the Heritage Asset Details step of the Add-Monument-Workflow to be a resource select for Bibliographic Sources.

While doing this I saw we were just using the comment node of the Citations nodegroup
![image](https://github.com/user-attachments/assets/3159ee17-585d-4a0b-a90d-54da63500eef)

It seemed more sensible to include some of the other parts of this in a many select. This is how H.E configured it when they did the same.

Testing:
stop your containers
`make webpack`
`make manage CMD="coral reload"`
complete test sheet in description of [Taiga #2114](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2114?milestone=400251)