### PR TITLE
Feat/2314 move merge submit onto its own page

### DIFF
--- a/coral/media/js/views/components/plugins/merge-workflow.js
+++ b/coral/media/js/views/components/plugins/merge-workflow.js
@@ -85,7 +85,7 @@ define([
           informationboxdata: {
             displayed: true,
             heading: 'Geometry Locations',
-            text: "Red represents the base resource. Blue represents the merge resource."
+            text: 'Red represents the base resource. Blue represents the merge resource.'
           },
           layoutSections: [
             {
@@ -96,7 +96,7 @@ define([
                   tilesManaged: 'none',
                   parameters: {
                     baseResourceId: "['search-step']['base-record'][0]['selectedResourceId']",
-                    mergeResourceId: "['merging-step']['merge-record'][0]['selectedResourceId']",
+                    mergeResourceId: "['merging-step']['merge-record'][0]['selectedResourceId']"
                   }
                 }
               ]
@@ -163,7 +163,7 @@ define([
           name: 'approval-step',
           required: true,
           workflowstepclass: 'workflow-form-component',
-          saveWithoutProgressing: true,
+          hiddenWorkflowButtons: ['undo'],
           layoutSections: [
             {
               componentConfigs: [
@@ -199,7 +199,24 @@ define([
                     resourceid:
                       "['information-step']['notes'][0]['resourceid']['resourceInstanceId']"
                   }
-                },
+                }
+              ]
+            }
+          ]
+        },
+        {
+          title: 'Submit Merge',
+          name: 'submit-merge-step',
+          required: true,
+          workflowstepclass: 'workflow-form-component',
+          hiddenWorkflowButtons: ['save', 'undo'],
+          informationboxdata: {
+            heading: 'WARNING: Process Description',
+            text: 'The merge process involves taking the values from the Merge Resource and applying them to the Base Resource. Single values from the Base Resource won\'t be overwritten by the Merge Resource (Base Resource takes precedence). This process cannot easily be undone please confirm you are happy with your decision.'
+          },
+          layoutSections: [
+            {
+              componentConfigs: [
                 {
                   componentName: 'submit-merge',
                   uniqueInstanceName: 'approval',

--- a/coral/media/js/views/components/workflows/merge-workflow/submit-merge.js
+++ b/coral/media/js/views/components/workflows/merge-workflow/submit-merge.js
@@ -11,6 +11,21 @@ define([
   function viewModel(params) {
     console.log('submit-merge params: ', params);
 
+    this.configKeys = ko.observable({ placeholder: 0 });
+
+    this.checkboxOptions = ko.observable([
+      {
+        text: '',
+        id: 'acknowledged'
+      }
+    ]);
+
+    this.selectedCheckboxOptions = ko.observableArray();
+
+    this.hasAcknowledgedProcess = ko.computed(() => {
+      return !!this.selectedCheckboxOptions().includes('acknowledged');
+    }, this);
+
     this.submitMerge = async () => {
       console.log('submitting merge');
 
@@ -37,7 +52,9 @@ define([
             'Merge process has STARTED',
             'You can now safely save and exit the workflow. Be aware that these two resources are in the process of merging which can take up to 5 minutes to complete.',
             null,
-            function () {}
+            function () {
+              window.window.location = arches.urls.plugin('init-workflow');
+            }
           )
         );
       } catch (e) {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=2, patch=10)
+APP_VERSION = semantic_version.Version(major=5, minor=3, patch=10)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/workflows/merge-workflow/submit-merge.htm
+++ b/coral/templates/views/components/workflows/merge-workflow/submit-merge.htm
@@ -11,7 +11,7 @@
                 configKeys: configKeys
           },
           config: {
-                label: 'By checking this box below you are acknowleding the process you are about to begin. At this point you should double check your work and confirm you are complete.',
+                label: 'By checking this box below you are acknowledging the process you are about to begin. At this point you should double check your work and confirm you are complete.',
                 options: checkboxOptions,
             },
             value: selectedCheckboxOptions,

--- a/coral/templates/views/components/workflows/merge-workflow/submit-merge.htm
+++ b/coral/templates/views/components/workflows/merge-workflow/submit-merge.htm
@@ -1,10 +1,33 @@
-<div class="card-component" style="width: 100%">
-  <div class="row widget-wrapper">
-    <button
-      data-bind="click: () => submitMerge()"
-      class="btn btn-success"
-    >
-      <span>Submit</span>
-    </button>
+<div class="card-component">
+  <div class="card">
+    <div class="widgets">
+      <div class="row widget-wrapper">
+        <domain-checkbox-widget
+          params="
+            node: {
+                config: {
+                    options: checkboxOptions,
+                },
+                configKeys: configKeys
+          },
+          config: {
+                label: 'By checking this box below you are acknowleding the process you are about to begin. At this point you should double check your work and confirm you are complete.',
+                options: checkboxOptions,
+            },
+            value: selectedCheckboxOptions,
+            loading: false,
+            pageVm: $root
+          "
+        ></domain-checkbox-widget>
+      </div>
+      <div class="row widget-wrapper">
+        <button
+          data-bind="click: () => submitMerge(), disable: !hasAcknowledgedProcess()"
+          class="btn btn-success"
+        >
+          <span>Submit</span>
+        </button>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
**Description**

Merge submit button has been moved onto a separate page and has multiple explanations and an acknowledgement checkbox.

**Tests**
- Create 2 new monuments manually or using the add monument workflow
- Open merge workflow
- Select one of those monuments for the first step
- Select the other for the second step
- Move to the information page
- Fill in the notes text with something
- You should be redirected to the submit merge step
- You should see a banner with further explainations
- There should be an acknowledgement checkbox
- If you click the checkbox the button should un-disable
- If you uncheck the checkbox it should re-disable
- Check the checkbox and then click submit
- a blue banner will appear
- Click ok and you should be kicked out of the workflow
- Next check that the merge has completed successfully by searching for the resource you selected on the first page