### PR TITLE
Fix: Garden Number increment

### DIFF
--- a/coral/utils/garden_number.py
+++ b/coral/utils/garden_number.py
@@ -70,7 +70,7 @@ class GardenNumber:
         )
 
         logger.info("Previous ID number: %s", latest_id_number)
-        id_number_parts = latest_id_number.split(":")
+        id_number_parts = latest_id_number.split("-")
         return {"index": int(id_number_parts[1])}
 
     def generate_id_number(self, resource_instance_id=None, attempts=0):


### PR DESCRIPTION
### Description
Garden number was erroring when trying to increment

### Test
- Add a garden
- Choose a county
- Navigate to the last page - generate a number
- Save the generated number
- Start a new add garden
- Add the same county
- Generate a number
- Should increment the number from the previous (this is where the error was)