### PR TITLE
Feat/#2094/update address card for all models

### DIFF
--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -196,7 +196,7 @@ define([
                       'a541e02f-f121-11eb-8d6a-a87eeabdefba', // street_type,
                       'a541e030-f121-11eb-aaf7-a87eeabdefba', // postcode_type,
                       'a541e033-f121-11eb-9f81-a87eeabdefba', // full_address_metatype,
-                      //'a541e034-f121-11eb-8803-a87eeabdefba', // county_value,
+                      //'a541e034-f121-11eb-8803-0242ac120003', // county_value,
                       'a541e035-f121-11eb-a3d9-a87eeabdefba' // street_metatype
                     ]
                   }

--- a/coral/media/js/views/components/workflows/assign-consultation-workflow/pc-summary.js
+++ b/coral/media/js/views/components/workflows/assign-consultation-workflow/pc-summary.js
@@ -93,7 +93,7 @@ define([
           { nodeId: '083e6c90-ca61-11ee-afca-0242ac180006', label: 'Full Address' },
           { nodeId: '083e8f4a-ca61-11ee-afca-0242ac180006', label: 'Street' },
           { nodeId: '083f8ad0-ca61-11ee-afca-0242ac180006', label: 'Town or City' },
-          { nodeId: '083fafe2-ca61-11ee-afca-0242ac180006', label: 'County' },
+          { nodeId: '083fafe2-345c-11ef-a5b7-0242ac120003', label: 'County' },
           { nodeId: '083f8f26-ca61-11ee-afca-0242ac180006', label: 'Postcode' }
         ]
       },

--- a/coral/media/js/views/components/workflows/licensing-workflow/license-cover-letter.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/license-cover-letter.js
@@ -626,7 +626,7 @@ define([
             buildingNumberId: 'a541b925-f121-11eb-9264-a87eeabdefba',
             streetNameId: 'a541b927-f121-11eb-8377-a87eeabdefba',
             localityId: 'a541b930-f121-11eb-a30c-a87eeabdefba',
-            countyId: 'a541e034-f121-11eb-8803-a87eeabdefba'
+            countyId: 'a541e034-f121-11eb-8803-0242ac120003'
           });
         }
 

