### PR TITLE
Fix(#2184): exclude owning resource from ihr validation

### DIFF
--- a/coral/functions/ihr_validation_function.py
+++ b/coral/functions/ihr_validation_function.py
@@ -23,6 +23,7 @@ details = {
 
 class IHRValidationFunction(BaseFunction):
     def save(self, tile, request, context):
+        resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
         input_ihr_tile = tile.data.get(IHR_NUMBER_NODE_ID, None)
 
         if not input_ihr_tile:
@@ -42,7 +43,7 @@ class IHRValidationFunction(BaseFunction):
         existing_tile = Tile.objects.filter(
             nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
             **ihr_string_query,
-        ).first()
+        ).exclude(resourceinstance_id=resource_instance_id).first()
 
         if existing_tile:
             raise ValueError("This IHR number has already been saved, please check your input")       


### PR DESCRIPTION
**Description**

Prevents the resource that owns the unique IHR id from being including in the uniqueness check

**Test**

- Save an IHR number
- Save again and it shouldn't produce an error saying it already exists