### PR TITLE
fix(#1820): Garden Number - change county abbreviations

### DIFF
--- a/coral/utils/garden_number.py
+++ b/coral/utils/garden_number.py
@@ -25,16 +25,16 @@ class GardenNumber:
             raise
 
     def id_number_format(self, index):
-        return f"{self.county_abbreviation}:{str(index).zfill(3)}"
+        return f"{self.county_abbreviation}-{str(index).zfill(3)}"
     
     def abbreviate_county(self, name):
         abbreviations = {
-            "Antrim": "ANT",
-            "Armagh": "ARM",
-            "Down": "DOW",
-            "Fermanagh": "FER",
-            "Londonderry": "LDY",
-            "Tyrone": "TYR"
+            "Antrim": "AN",
+            "Armagh": "A",
+            "Down": "D",
+            "Fermanagh": "F",
+            "Londonderry": "L",
+            "Tyrone": "T"
         }
         abbreviation = abbreviations.get(name, None)
         if abbreviation is None:


### PR DESCRIPTION
## Description
Changed the garden number from ANT:001 to AN-001

## Test
- Restart containers
- New Add Garden workflow
- Add a county
- Navigate to last step
- Generate Garden number
- Should see number similar to pattern on this ticket https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/1820