### PR TITLE
Fix(#2201): mark form dirty after setting today's date

### DIFF
--- a/coral/media/js/views/components/widgets/datepicker.js
+++ b/coral/media/js/views/components/widgets/datepicker.js
@@ -116,6 +116,7 @@ define([
         const tileData = JSON.parse(self.tile._tileData());
         tileData[this.node.id] = today.toLocaleDateString('en-CA');
         self.tile._tileData(koMapping.toJSON(tileData));
+        this.form.dirty(true);
       }
     }
 

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=0, patch=7)
+APP_VERSION = semantic_version.Version(major=5, minor=1, patch=7)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
**Description**

Error was found on the merge workflow but it applies to all dates that are defaulted with today's date. A good double check of the other places dates have been used is needed.

**Tests**
- Open merge workflow
- Get to the Approval step
- You should see a date populated with today's date
- The save button should be visible
- Click save take the MRT reference and search for it
- IN time-spans on the matching model you should see today's date that you saved
- Start a new merge workflow and provide a different date
- Should be the same outcome on the model
- Try the date widgets on the Licensing workflow Application Details step
- Try the multi tile date widgets on the Licensing workflow Communcations step