### PR TITLE
Fix(#2213): HM Response - change county node id in the application summary description

### DIFF
--- a/coral/media/js/views/components/workflows/assign-consultation-workflow/pc-summary.js
+++ b/coral/media/js/views/components/workflows/assign-consultation-workflow/pc-summary.js
@@ -93,7 +93,7 @@ define([
           { nodeId: '083e6c90-ca61-11ee-afca-0242ac180006', label: 'Full Address' },
           { nodeId: '083e8f4a-ca61-11ee-afca-0242ac180006', label: 'Street' },
           { nodeId: '083f8ad0-ca61-11ee-afca-0242ac180006', label: 'Town or City' },
-          { nodeId: '083fafe2-345c-11ef-a5b7-0242ac120003', label: 'County' },
+          { nodeId: '083fafe2-ca61-11ee-afca-0242ac180009', label: 'County' },
           { nodeId: '083f8f26-ca61-11ee-afca-0242ac180006', label: 'Postcode' }
         ]
       },

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=0, patch=2)
+APP_VERSION = semantic_version.Version(major=5, minor=0, patch=3)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
### Description
In the HM response, the application summary was showing the townland node in the county descriptor.

### Test
- Reload containers
- make webpack
- coral reload
- Start a planning consultation. Assign to HM and set a county in the location step
- Open the same consultation in HM response and navigate to the application summary
- Should see the county label showing the chosen county