### PR TITLE
Fix(#2145): Change last workflow step to have save button

### DIFF
--- a/coral/media/js/views/components/plugins/merge-workflow.js
+++ b/coral/media/js/views/components/plugins/merge-workflow.js
@@ -163,6 +163,7 @@ define([
           name: 'approval-step',
           required: true,
           workflowstepclass: 'workflow-form-component',
+          saveWithoutProgressing: true,
           layoutSections: [
             {
               componentConfigs: [

--- a/coral/media/js/views/components/plugins/relate-two-monuments-workflow.js
+++ b/coral/media/js/views/components/plugins/relate-two-monuments-workflow.js
@@ -63,6 +63,7 @@ define([
           title: 'Complete',
           name: 'complete-step',
           workflowstepclass: 'workflow-form-component',
+          saveWithoutProgressing: true,
           layoutSections: [
             {
               componentConfigs: [

--- a/coral/plugins/add-building-workflow.json
+++ b/coral/plugins/add-building-workflow.json
@@ -320,6 +320,7 @@
         "name": "finish-step",
         "title": "Finish",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -321,6 +321,7 @@
         "name": "finish-step",
         "title": "Finish",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/add-ihr-workflow.json
+++ b/coral/plugins/add-ihr-workflow.json
@@ -327,6 +327,7 @@
         "name": "finish-step",
         "title": "Finish",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -375,6 +375,7 @@
         "name": "finish-step",
         "title": "Finish",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/archive-catalogue-workflow.json
+++ b/coral/plugins/archive-catalogue-workflow.json
@@ -181,6 +181,7 @@
         "name": "archive-loan-history-step",
         "title": "Archive Loan History",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/assign-consultation-workflow.json
+++ b/coral/plugins/assign-consultation-workflow.json
@@ -281,6 +281,7 @@
         "name": "action-step",
         "title": "Action",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/curatorial-workflow.json
+++ b/coral/plugins/curatorial-workflow.json
@@ -200,6 +200,7 @@
         "name": "sign-off-step",
         "title": "Sign Off",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/evaluation-meeting-workflow.json
+++ b/coral/plugins/evaluation-meeting-workflow.json
@@ -238,6 +238,7 @@
         "name": "a6b88088-53f9-4f01-8e68-e5081a669250",
         "title": "Evaluation",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/excavation-site-visit-workflow.json
+++ b/coral/plugins/excavation-site-visit-workflow.json
@@ -38,6 +38,7 @@
         "name": "site-visit-step",
         "title": "Site Visit",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/fmw-inspection-workflow.json
+++ b/coral/plugins/fmw-inspection-workflow.json
@@ -225,6 +225,7 @@
         "name": "sign-off-step",
         "title": "Sign Off",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/hb-planning-consultation-response-workflow.json
+++ b/coral/plugins/hb-planning-consultation-response-workflow.json
@@ -161,6 +161,7 @@
         "name": "upload-response",
         "title": "Upload Response",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -282,6 +282,7 @@
         "name": "letters-step",
         "title": "Letters",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": []

--- a/coral/plugins/hm-planning-consultation-response-workflow.json
+++ b/coral/plugins/hm-planning-consultation-response-workflow.json
@@ -171,6 +171,7 @@
         "name": "upload-response",
         "title": "Upload Response",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/incident-report-workflow.json
+++ b/coral/plugins/incident-report-workflow.json
@@ -317,6 +317,7 @@
         "name": "c167db3b-5bf4-438a-bbc3-de458c312473",
         "title": "Sign Off",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/scheduled-monument-consent-workflow.json
+++ b/coral/plugins/scheduled-monument-consent-workflow.json
@@ -222,6 +222,7 @@
         "name": "ea74e8cb-ce03-49c6-aeef-b5a0e62f8cdf",
         "title": "Letter",
         "required": false,
+        "saveWithoutProgressing": true,
         "layoutSections": [
           {
             "componentConfigs": [


### PR DESCRIPTION
### Description
Most workflows have a save and continue button on the last step, this has been changed to just a save button

### Test
- coral reload
- check each workflow that the last step shows a save button and not save and continue
- check that the save button is saving the data to the resource

[Taiga](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2145)