### PR TITLE
Fix/2254 Allow Garden Number to update if the county changes

### DIFF
--- a/coral/functions/generate_ha_name_function.py
+++ b/coral/functions/generate_ha_name_function.py
@@ -214,6 +214,9 @@ class GenerateHertiageAssetNameFunction(BaseFunction):
             display_name.append(hb_number)
         if show_hpg_number:
             display_name.append(hpg_number)
+            self.update_display_name_tile(
+                    ha_display_name_tile, f"{hpg_number} {ha_name}"
+                )
         display_name.append(ha_name)
 
         self.update_display_name_tile(ha_display_name_tile, " ".join(display_name))

--- a/coral/functions/generate_ha_name_function.py
+++ b/coral/functions/generate_ha_name_function.py
@@ -214,9 +214,6 @@ class GenerateHertiageAssetNameFunction(BaseFunction):
             display_name.append(hb_number)
         if show_hpg_number:
             display_name.append(hpg_number)
-            self.update_display_name_tile(
-                    ha_display_name_tile, f"{hpg_number} {ha_name}"
-                )
         display_name.append(ha_name)
 
         self.update_display_name_tile(ha_display_name_tile, " ".join(display_name))

--- a/coral/media/js/views/components/workflows/generate-garden-number.js
+++ b/coral/media/js/views/components/workflows/generate-garden-number.js
@@ -74,12 +74,12 @@ define([
             }
           });
         } else {
-          this.tile.data[this.GENERATED_GARDEN_NODE_ID] = {
+          this.tile.data[this.GENERATED_GARDEN_NODE_ID] = ko.observable({
             en: {
               direction: "ltr",
               value: response.gardenNumber
             }
-          };
+          });
         }
         params.pageVm.loading(false);
       };

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=0, patch=1)
+APP_VERSION = semantic_version.Version(major=5, minor=0, patch=2)
 
 GROUPINGS = {
     "groups": {

--- a/coral/utils/garden_number.py
+++ b/coral/utils/garden_number.py
@@ -45,7 +45,7 @@ class GardenNumber:
         latest_id_number_tile = None
         try:
             id_number_generated = {
-                f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_abbreviation,
+                f"data__{GARDEN_NUMBER_NODE_ID}__icontains": self.county_abbreviation + '-',
             }
             query_result = Tile.objects.filter(
                 nodegroup_id=HERITAGE_ASSET_REFERENCES_NODEGROUP_ID,
@@ -70,7 +70,7 @@ class GardenNumber:
         )
 
         logger.info("Previous ID number: %s", latest_id_number)
-        id_number_parts = latest_id_number.split(":")
+        id_number_parts = latest_id_number.split("-")
         return {"index": int(id_number_parts[1])}
 
     def generate_id_number(self, resource_instance_id=None, attempts=0):
@@ -100,8 +100,13 @@ class GardenNumber:
                 return retry()
 
             if id_number_tile:
-                logger.info("A ID number has already been created for this resource")
-                return
+                tile_garden_id = id_number_tile.data.get(GARDEN_NUMBER_NODE_ID).get("en").get("value")
+                if tile_garden_id:
+                    abbreviation = tile_garden_id.split("-")[0]
+
+                if abbreviation == self.county_abbreviation:
+                    logger.info("A ID number has already been created for this resource")
+                    return
 
         latest_id_number = None
         try:
@@ -111,7 +116,7 @@ class GardenNumber:
             return retry()
 
         if latest_id_number:
-            next_number = latest_id_number["index"] + attempts + 1
+            next_number = latest_id_number["index"] + attempts
             id_number = self.id_number_format(next_number)
         else:
             # If there is no latest resource to work from we know

--- a/coral/views/garden_number.py
+++ b/coral/views/garden_number.py
@@ -29,19 +29,32 @@ class GardenNumberView(View):
                 nodegroup_id=ADDRESS_NODEGROUP_ID,
             ).first()
 
-            if references_tile and references_tile.data.get(GARDEN_NUMBER_NODE_ID, None):
-                id = (
+            if county_tile and references_tile:
+                county_name_tile = models.Value.objects.filter(
+                    valueid= county_tile.data.get(COUNTY_NODE_ID)
+                ).first()
+                county_name = county_name_tile.value
+                county_abbreviation = GardenNumber(county_name).abbreviate_county(county_name)
+                abbreviation = (
                     references_tile.data.get(GARDEN_NUMBER_NODE_ID, None)
                     .get("en")
                     .get("value")
+                    .split("-")[0]
                 )
-                print("Historic Parks and Garden Number has already been generated: ", id)
-                return JSONResponse(
-                    {
-                        "message": "Historic Parks and Garden has already been generated",
-                        "gardenNumber": id,
-                    }
-                )
+                if county_abbreviation == abbreviation:
+                    if references_tile.data.get(GARDEN_NUMBER_NODE_ID, None):
+                        id = (
+                            references_tile.data.get(GARDEN_NUMBER_NODE_ID, None)
+                            .get("en")
+                            .get("value")
+                        )
+                        print("Historic Parks and Garden Number has already been generated: ", id)
+                        return JSONResponse(
+                            {
+                                "message": "Historic Parks and Garden has already been generated",
+                                "gardenNumber": id,
+                            }
+                        )
             
         self.county_name = ""
 


### PR DESCRIPTION
### Description
Noticed that if the county changes after saving the garden number does not update.
There was also an issue when you have saved the garden number and then regenerate the number, the widget errors

### Test
- Start 'Add Garden'
- Select a county from the location step
- Go to the finish step and generate a number
- Check the increment is either the first number for that county or the next consecutive (there was an issue with it incrementing the last garden number rather than a specific county)
- Click save
- Check in the search that the garden number is as it was generated and showing
- Go back to the workflow and click generate
- The widget should be fine and the garden number should not change
- Go to the location step and change the county
- Go back to the finish step and click generate garden number
- This should update using the new county
- Check in search that this has updated the display name and that the increment is correct
- Start 2 new add gardens at the same time
- Choose the same county for both and generate the garden numbers, don't save either before this is done
- Click save on both
- Check in the search, the last save should have incremented the number (this won't show in the workflow)
- Go back to the workflows
- Change the county on both to a new county but the same for both
- Generate the numbers again
- This should have updated and be the same in both workflows
- Save each
- You should see in the search this has updated and one will have incremented so there are no duplicate names