--- a/coral/media/js/views/components/workflows/licensing-workflow/license-final-step.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/license-final-step.js
@@ -150,7 +150,7 @@ define([
         nodegroupId: 'a5416b3d-f121-11eb-85b4-a87eeabdefba',
         renderNodeIds: [
           'a5419224-f121-11eb-9ca7-a87eeabdefba',
-          'a541e034-f121-11eb-8803-a87eeabdefba',
+          'a541e034-f121-11eb-8803-0242ac120003',
           'a541e030-f121-11eb-aaf7-a87eeabdefba',
           'a541e029-f121-11eb-802c-a87eeabdefba',
           'a541e027-f121-11eb-ba26-a87eeabdefba',

--- a/coral/pkg/graphs/resource_models/Activity.json
+++ b/coral/pkg/graphs/resource_models/Activity.json
@@ -5328,28 +5328,6 @@
                 {
                     "card_id": "a5416b3f-f121-11eb-9d4a-a87eeabdefba",
                     "config": {
-                        "defaultValue": "6bdffb5e-9f5b-44f7-a3a6-11cf81219fd8",
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "County Metatype",
-                        "options": [],
-                        "placeholder": {
-                            "en": "Select an option"
-                        }
-                    },
-                    "id": "a541e06c-f121-11eb-9dcc-a87eeabdefba",
-                    "label": {
-                        "en": "County Metatype"
-                    },
-                    "node_id": "a541b92d-f121-11eb-8993-a87eeabdefba",
-                    "sortorder": 26,
-                    "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                },
-                {
-                    "card_id": "a5416b3f-f121-11eb-9d4a-a87eeabdefba",
-                    "config": {
                         "defaultValue": "2103d23d-2b68-4bfb-ad23-2689f060e357",
                         "i18n_properties": [
                             "placeholder"
@@ -5372,31 +5350,24 @@
                 {
                     "card_id": "a5416b3f-f121-11eb-9d4a-a87eeabdefba",
                     "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
+                        "defaultValue": "",
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "County ",
-                        "maxLength": null,
+                        "label": "County",
+                        "options": [],
                         "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%"
+                            "en": "Select an option"
+                        }
                     },
                     "id": "a541e06e-f121-11eb-aea7-a87eeabdefba",
                     "label": {
                         "en": "County "
                     },
-                    "node_id": "a541e034-f121-11eb-8803-a87eeabdefba",
+                    "node_id": "a541e034-f121-11eb-8803-0242ac120003",
                     "sortorder": 24,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "a5416b3f-f121-11eb-9d4a-a87eeabdefba",
@@ -5468,28 +5439,6 @@
                     },
                     "node_id": "a541b91d-f121-11eb-adf3-a87eeabdefba",
                     "sortorder": 34,
-                    "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                },
-                {
-                    "card_id": "a5416b3f-f121-11eb-9d4a-a87eeabdefba",
-                    "config": {
-                        "defaultValue": "98355a3e-6f84-45ae-9281-8aa7e20d47f5",
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "County Type",
-                        "options": [],
-                        "placeholder": {
-                            "en": "Select an option"
-                        }
-                    },
-                    "id": "a541e072-f121-11eb-8a84-a87eeabdefba",
-                    "label": {
-                        "en": "County Type"
-                    },
-                    "node_id": "a541b92b-f121-11eb-ade9-a87eeabdefba",
-                    "sortorder": 25,
                     "visible": false,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -7744,6 +7693,15 @@
             "edges": [
                 {
                     "description": null,
+                    "domainnode_id": "a5416b3d-f121-11eb-85b4-a87eeabdefba",
+                    "edgeid": "a541e034-e92d-4603-91f2-bf91f159b2b3",
+                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "a541e034-f121-11eb-8803-0242ac120003"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "a472226f-9937-11ea-966a-f875a44e0e11",
                     "edgeid": "62b74941-e92d-4603-91f2-bf91f159b2b3",
                     "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
@@ -9436,15 +9394,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "a5416b3d-f121-11eb-85b4-a87eeabdefba",
-                    "edgeid": "a54ac3bc-f121-11eb-b501-a87eeabdefba",
-                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P106_is_composed_of",
-                    "rangenode_id": "a541e02c-f121-11eb-9827-a87eeabdefba"
-                },
-                {
-                    "description": null,
                     "domainnode_id": "a541b926-f121-11eb-a088-a87eeabdefba",
                     "edgeid": "a54ac3bd-f121-11eb-ab90-a87eeabdefba",
                     "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
@@ -9589,24 +9538,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "a541e02c-f121-11eb-9827-a87eeabdefba",
-                    "edgeid": "a54aea91-f121-11eb-b54c-a87eeabdefba",
-                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
-                    "rangenode_id": "a541e034-f121-11eb-8803-a87eeabdefba"
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "a541e02c-f121-11eb-9827-a87eeabdefba",
-                    "edgeid": "a54aea92-f121-11eb-ae8b-a87eeabdefba",
-                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "rangenode_id": "a541b92b-f121-11eb-ade9-a87eeabdefba"
-                },
-                {
-                    "description": null,
                     "domainnode_id": "a541e028-f121-11eb-a086-a87eeabdefba",
                     "edgeid": "a54aea93-f121-11eb-b815-a87eeabdefba",
                     "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
@@ -9694,15 +9625,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P106_is_composed_of",
                     "rangenode_id": "a541e032-f121-11eb-9572-a87eeabdefba"
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "a541b92b-f121-11eb-ade9-a87eeabdefba",
-                    "edgeid": "a54aea9d-f121-11eb-b3c7-a87eeabdefba",
-                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "rangenode_id": "a541b92d-f121-11eb-8993-a87eeabdefba"
                 },
                 {
                     "description": null,
@@ -16629,29 +16551,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "county_type",
-                    "config": {
-                        "rdmCollection": "02458080-9b7a-4a02-b298-f7ea61f60dbb"
-                    },
-                    "datatype": "concept",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": false,
-                    "istopnode": false,
-                    "name": "County Type",
-                    "nodegroup_id": "a5416b3d-f121-11eb-85b4-a87eeabdefba",
-                    "nodeid": "a541b92b-f121-11eb-ade9-a87eeabdefba",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "sub_street_type",
                     "config": {
                         "rdmCollection": "02458080-9b7a-4a02-b298-f7ea61f60dbb"
@@ -16669,29 +16568,6 @@
                     "name": "Sub-Street Type",
                     "nodegroup_id": "a5416b3d-f121-11eb-85b4-a87eeabdefba",
                     "nodeid": "a541b92c-f121-11eb-b09e-a87eeabdefba",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "county_metatype",
-                    "config": {
-                        "rdmCollection": "1e63c514-eb9d-48d3-94b5-35e060e5f368"
-                    },
-                    "datatype": "concept",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": false,
-                    "istopnode": false,
-                    "name": "County Metatype",
-                    "nodegroup_id": "a5416b3d-f121-11eb-85b4-a87eeabdefba",
-                    "nodeid": "a541b92d-f121-11eb-8993-a87eeabdefba",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
@@ -17927,27 +17803,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "county",
-                    "config": {},
-                    "datatype": "semantic",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "County",
-                    "nodegroup_id": "a5416b3d-f121-11eb-85b4-a87eeabdefba",
-                    "nodeid": "a541e02c-f121-11eb-9827-a87eeabdefba",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P106_is_composed_of",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "address_currency",
                     "config": {
                         "rdmCollection": "a346ee99-67f6-44cd-87f7-b564ce32cdf3"
@@ -18106,8 +17961,10 @@
                 },
                 {
                     "alias": "county_value",
-                    "config": {},
-                    "datatype": "string",
+                    "config": {
+                        "rdmCollection": "763ba635-3800-324a-8d54-c1427bcaa5aa"
+                    },
+                    "datatype": "concept",
                     "description": null,
                     "exportable": true,
                     "fieldname": "County",
@@ -18119,7 +17976,7 @@
                     "istopnode": false,
                     "name": "County Value",
                     "nodegroup_id": "a5416b3d-f121-11eb-85b4-a87eeabdefba",
-                    "nodeid": "a541e034-f121-11eb-8803-a87eeabdefba",
+                    "nodeid": "a541e034-f121-11eb-8803-0242ac120003",
                     "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,

--- a/coral/pkg/graphs/resource_models/Consultation.json
+++ b/coral/pkg/graphs/resource_models/Consultation.json
@@ -1974,6 +1974,28 @@
             ],
             "cards_x_nodes_x_widgets": [
                 {
+                    "card_id": "083e195c-ca61-11ee-afca-0242ac180006",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Townland",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "d033683a-aea5-4ff1-9d15-95911513ef66",
+                    "label": {
+                        "en": "Townland"
+                    },
+                    "node_id": "083fafe2-345c-11ef-a5b7-0242ac120003",
+                    "sortorder": 34,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                },
+                {
                     "card_id": "caf5bff3-a3d7-11e9-b521-00224800b26d",
                     "config": {
                         "defaultValue": {
@@ -4523,31 +4545,24 @@
                 {
                     "card_id": "083e195c-ca61-11ee-afca-0242ac180006",
                     "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
+                        "defaultValue": "",
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "County ",
-                        "maxLength": null,
+                        "label": "County",
+                        "options": [],
                         "placeholder": {
-                            "en": "Enter text"
-                        },
-                        "uneditable": false,
-                        "width": "100%"
+                            "en": "Select an option"
+                        }
                     },
                     "id": "084032aa-ca61-11ee-afca-0242ac180006",
                     "label": {
                         "en": "County "
                     },
-                    "node_id": "083fafe2-ca61-11ee-afca-0242ac180006",
+                    "node_id": "083fafe2-ca61-11ee-afca-0242ac180009",
                     "sortorder": 24,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "083e195c-ca61-11ee-afca-0242ac180006",
@@ -12265,6 +12280,15 @@
             "edges": [
                 {
                     "description": null,
+                    "domainnode_id": "083e14f2-ca61-11ee-afca-0242ac180006",
+                    "edgeid": "d033683a-bb5a-45bc-bcc3-f56a0052f5cb",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "083fafe2-345c-11ef-a5b7-0242ac120003"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "93199292-fb24-11ee-838d-0242ac190006",
                     "edgeid": "f0050529-2876-4007-b31c-b788f21bf1c4",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
@@ -13160,8 +13184,8 @@
                     "edgeid": "084ff7da-ca61-11ee-afca-0242ac180006",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
                     "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
-                    "rangenode_id": "083fafe2-ca61-11ee-afca-0242ac180006"
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "rangenode_id": "083fafe2-ca61-11ee-afca-0242ac180009"
                 },
                 {
                     "description": null,
@@ -17658,6 +17682,33 @@
             ],
             "nodes": [
                 {
+                    "alias": "townland",
+                    "config": {
+                        "i18n_config": {
+                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
+                        },
+                        "options": [],
+                        "rdmCollection": "c333cc6e-9abe-9782-bfe5-085f1389c2c7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "Townland",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Townland",
+                    "nodegroup_id": "083e14f2-ca61-11ee-afca-0242ac180006",
+                    "nodeid": "083fafe2-345c-11ef-a5b7-0242ac120003",
+                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "send_papers",
                     "config": {
                         "falseLabel": {
@@ -21864,8 +21915,10 @@
                 },
                 {
                     "alias": "county_value",
-                    "config": {},
-                    "datatype": "string",
+                    "config": {
+                        "rdmCollection": "763ba635-3800-324a-8d54-c1427bcaa5aa"
+                    },
+                    "datatype": "concept",
                     "description": null,
                     "exportable": true,
                     "fieldname": "County",
@@ -21877,9 +21930,9 @@
                     "istopnode": false,
                     "name": "County Value",
                     "nodegroup_id": "083e14f2-ca61-11ee-afca-0242ac180006",
-                    "nodeid": "083fafe2-ca61-11ee-afca-0242ac180006",
-                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "nodeid": "083fafe2-ca61-11ee-afca-0242ac180009",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": "9c503f1e-06d9-11ed-ad22-acde48001122"
                 },


### PR DESCRIPTION
[Taiga #2094](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2094)

## Consultation

- Changed County to drop down (requires changing of nodeid from 083fafe2-ca61-11ee-afca-0242ac180006 to 083fafe2-345c-11ef-a5b7-0242ac120003)
- Added Townland to addresses Card
- updated coral/media/js/views/components/workflows/assign-consultation-workflow/pc-summary.js to use the new County Node Id

## Activity

There were two separate county nodes in the Activity model (a541e034-f121-11eb-8803-a87eeabdefba and a541e02c-f121-11eb-9827-a87eeabdefba ) both are used in different places throughout the site

- Removed duplicate County from earlier error (node_id": "a541e02c-f121-11eb-9827-a87eeabdefba")
- Changing County to drop down (nodeid a541e034-f121-11eb-8803-a87eeabdefba to a541e034-f121-11eb-8803-0242ac120003)
- Updated the licensing workflow and it's cover letter / final step components to use the new id

These Changes will replace the county with a drop down for the mentioned workflows 

![image](https://github.com/user-attachments/assets/35b32ad6-a70e-4e24-86f1-eb6d0b6c9478)

There are still other models that need the Addresses Card standardised to include this drop down / Townlands fields but This PR is open to make the 3pm cut off


**Test**
Delete Activity and Consultation Models
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Activity.json'`
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Consultation.json'`
restart containers
`make webpack`
then follow test sheet in [Taiga #2094](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2094)

