### PR TITLE
Fix(Taiga #2280): fmw inspection display b file

### DIFF
--- a/coral/media/js/views/components/workflows/fmw-workflow/get-selected-monument-details.js
+++ b/coral/media/js/views/components/workflows/fmw-workflow/get-selected-monument-details.js
@@ -53,7 +53,7 @@ define([
 
     this.tile.data['58a2b98f-a255-11e9-9a30-00224800b26d'].subscribe((value) => {
       if (value && value.length) {
-        currentResources = value.map(t => t.resourceId())
+        currentResources = value.map(t => ko.unwrap(t.resourceId))
         currentResources.forEach(id => {
           this.cards({...this.cards(), [id] : {
             designationType : "",

--- a/coral/media/js/views/components/workflows/fmw-workflow/get-selected-monument-details.js
+++ b/coral/media/js/views/components/workflows/fmw-workflow/get-selected-monument-details.js
@@ -26,6 +26,9 @@ define([
     this.TOWNLAND_NODEGROUP = '87d38725-f44f-11eb-8d4b-a87eeabdefba';
     this.TOWNLAND_NODE = '87d3c3ea-f44f-11eb-b532-a87eeabdefba';
 
+    this.BFILE_NODEGROUP = "4e6c2d46-1f3f-11ef-ac74-0242ac150006";
+    this.BFILE_NODE = "72331a22-4ff1-11ef-a810-0242ac120009";
+
     this.labels = params.labels || [];
 
     this.selectedMonument = ko.observable();
@@ -34,7 +37,10 @@ define([
     this.monumentName = ko.observable();
     this.cmNumber = ko.observable();
     this.smrNumber = ko.observable();
+    this.bFile = ko.observable();
     this.townlandValue = ko.observable();
+
+    const self = this
 
     this.form
       .card()
@@ -77,6 +83,35 @@ define([
 
         if (tile.nodegroup === this.CM_REFERENCE_NODEGROUP) {
           this.cmNumber(tile.data[this.CM_REFERENCE_NODE].en.value);
+        }
+
+        if (tile.nodegroup === this.BFILE_NODEGROUP) {
+          console.log("B FILE TILE", tile)
+          let bfileIds = tile.data[this.BFILE_NODE].map(t => t.resourceId)
+          let bfiles = []
+          bfileIds.forEach(async id => {
+            console.log("searching...", id)
+            console.log(arches.urls.api_resource_report(id))
+            const response = await $.ajax({
+              type: 'GET',
+              url: arches.urls.api_resource_report(id),
+              context: self,
+              success: async function (responseJSON, status, response) {
+                self.bFile(self.bFile() ? `${self.bFile()},\n${responseJSON.report_json["Display Name"]["Display Name Value"]}`: responseJSON.report_json["Display Name"]["Display Name Value"])
+              },
+              error: function (response, status, error) {
+                if (response.statusText !== 'abort') {
+                  this.viewModel.alert(
+                    new AlertViewModel(
+                      'ep-alert-red',
+                      arches.requestFailed.title,
+                      response.responseText
+                    )
+                  );
+                }
+              }
+            });
+          })
         }
 
         if (tile.nodegroup === this.DESIGNATIONS_NODEGROUP) {

--- a/coral/plugins/fmw-inspection-workflow.json
+++ b/coral/plugins/fmw-inspection-workflow.json
@@ -49,7 +49,7 @@
             "componentConfigs": [
               {
                 "parameters": {
-                  "labels": [["Monument or Area", "SMR Number"]],
+                  "labels": [["Monument or Area", "SMR Number(s)"]],
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['start-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "58a2b98f-a255-11e9-9a30-00224800b26d"
@@ -57,16 +57,6 @@
                 "tilesManaged": "one",
                 "componentName": "get-selected-monument-details",
                 "uniqueInstanceName": "monument-select"
-              },
-              {
-                "parameters": {
-                  "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
-                  "nodegroupid": "e85f6714-24cc-11ef-a3a4-0242ac130006",
-                  "resourceid": "['start-step']['system-reference'][0]['resourceid']['resourceInstanceId']"
-                },
-                "tilesManaged": "one",
-                "componentName": "default-card",
-                "uniqueInstanceName": "38e300d3-20d8-4b58-8b77-3bed76a28e29"
               },
               {
                 "parameters": {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=0, patch=5)
+APP_VERSION = semantic_version.Version(major=5, minor=0, patch=6)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/workflows/fmw-workflow/get-selected-monument-details.htm
+++ b/coral/templates/views/components/workflows/fmw-workflow/get-selected-monument-details.htm
@@ -1,6 +1,5 @@
 {% load i18n %}
 <!-- ko foreach: { data: [$data], as: 'self' } -->
-
 <!-- ko if: state === 'editor-tree' && self.card.model.visible() -->
 {% block editor_tree %}
 <li role="treeitem card-treeitem" class="jstree-node" data-bind="css: {'jstree-open': (card.tiles().length > 0 && card.expanded()), 'jstree-closed' : (card.tiles().length > 0 && !card.expanded()), 'jstree-leaf': card.tiles().length === 0, 'hide-background': !self.showGrid()}, scrollTo: card.scrollTo, container: '.resource-editor-tree'">
@@ -322,6 +321,8 @@
                             tile: self.tile,
                             form: self.form,
                             config: widget.configJSON,
+                            allowInstanceCreation: false,
+                            searchString: "/search?paging-filter=1&tiles=true&format=tilecsv&reportlink=false&precision=6&total=16472&advanced-search=%5B%7B%22op%22%3A%22and%22%2C%22158e1ed2-3aae-11ef-a2d0-0242ac120003%22%3A%7B%22op%22%3A%22not_null%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%2C%221de9abf0-3aae-11ef-91fd-0242ac120003%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%2C%22250002fe-3aae-11ef-91fd-0242ac120003%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%2C%222c2d02fc-3aae-11ef-91fd-0242ac120003%22%3A%7B%22op%22%3A%22~%22%2C%22lang%22%3A%22en%22%2C%22val%22%3A%22%22%7D%7D%5D",
                             label: widget.label(),
                             inResourceEditor: self.inResourceEditor,
                             value: self.tile.data[widget.node_id()],
@@ -356,6 +357,10 @@
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">Townland</span>
                         <span data-bind="text: townlandValue" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                    </div>
+                    <div style="display: flex; flex-direction: column; gap: 4px">
+                        <span style="font-weight: bold; font-size: 14px">B File</span>
+                        <span data-bind="text: bFile" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                 </div>
                 <!-- /ko -->

--- a/coral/templates/views/components/workflows/fmw-workflow/get-selected-monument-details.htm
+++ b/coral/templates/views/components/workflows/fmw-workflow/get-selected-monument-details.htm
@@ -359,7 +359,7 @@
                         <span data-bind="text: cards()[monument].townlandValue" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
-                        <span style="font-weight: bold; font-size: 14px">B File</span>
+                        <span style="font-weight: bold; font-size: 14px">B File(s)</span>
                         <span data-bind="text: cards()[monument].bFile" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div> 
                 </div>

--- a/coral/templates/views/components/workflows/fmw-workflow/get-selected-monument-details.htm
+++ b/coral/templates/views/components/workflows/fmw-workflow/get-selected-monument-details.htm
@@ -336,32 +336,32 @@
                 }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}
             }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible'></div>
                 </div>
-                <!-- ko if: selectedMonument() -->
+                <!-- ko foreach: { data: selectedMonuments(), as: 'monument', noChildContext: true } -->
                 <div  style="max-width: 600px !important; background: #eee; padding: 8px; border-radius: 6px; margin: 10px 5px 25px 5px; display: flex; flex-direction: column; gap: 12px">
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">SMR Number</span>
-                        <span data-bind="text: smrNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                        <span data-bind="text: cards()[monument].smrNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">CM Number</span>
-                        <span data-bind="text: cmNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                        <span data-bind="text: cards()[monument].cmNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">Monument Name</span>
-                        <span data-bind="text: monumentName" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                        <span data-bind="text: cards()[monument].monumentName" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">Designation Type</span>
-                        <span data-bind="text: designationType" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                        <span data-bind="text: cards()[monument].designationType" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">Townland</span>
-                        <span data-bind="text: townlandValue" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                        <span data-bind="text: cards()[monument].townlandValue" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">B File</span>
-                        <span data-bind="text: bFile" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
-                    </div>
+                        <span data-bind="text: cards()[monument].bFile" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                    </div> 
                 </div>
                 <!-- /ko -->
             </form>


### PR DESCRIPTION
[Taiga #2280](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2280)

Changes in this PR:
- Added a Search String to the resource select to only include Monuments with an SMR
- Added `allowInstanceCreation: false` to the resource select to restrict users (this allowed new HA's without an SMR to be selected)
- Change label from "SMR Number" to "SMR Number(s)" to highlight that multiple can be selected
- Change the "SMR" field of the additional information card to show SMR number rather than HA number
- Change the "Townland" field of the additional information card  to use the Townland node in the Addresses nodegroup rather than the administritive localities node group
- Adds a "B File(s)" field the the additional information card
- Removes the consultation's "B File" Node from rendering on the workflow
- Allows additional information card to render from a pre-filled value when re-opening workflow
- Allows multiple additional information cards to be displayed at once
- Makes additional information cards disappear when their respective resource is unselected


## Test
To test stop all containers and do a `make webpack`
then follow the agreed test criteria on [Taiga #2280](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2280)
If you notice gaps in the testing please update the description.

Thank you!