### PR TITLE
Fix(#2176): move ihr number field to last page to prevent name and ihr race condtion

### DIFF
--- a/coral/plugins/add-ihr-workflow.json
+++ b/coral/plugins/add-ihr-workflow.json
@@ -53,22 +53,6 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['f100407e-3c79-459d-bf91-21b4358c17f6'][0]['resourceid']['resourceInstanceId']",
                   "hiddenNodes": [
-                    "250002fe-3aae-11ef-91fd-0242ac120003",
-                    "2c2d02fc-3aae-11ef-91fd-0242ac120003",
-                    "158e1ed2-3aae-11ef-a2d0-0242ac120003"
-                  ],
-                  "nodegroupid": "e71df5cc-3aad-11ef-a2d0-0242ac120003",
-                  "semanticName": "Heritage Asset References"
-                },
-                "tilesManaged": "one",
-                "componentName": "default-card-util",
-                "uniqueInstanceName": "ihr-heritage-asset-references"
-              },
-              {
-                "parameters": {
-                  "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                  "resourceid": "['start-step']['f100407e-3c79-459d-bf91-21b4358c17f6'][0]['resourceid']['resourceInstanceId']",
-                  "hiddenNodes": [
                     "676d47fc-9c1c-11ea-b5b0-f875a44e0e11",
                     "676d47fd-9c1c-11ea-9d73-f875a44e0e11"
                   ],
@@ -341,6 +325,22 @@
                 "tilesManaged": "one",
                 "componentName": "default-card",
                 "uniqueInstanceName": "c9380a22-31a7-46eb-9730-1f06c86d6ca8"
+              },
+              {
+                "parameters": {
+                  "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                  "resourceid": "['start-step']['f100407e-3c79-459d-bf91-21b4358c17f6'][0]['resourceid']['resourceInstanceId']",
+                  "hiddenNodes": [
+                    "250002fe-3aae-11ef-91fd-0242ac120003",
+                    "2c2d02fc-3aae-11ef-91fd-0242ac120003",
+                    "158e1ed2-3aae-11ef-a2d0-0242ac120003"
+                  ],
+                  "nodegroupid": "e71df5cc-3aad-11ef-a2d0-0242ac120003",
+                  "semanticName": "Heritage Asset References"
+                },
+                "tilesManaged": "one",
+                "componentName": "default-card-util",
+                "uniqueInstanceName": "ihr-heritage-asset-references"
               }
             ]
           }


### PR DESCRIPTION
**Description**

Moved the IHR number field from the Add IHR workflow Asset Details page to the Finish page. This is to prevent the Heritage Asset Name and IHR Number being able to save at the same time.

**Tests**

- Start Add IHR
- Save a Site Name value
- Check HA/00 Site Name appears in search
- Go add an IHR Number
- Check IHR Number Site Name appears in search
- Reverse the process and do IHR first then Site Name
- Should be IHR Number None for Site name
- Then IHR Number Site Name