### PR TITLE
Fix(#2179): date picker and save multi tiles

### DIFF
--- a/coral/media/js/views/components/widgets/datepicker.js
+++ b/coral/media/js/views/components/widgets/datepicker.js
@@ -119,6 +119,12 @@ define([
       }
     }
 
+    if (this.value()) {
+      const parsedDate = moment(this.value(), 'YYYY-MM-DD');
+      const formattedDate = parsedDate.format('DD-MM-YYYY');
+      this.dateValue(formattedDate);
+    }
+
     /**
      * Date format overriding logic
      */
@@ -126,10 +132,15 @@ define([
       const parsedDate = moment(value, 'DD-MM-YYYY');
       const formattedDate = parsedDate.format('YYYY-MM-DD');
       this.value(formattedDate);
-      const tileData = JSON.parse(self.tile._tileData());
-      tileData[this.node.id] = formattedDate;
-      self.tile._tileData(koMapping.toJSON(tileData));
     }, this);
+
+    this.value.subscribe((value) => {
+      const parsedDate = moment(this.dateValue(), 'DD-MM-YYYY');
+      const formattedDate = parsedDate.format('YYYY-MM-DD');
+      if (value !== formattedDate) {
+        this.value(formattedDate);
+      }
+    });
 
     this.disposables.push(this.getdefault);
   };

--- a/coral/media/js/views/components/widgets/datepicker.js
+++ b/coral/media/js/views/components/widgets/datepicker.js
@@ -134,12 +134,10 @@ define([
       this.value(formattedDate);
     }, this);
 
-    this.value.subscribe((value) => {
-      const parsedDate = moment(this.dateValue(), 'DD-MM-YYYY');
-      const formattedDate = parsedDate.format('YYYY-MM-DD');
-      if (value !== formattedDate) {
-        this.value(formattedDate);
-      }
+    this.value?.subscribe((value) => {
+      const parsedDate = moment(value, 'YYYY-MM-DD');
+      const formattedDate = parsedDate.format('DD-MM-YYYY');
+      this.dateValue(formattedDate);
     });
 
     this.disposables.push(this.getdefault);

--- a/coral/media/js/views/components/widgets/datepicker.js
+++ b/coral/media/js/views/components/widgets/datepicker.js
@@ -26,14 +26,18 @@ define([
   var DatePickerWidget = function (params) {
     var self = this;
     params.configKeys = ['minDate', 'maxDate', 'viewMode', 'dateFormat', 'defaultValue'];
-    if (params.config && typeof params.config === 'function' && params.config().maxDate === "today") {
+    if (
+      params.config &&
+      typeof params.config === 'function' &&
+      params.config().maxDate === 'today'
+    ) {
       const date = new Date();
       let day = date.getDate();
       let month = date.getMonth() + 1;
       let year = date.getFullYear();
       let currentDate = `${year}-${month}-${day}`;
-      params.config.maxDate = moment(`${currentDate} 23:59:59`,"YYYY-MM-DD HH:mm:ss")
-      params.config().maxDate = moment(`${currentDate} 23:59:59`,"YYYY-MM-DD HH:mm:ss")
+      params.config.maxDate = moment(`${currentDate} 23:59:59`, 'YYYY-MM-DD HH:mm:ss');
+      params.config().maxDate = moment(`${currentDate} 23:59:59`, 'YYYY-MM-DD HH:mm:ss');
     }
     WidgetViewModel.apply(this, [params]);
 
@@ -43,7 +47,7 @@ define([
     if (!ko.unwrap(this.dateFormat)) {
       this.dateFormat = ko.observable(self.node.datatypeLookup.date.config);
     }
- 
+
     /**
      * Date format overriding logic
      */
@@ -106,27 +110,25 @@ define([
       if (this.value() === 'Date of Data Entry') {
         const today = new Date();
         this.value(today.toLocaleDateString('en-CA')); //"en-CA" formats the date in the desired format YYYY-MM-DD
+        const parsedDate = moment(this.value(), 'YYYY-MM-DD');
+        const formattedDate = parsedDate.format('DD-MM-YYYY');
+        this.dateValue(formattedDate);
+        const tileData = JSON.parse(self.tile._tileData());
+        tileData[this.node.id] = today.toLocaleDateString('en-CA');
+        self.tile._tileData(koMapping.toJSON(tileData));
       }
     }
-    
+
     /**
      * Date format overriding logic
      */
-    if (this.value()) {
-      const parsedDate = moment(this.value(), 'YYYY-MM-DD');
-      const formattedDate = parsedDate.format('DD-MM-YYYY');
-      this.dateValue(formattedDate);
-    }
-    this.value.subscribe((value) => {
-      const parsedDate = moment(this.value(), 'YYYY-MM-DD');
-      const formattedDate = parsedDate.format('DD-MM-YYYY');
-      this.dateValue(formattedDate);
-    })
     this.dateValue.subscribe((value) => {
-      console.log("date Value updating", value)
       const parsedDate = moment(value, 'DD-MM-YYYY');
       const formattedDate = parsedDate.format('YYYY-MM-DD');
       this.value(formattedDate);
+      const tileData = JSON.parse(self.tile._tileData());
+      tileData[this.node.id] = formattedDate;
+      self.tile._tileData(koMapping.toJSON(tileData));
     }, this);
 
     this.disposables.push(this.getdefault);


### PR DESCRIPTION
**Description**

https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2179

Adding a date in multi tile will now save the date provided. Adding a another will have the provided value and not show invalid date.

Multi tiles can be removed and edited so they reflect after saving the step and returning. This was previously only implemented in the default-card-util but the fix is available to default-card now.

**Tests**
- Enter License Communications step
- Click add with the default date provided
- The same date should be visible in the side bar
- Change the date
- Clcik add again
- Now that date should be visible
- Don't change the date and click add again
- The same date as the last should be visible on the sidebar
- Hit save
- Return to see the same dates you saved
- Add one more and save again
- Return confirm its the same
- Now remove one of the tiles on the sidebar that you have saved. Save the wit hit removed
- Return is it gone?
- Do remove another one 
- Return and confirm its gone
- Edit one of the tiles
- Save and return is the information there
- Remove it and return confirm it all looks as it should