### PR TITLE
Fix (Taiga #2162): excavation site visit with granted licence filter

### DIFF
--- a/coral/plugins/open-workflow.json
+++ b/coral/plugins/open-workflow.json
@@ -85,7 +85,9 @@
       {
         "slug": "excavation-site-visit-workflow",
         "name": "Excavation Site Visit",
-        "graphIds": ["b9e0701e-5463-11e9-b5f5-000d3ab1e588"]
+        "graphIds": ["b9e0701e-5463-11e9-b5f5-000d3ab1e588"],
+        "disableStartNew": true,
+        "searchString": "/search/resources?paging-filter=1&tiles=true&format=tilecsv&reportlink=false&precision=6&total=72&language=*&advanced-search=%5B%7B%22op%22%3A%22and%22%2C%22879fc326-02f6-11ef-927a-0242ac150006%22%3A%7B%22op%22%3A%22not_null%22%2C%22val%22%3A%22%22%7D%7D%5D"
       },
       {
         "slug": "add-garden-workflow",


### PR DESCRIPTION
[Taiga #2162](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2162)
This changes the open-workflow.json so that excavation site visit no longer has a "Start New" button and the drop down only includes Sites associated with a licence that has been granted