### PR TITLE
Fix(#2072): remove duplicated outline dropdown option

### DIFF
--- a/coral/pkg/graphs/resource_models/Consultation.json
+++ b/coral/pkg/graphs/resource_models/Consultation.json
@@ -24996,13 +24996,6 @@
                                 }
                             },
                             {
-                                "id": "32d2e13f-31fb-4031-9bbb-cd159c76a28e",
-                                "selected": false,
-                                "text": {
-                                    "en": "O - Outline"
-                                }
-                            },
-                            {
                                 "id": "8d94cad7-059e-4666-932a-cc94a9b5eb92",
                                 "selected": false,
                                 "text": {


### PR DESCRIPTION
**Description**

Removes duplicated item from the dropdown

**Test**

Check "O - Outline" only appears once