### PR TITLE
Fix/2278 separate the hm and hb response file uploads

### DIFF
--- a/coral/media/js/views/components/workflows/related-document-upload.js
+++ b/coral/media/js/views/components/workflows/related-document-upload.js
@@ -160,16 +160,25 @@ define([
        *
        * This can be found in datatypes.py on line 2080.
        */
+
+      prefilledKeys = {};
+      if (params.prefilledNodes) {
+        params.prefilledNodes.forEach(([nodeId, value]) => {
+          prefilledKeys[nodeId] = value;
+        });
+      }
+
       const fileTileTemplate = {
         tileid: '',
         data: {
-          [self.resourceModelDigitalObjectNodeGroupId]: [
+          [self.resourceModelDigitalObjectNodeId]: [
             {
               resourceId: self.resourceId(),
               ontologyProperty: '',
               inverseOntologyProperty: ''
             }
-          ]
+          ],
+          ...prefilledKeys
         },
         nodegroup_id: self.resourceModelDigitalObjectNodeGroupId,
         parenttile_id: null,

--- a/coral/pkg/graphs/resource_models/Consultation.json
+++ b/coral/pkg/graphs/resource_models/Consultation.json
@@ -5,6 +5,33 @@
             "cards": [
                 {
                     "active": true,
+                    "cardid": "7c52fa14-bbc8-4747-8a74-7ba96b58a7ed",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "is_editable": true,
+                    "name": {
+                        "en": "Response Files"
+                    },
+                    "nodegroup_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "044949c0-c769-11ee-82c4-0242ac180006",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -1377,6 +1404,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "7c52fa14-bbc8-4747-8a74-7ba96b58a7ed",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "is_editable": true,
+                    "name": {
+                        "en": "Response Files"
+                    },
+                    "nodegroup_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "82f8a165-951a-11ea-90f3-f875a44e0e11",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -1720,7 +1774,7 @@
                     "instructions": {
                         "en": ""
                     },
-                    "is_editable": true,
+                    "is_editable": false,
                     "name": {
                         "en": "Actions"
                     },
@@ -1973,28 +2027,6 @@
                 }
             ],
             "cards_x_nodes_x_widgets": [
-                {
-                    "card_id": "083e195c-ca61-11ee-afca-0242ac180006",
-                    "config": {
-                        "defaultValue": "",
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "Townland",
-                        "options": [],
-                        "placeholder": {
-                            "en": "Select an option"
-                        }
-                    },
-                    "id": "d033683a-aea5-4ff1-9d15-95911513ef66",
-                    "label": {
-                        "en": "Townland"
-                    },
-                    "node_id": "083fafe2-345c-11ef-a5b7-0242ac120003",
-                    "sortorder": 34,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
-                },
                 {
                     "card_id": "caf5bff3-a3d7-11e9-b521-00224800b26d",
                     "config": {
@@ -11533,6 +11565,28 @@
                     "widget_id": "10000000-0000-0000-0000-000000000015"
                 },
                 {
+                    "card_id": "083e195c-ca61-11ee-afca-0242ac180006",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Townland",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "d033683a-aea5-4ff1-9d15-95911513ef66",
+                    "label": {
+                        "en": "Townland"
+                    },
+                    "node_id": "083fafe2-345c-11ef-a5b7-0242ac120003",
+                    "sortorder": 34,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
+                },
+                {
                     "card_id": "548d948e-7642-4752-89a6-4ba21773cbc6",
                     "config": {
                         "defaultResourceInstance": [],
@@ -12278,6 +12332,33 @@
                 "en": "Version 0.1; A model to represent activities and information related to the review and evaluation of proposed developments or alterations to a structure.  This model supposes that an official of a government agency must review proposed construction activities and determine whether the activities require conditions/mitigations to conform with local requirements.  This model allows for formal application review and informal (e.g.: pre-application) consultations."
             },
             "edges": [
+                {
+                    "description": null,
+                    "domainnode_id": "8d41e4d2-a250-11e9-8fd3-00224800b26d",
+                    "edgeid": "1da0f502-fb54-41e4-ba6e-4dfa288332fb",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "rangenode_id": "31e5ece6-5989-11ef-af2d-0242ac120006"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "edgeid": "6824233a-baa8-4064-9898-98f6f5fc760d",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "rangenode_id": "5d401df8-5989-11ef-9d18-0242ac120006"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "edgeid": "8a17922e-1c8a-4123-8394-3010fc1b0c19",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "983d73b0-5989-11ef-af2d-0242ac120006"
+                },
                 {
                     "description": null,
                     "domainnode_id": "083e14f2-ca61-11ee-afca-0242ac180006",
@@ -14071,6 +14152,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "8d41e4d2-a250-11e9-8fd3-00224800b26d",
+                    "edgeid": "1da0f502-fb54-41e4-ba6e-4dfa288332fb",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "rangenode_id": "31e5ece6-5989-11ef-af2d-0242ac120006"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "43881c14-031a-11ef-8a7d-0242ac150006",
                     "edgeid": "1fcc5a2a-c08b-4136-ab05-925909a4d706",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
@@ -15475,6 +15565,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "edgeid": "6824233a-baa8-4064-9898-98f6f5fc760d",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "rangenode_id": "5d401df8-5989-11ef-9d18-0242ac120006"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "f3337e0a-69b5-11ee-908a-0242ac120002",
                     "edgeid": "68bc96ee-fae6-49da-812c-99cb6b0b11e7",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
@@ -15724,6 +15823,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P165i_is_incorporated_in",
                     "rangenode_id": "87e0b839-9391-11ea-8a85-f875a44e0e11"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "edgeid": "8a17922e-1c8a-4123-8394-3010fc1b0c19",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "983d73b0-5989-11ef-af2d-0242ac120006"
                 },
                 {
                     "description": null,
@@ -16645,6 +16753,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "083e14f2-ca61-11ee-afca-0242ac180006",
+                    "edgeid": "d033683a-bb5a-45bc-bcc3-f56a0052f5cb",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "083fafe2-345c-11ef-a5b7-0242ac120003"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "82b3ed68-8882-11ea-8ff6-f875a44e0e11",
                     "edgeid": "d0c9c724-95be-11ea-85e2-f875a44e0e11",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
@@ -16951,6 +17068,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "93199292-fb24-11ee-838d-0242ac190006",
+                    "edgeid": "f0050529-2876-4007-b31c-b788f21bf1c4",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "rangenode_id": "ff42f8f2-3e93-11ef-9023-0242ac140007"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "3406cffa-cfdb-11ee-8cc1-0242ac180006",
                     "edgeid": "f056d1f9-87fb-4a70-9166-ae67b2a6ab35",
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
@@ -17254,6 +17380,12 @@
             },
             "nodegroups": [
                 {
+                    "cardinality": "n",
+                    "legacygroupid": null,
+                    "nodegroupid": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "parentnodegroup_id": null
+                },
+                {
                     "cardinality": "1",
                     "legacygroupid": null,
                     "nodegroupid": "04492152-c769-11ee-82c4-0242ac180006",
@@ -17401,6 +17533,12 @@
                     "cardinality": "1",
                     "legacygroupid": null,
                     "nodegroupid": "2ca5f42c-0319-11ef-8a7d-0242ac150006",
+                    "parentnodegroup_id": null
+                },
+                {
+                    "cardinality": "n",
+                    "legacygroupid": null,
+                    "nodegroupid": "31e5ece6-5989-11ef-af2d-0242ac120006",
                     "parentnodegroup_id": null
                 },
                 {
@@ -17682,60 +17820,58 @@
             ],
             "nodes": [
                 {
-                    "alias": "townland",
+                    "alias": "response_files",
                     "config": {
-                        "i18n_config": {
-                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
-                        },
-                        "options": [],
-                        "rdmCollection": "c333cc6e-9abe-9782-bfe5-085f1389c2c7"
+                        "en": ""
                     },
-                    "datatype": "concept",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "Townland",
-                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "Townland",
-                    "nodegroup_id": "083e14f2-ca61-11ee-afca-0242ac180006",
-                    "nodeid": "083fafe2-345c-11ef-a5b7-0242ac120003",
-                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "send_papers",
-                    "config": {
-                        "falseLabel": {
-                            "en": "No"
-                        },
-                        "i18n_properties": [
-                            "trueLabel",
-                            "falseLabel"
-                        ],
-                        "trueLabel": {
-                            "en": "Yes"
-                        }
-                    },
-                    "datatype": "boolean",
+                    "datatype": "semantic",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
                     "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
                     "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Response Files",
+                    "nodegroup_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "nodeid": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "response_digital_objects",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "a535a235-8481-11ea-a6b9-f875a44e0e11",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Digital Object",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "RespFiles",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
                     "is_collector": false,
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Send Papers",
-                    "nodegroup_id": "93199292-fb24-11ee-838d-0242ac190006",
-                    "nodeid": "ff42f8f2-3e93-11ef-9023-0242ac140007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E31_Document",
+                    "name": "Response Digital Objects",
+                    "nodegroup_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "nodeid": "5d401df8-5989-11ef-9d18-0242ac120006",
+                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
@@ -21914,6 +22050,33 @@
                     "sourcebranchpublication_id": "9c503f1e-06d9-11ed-ad22-acde48001122"
                 },
                 {
+                    "alias": "townland",
+                    "config": {
+                        "i18n_config": {
+                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
+                        },
+                        "options": [],
+                        "rdmCollection": "c333cc6e-9abe-9782-bfe5-085f1389c2c7"
+                    },
+                    "datatype": "concept",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "Townland",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Townland",
+                    "nodegroup_id": "083e14f2-ca61-11ee-afca-0242ac180006",
+                    "nodeid": "083fafe2-345c-11ef-a5b7-0242ac120003",
+                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "county_value",
                     "config": {
                         "rdmCollection": "763ba635-3800-324a-8d54-c1427bcaa5aa"
@@ -23036,6 +23199,29 @@
                     "nodeid": "311e0406-fb15-11ee-838d-0242ac190006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "response_files",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "semantic",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Response Files",
+                    "nodegroup_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "nodeid": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },
@@ -25374,6 +25560,40 @@
                     "nodeid": "5c05ae64-031a-11ef-8ec2-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "response_digital_objects",
+                    "config": {
+                        "graphs": [
+                            {
+                                "graphid": "a535a235-8481-11ea-a6b9-f875a44e0e11",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Digital Object",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
+                        "searchDsl": "",
+                        "searchString": ""
+                    },
+                    "datatype": "resource-instance-list",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": "RespFiles",
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Response Digital Objects",
+                    "nodegroup_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "nodeid": "5d401df8-5989-11ef-9d18-0242ac120006",
+                    "ontologyclass": "http://www.ics.forth.gr/isl/CRMdig/D1_Digital_Object",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },
@@ -27789,6 +28009,47 @@
                     "name": "Consultation Metatype",
                     "nodegroup_id": "771bb1e2-8895-11ea-8446-f875a44e0e11",
                     "nodeid": "976c86a4-9528-11ea-b735-f875a44e0e11",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "response_team_files",
+                    "config": {
+                        "i18n_config": {
+                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
+                        },
+                        "options": [
+                            {
+                                "id": "761b9622-3c45-4e78-9f7b-241ffd0f5ec1",
+                                "selected": false,
+                                "text": {
+                                    "en": "HM"
+                                }
+                            },
+                            {
+                                "id": "b66e5025-7695-43b3-b931-e67f1222ec43",
+                                "selected": false,
+                                "text": {
+                                    "en": "HB"
+                                }
+                            }
+                        ]
+                    },
+                    "datatype": "domain-value",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Response Team Files",
+                    "nodegroup_id": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                    "nodeid": "983d73b0-5989-11ef-af2d-0242ac120006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
@@ -31154,14 +31415,46 @@
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "send_papers",
+                    "config": {
+                        "falseLabel": {
+                            "en": "No"
+                        },
+                        "i18n_properties": [
+                            "trueLabel",
+                            "falseLabel"
+                        ],
+                        "trueLabel": {
+                            "en": "Yes"
+                        }
+                    },
+                    "datatype": "boolean",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Send Papers",
+                    "nodegroup_id": "93199292-fb24-11ee-838d-0242ac190006",
+                    "nodeid": "ff42f8f2-3e93-11ef-9023-0242ac140007",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E31_Document",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
                 }
             ],
             "ontology_id": "e6e8db47-2ccf-11e6-927e-b8f6b115d7dd",
             "publication": {
                 "graph_id": "8d41e49e-a250-11e9-9eab-00224800b26d",
                 "notes": null,
-                "publicationid": "53465862-3dfa-11ef-b4d7-0242ac120006",
-                "published_time": "2024-07-09T13:51:22.001"
+                "publicationid": "e1067d62-5989-11ef-af2d-0242ac120006",
+                "published_time": "2024-08-13T15:36:59.246"
             },
             "relatable_resource_model_ids": [],
             "resource_2_resource_constraints": [],
@@ -31197,6 +31490,6 @@
         "db": "PostgreSQL 12.2 (Debian 12.2-2.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit",
         "git hash": "f8671a0bd 2024-06-18 14:23:46 +0100",
         "os": "Linux",
-        "os version": "6.8.0-36-generic"
+        "os version": "6.1.0-22-amd64"
     }
 }

--- a/coral/plugins/hb-planning-consultation-response-workflow.json
+++ b/coral/plugins/hb-planning-consultation-response-workflow.json
@@ -190,8 +190,12 @@
                   "graphid": "a535a235-8481-11ea-a6b9-f875a44e0e11",
                   "nodegroupid": "7db68c6c-8490-11ea-a543-f875a44e0e11",
                   "resourceModelId": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
-                  "fileObjectNamePrefix": "Response files for ",
-                  "resourceModelDigitalObjectNodeGroupId": "b3addca4-8882-11ea-acc1-f875a44e0e11"
+                  "fileObjectNamePrefix": "HB Response files for ",
+                  "resourceModelDigitalObjectNodeGroupId": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                  "resourceModelDigitalObjectNodeId": "5d401df8-5989-11ef-9d18-0242ac120006",
+                  "prefilledNodes": [
+                    ["983d73b0-5989-11ef-af2d-0242ac120006", "b66e5025-7695-43b3-b931-e67f1222ec43"]
+                  ]
                 },
                 "tilesManaged": "one",
                 "componentName": "related-document-upload",

--- a/coral/plugins/hm-planning-consultation-response-workflow.json
+++ b/coral/plugins/hm-planning-consultation-response-workflow.json
@@ -201,8 +201,12 @@
                   "graphid": "a535a235-8481-11ea-a6b9-f875a44e0e11",
                   "nodegroupid": "7db68c6c-8490-11ea-a543-f875a44e0e11",
                   "resourceModelId": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
-                  "fileObjectNamePrefix": "Response files for ",
-                  "resourceModelDigitalObjectNodeGroupId": "b3addca4-8882-11ea-acc1-f875a44e0e11"
+                  "fileObjectNamePrefix": "HM Response files for ",
+                  "resourceModelDigitalObjectNodeGroupId": "31e5ece6-5989-11ef-af2d-0242ac120006",
+                  "resourceModelDigitalObjectNodeId": "5d401df8-5989-11ef-9d18-0242ac120006",
+                  "prefilledNodes": [
+                    ["983d73b0-5989-11ef-af2d-0242ac120006", "761b9622-3c45-4e78-9f7b-241ffd0f5ec1"]
+                  ]
                 },
                 "tilesManaged": "one",
                 "componentName": "related-document-upload",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=1, patch=8)
+APP_VERSION = semantic_version.Version(major=5, minor=1, patch=9)
 
 GROUPINGS = {
     "groups": {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=1, patch=7)
+APP_VERSION = semantic_version.Version(major=5, minor=1, patch=8)
 
 GROUPINGS = {
     "groups": {

--- a/coral/views/open_workflow.py
+++ b/coral/views/open_workflow.py
@@ -62,6 +62,26 @@ class OpenWorkflow(View):
                         workflow_step_data[step_name]["componentIdLookup"][
                             unique_instance_name
                         ] = data_lookup_id
+
+
+                        related_document_nodegroup_id = component_config[
+                            "parameters"
+                        ].get(
+                            "resourceModelDigitalObjectNodeGroupId", None
+                        )
+                        related_document_upload_node_id = component_config[
+                            "parameters"
+                        ].get(
+                            "resourceModelDigitalObjectNodeId", related_document_nodegroup_id
+                        )
+
+                        related_document_upload = None
+                        if related_document_nodegroup_id:
+                            related_document_upload = {
+                                "nodegroup_id": related_document_nodegroup_id,
+                                "node_id": related_document_upload_node_id
+                            }
+
                         step_mapping.append(
                             {
                                 "unique_instance_name": unique_instance_name,
@@ -71,11 +91,7 @@ class OpenWorkflow(View):
                                 "tiles_managed": component_config["tilesManaged"],
                                 "data_lookup_id": data_lookup_id,
                                 "required_parent_tiles": required_parent_tiles,
-                                "related_document_upload_id": component_config[
-                                    "parameters"
-                                ].get(
-                                    "resourceModelDigitalObjectNodeGroupId", None
-                                ),  # Special case for the related-document-upload component
+                                "related_document_upload": related_document_upload,  # Special case for the related-document-upload component
                             }
                         )
         return workflow_step_data, step_mapping
@@ -233,6 +249,11 @@ class OpenWorkflow(View):
         ASSIGNMENT_TEAM_HM = 'e377b8a9-ced0-4186-84ff-0b5c3ece9c78'
         ASSIGNMENT_TEAM_HB = '18b628c9-149f-4c37-bc27-e8e0d714a037'
 
+        RESPONSE_FILES_NODEGROUP = '31e5ece6-5989-11ef-af2d-0242ac120006'
+        RESPONSE_FILES_TEAM_NODE = '983d73b0-5989-11ef-af2d-0242ac120006'
+        RESPONSE_FILES_TEAM_HM = '761b9622-3c45-4e78-9f7b-241ffd0f5ec1'
+        RESPONSE_FILES_TEAM_HB = 'b66e5025-7695-43b3-b931-e67f1222ec43'
+
         response_tiles = self.grouped_tiles.get(RESPONSE_ACTION_NODEGROUP, [])
         remove_ids = []
         for tile in response_tiles:
@@ -254,6 +275,17 @@ class OpenWorkflow(View):
                 remove_ids.append(tile.tileid)
                 continue
         self.grouped_tiles[ASSIGNMENT_NODEGROUP] = list(filter(lambda tile: tile.tileid not in remove_ids, assignment_tiles))
+
+        response_files_tiles = self.grouped_tiles.get(RESPONSE_FILES_NODEGROUP, [])
+        remove_ids = []
+        for tile in response_files_tiles:
+            if tile.data[RESPONSE_FILES_TEAM_NODE] == RESPONSE_FILES_TEAM_HM and self.workflow_slug == HB_RESPONSE_SLUG:
+                remove_ids.append(tile.tileid)
+                continue
+            if tile.data[RESPONSE_FILES_TEAM_NODE] == RESPONSE_FILES_TEAM_HB and self.workflow_slug == HM_RESPONSE_SLUG:
+                remove_ids.append(tile.tileid)
+                continue
+        self.grouped_tiles[RESPONSE_FILES_NODEGROUP] = list(filter(lambda tile: tile.tileid not in remove_ids, response_files_tiles))
 
     def setup_designation(self):
         REVISION_APPROVALS_NODEGROUP_ID = "3c51740c-dbd0-11ee-8835-0242ac120006"
@@ -377,21 +409,21 @@ class OpenWorkflow(View):
             data_lookup_id = map_data["data_lookup_id"]
             tiles = self.grouped_tiles.get(nodegroup_id, [])
 
-            if map_data["related_document_upload_id"]:
-                nodegroup_id = map_data["related_document_upload_id"]
+            if map_data["related_document_upload"]:
+                # If this path is followed we're using a digital object tile instead of
+                # a tile from the resource we are actually accessing
+                nodegroup_id = map_data["related_document_upload"]['nodegroup_id']
+                node_id = map_data["related_document_upload"]['node_id']
                 tiles = self.grouped_tiles.get(nodegroup_id, [])
 
                 if not len(tiles):
                     continue
 
-                if not len(tiles[0].data.get(nodegroup_id)):
+                if not len(tiles[0].data.get(node_id)):
                     continue
 
-                # This expects that you are using a digital object nodegroup with a single
-                # level nodegroup. It must not be nested within a nodegroup so that the nodegroup
-                # ids are identical.
                 digital_object_resource_id = (
-                    tiles[0].data.get(nodegroup_id)[0].get("resourceId")
+                    tiles[0].data.get(node_id)[0].get("resourceId")
                 )
 
                 DIGITAL_OBJECT_NODEGROUP_ID = "7db68c6c-8490-11ea-a543-f875a44e0e11"

--- a/coral/views/open_workflow.py
+++ b/coral/views/open_workflow.py
@@ -412,18 +412,18 @@ class OpenWorkflow(View):
             if map_data["related_document_upload"]:
                 # If this path is followed we're using a digital object tile instead of
                 # a tile from the resource we are actually accessing
-                nodegroup_id = map_data["related_document_upload"]['nodegroup_id']
-                node_id = map_data["related_document_upload"]['node_id']
-                tiles = self.grouped_tiles.get(nodegroup_id, [])
+                related_document_upload_nodegroup_id = map_data["related_document_upload"]['nodegroup_id']
+                related_document_upload_node_id = map_data["related_document_upload"]['node_id']
+                tiles = self.grouped_tiles.get(related_document_upload_nodegroup_id, [])
 
                 if not len(tiles):
                     continue
 
-                if not len(tiles[0].data.get(node_id)):
+                if not len(tiles[0].data.get(related_document_upload_node_id)):
                     continue
 
                 digital_object_resource_id = (
-                    tiles[0].data.get(node_id)[0].get("resourceId")
+                    tiles[0].data.get(related_document_upload_node_id)[0].get("resourceId")
                 )
 
                 DIGITAL_OBJECT_NODEGROUP_ID = "7db68c6c-8490-11ea-a543-f875a44e0e11"


### PR DESCRIPTION
**Description**

Separates the file uploads for the HB and HM response workflows to prevent them accessing each others files or accidentally deleting them.

**Tests**
- Create a new Planning Consultation
- Goto Action and assign it to both teams
- Open up the HM workflow for that Consultation and navigate to the file upload
- Upload a file
- Check the consultation model for "Response Files" and confirm that a HM Response Files exists on the model
- Open up the HB workflow for that Consultation and navigate to the file upload
- Upload a different file to the HM workflow
- Check the consultation model for "Response Files" and confirm that a HB Response Files exists on the model
- Now re-open the HM response
- The workflow should load correctly and display the file that you submitted
- Upload another file with your original
- Confirm the resource model reflects the change
- Re-open HM response one more time just to confirm your always selecting the right tile to load into the workflow
- Repeat last 5 steps for the HB response workflow