### PR TITLE
Fix(#1966 | Heritage Asset | Heritage Asset Revision): b file is resource select

### DIFF
--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -2640,31 +2640,23 @@
                 {
                     "card_id": "99baff15-bffb-4f66-802d-433fab3b325f",
                     "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
+                        "defaultResourceInstance": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "B File",
-                        "maxLength": null,
                         "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%%"
+                            "en": ""
+                        }
                     },
                     "id": "07f9868e-fc42-44a9-bc46-b6c6ec9dea68",
                     "label": {
                         "en": "B File"
                     },
-                    "node_id": "0752c8f6-1f40-11ef-bf79-0242ac150006",
+                    "node_id": "9952c8f6-1f40-11ef-bf79-0242ac150009",
                     "sortorder": 0,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "a0e4c7f4-aa3b-468a-ae9d-5e3515f8c3e1",
@@ -16947,7 +16939,7 @@
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
-                    "rangenode_id": "0752c8f6-1f40-11ef-bf79-0242ac150006"
+                    "rangenode_id": "9952c8f6-1f40-11ef-bf79-0242ac150009"
                 },
                 {
                     "description": null,
@@ -22685,9 +22677,16 @@
                 {
                     "alias": "b_file_reference_number",
                     "config": {
-                        "en": ""
+                        "graphs": [
+                            {
+                                "graphid": "b07cfa6f-894d-11ea-82aa-f875a44e0e11",
+                                "name": "Archive Source"
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
                     },
-                    "datatype": "string",
+                    "datatype": "resource-instance",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -22699,7 +22698,7 @@
                     "istopnode": false,
                     "name": "B File Reference Number",
                     "nodegroup_id": "dd6bb692-1f3f-11ef-bf79-0242ac150006",
-                    "nodeid": "0752c8f6-1f40-11ef-bf79-0242ac150006",
+                    "nodeid": "9952c8f6-1f40-11ef-bf79-0242ac150009",
                     "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -14375,31 +14375,23 @@
                 {
                     "card_id": "9a603999-b64c-414a-9d6b-a210acf5329c",
                     "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
+                        "defaultResourceInstance": [],
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "B File",
-                        "maxLength": null,
                         "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%%"
+                            "en": ""
+                        }
                     },
                     "id": "dbd71c83-b3c6-4a6e-9bbd-165f43a9dd99",
                     "label": {
                         "en": "B File"
                     },
-                    "node_id": "901eff84-1f3f-11ef-ac74-0242ac150006",
+                    "node_id": "72331a22-4ff1-11ef-a810-0242ac120009",
                     "sortorder": 0,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "3111eec9-9b39-4378-95d7-0d16b45f83be",
@@ -17168,7 +17160,7 @@
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
-                    "rangenode_id": "901eff84-1f3f-11ef-ac74-0242ac150006"
+                    "rangenode_id": "72331a22-4ff1-11ef-a810-0242ac120009"
                 },
                 {
                     "description": null,
@@ -34035,9 +34027,16 @@
                 {
                     "alias": "b_file_reference_number",
                     "config": {
-                        "en": ""
+                        "graphs": [
+                            {
+                                "graphid": "b07cfa6f-894d-11ea-82aa-f875a44e0e11",
+                                "name": "Archive Source"
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
                     },
-                    "datatype": "string",
+                    "datatype": "resource-instance",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -34049,7 +34048,7 @@
                     "istopnode": false,
                     "name": "B File Reference Number",
                     "nodegroup_id": "4e6c2d46-1f3f-11ef-ac74-0242ac150006",
-                    "nodeid": "901eff84-1f3f-11ef-ac74-0242ac150006",
+                    "nodeid": "72331a22-4ff1-11ef-a810-0242ac120009",
                     "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,


### PR DESCRIPTION
[Taiga #1966](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/1966)

removes the text node for b file number and replaces it with a resource-instance select. It does need to change the node id due to lingering rows in the db.

Notes:
While not 100% relevant to this PR, please ensure you have ihr_validation_function.py; hb_number_function.py; smr_number_function.py; and garden_number_function.py registered

**Test**
Remove Heritage Asset and Heritage Asset Revision models
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Monument\ Revision.json'`
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Monument.json'`
Go to Heritage Asset workflows and Heritage Asset Detail Steps. Ensure B File field is a resource select directed towards Archive source
Make two Heritage Asset Resources; one with B File one with out
Merge the two together, ensure B File is present on remaining asset

