### PR TITLE
Fix(#2262): if display value has a date pattern it will be changed to the uk format

### DIFF
--- a/coral/media/js/views/components/workflows/summary-step.js
+++ b/coral/media/js/views/components/workflows/summary-step.js
@@ -3,6 +3,7 @@ define([
   'views/components/workflows/final-step',
   'geojson-extent',
   'arches',
+  'moment',
   'views/components/map',
   'views/components/cards/select-feature-layers',
   'viewmodels/alert',
@@ -12,6 +13,7 @@ define([
   FinalStep,
   geojsonExtent,
   arches,
+  moment,
   MapComponentViewModel,
   selectFeatureLayersFactory,
   AlertViewModel
@@ -198,6 +200,12 @@ define([
           }
         }
         tile.display_values.forEach((display) => {
+          const dateRegex = /\d{4}-\d{2}-\d{2}/;
+          if (dateRegex.test(display.value)) {
+            const parsedDate = moment(display.value, 'YYYY-MM-DD');
+            const formattedDate = parsedDate.format('DD-MM-YYYY');
+            display.value = formattedDate;
+          }
           if (!cardinality) {
             formatted[tile.nodegroup]['data'][display.nodeid] = {
               nodeId: display.nodeid,

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=0, patch=3)
+APP_VERSION = semantic_version.Version(major=5, minor=0, patch=4)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
**Description**

The summary component rendered the raw display value for dates which showed the American format.

**Tests**

- Open Planning Consultation
- Fill in a couple of dates target date on the last page is good
- Assign to one of the teams or both
- Navigate to the response workflows
- Confirm the summary page is rendering the UK format for dates