### PR TITLE
Fix(#2158 | #2151 | #2247 | open-excavation-site-visit-workflow): excavation site visit licence is read only

### DIFF
--- a/coral/media/js/views/components/plugins/open-excavation-site-visit-workflow.js
+++ b/coral/media/js/views/components/plugins/open-excavation-site-visit-workflow.js
@@ -1,0 +1,121 @@
+define([
+    'jquery',
+    'knockout',
+    'knockout-mapping',
+    'arches',
+    'uuid',
+    'viewmodels/open-workflow',
+    'templates/views/components/plugins/open-excavation-site-visit-workflow.htm'
+  ], function ($, ko, koMapping, arches, uuid, OpenWorkflow, pageTemplate) {
+    const openWorkflowViewModel = function (params) {
+      OpenWorkflow.apply(this, [params]);
+      this.OPEN_WORKFLOW_CONFIG = 'open-workflow-config';
+  
+      this.incidentTiles = ko.observableArray();
+      this.selectedActivity = ko.observable();
+  
+      this.configKeys = ko.observable({ placeholder: 0 });
+  
+      this.addtionalConfigData = ko.observable({
+        parentTileIds: {},
+        activityId: [{}],
+        resourceInstanceId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+      });
+  
+      this.parentTileOptions = ko.observableArray();
+
+      this.fetchTileData = async (resourceId) => {
+        const tilesResponse = await window.fetch(
+          arches.urls.resource_tiles.replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', resourceId)
+        );
+        const data = await tilesResponse.json();
+        return data.tiles;
+      };
+  
+      this.searchSiteVisits = async (resourceId) => {
+        console.log("searching", resourceId)
+        const searchResponse = await window.fetch(
+            arches.urls.search_results + `?advanced-search=[{"op"%3A"and"%2C"ea059ab7-83d7-11ea-a3c4-f875a44e0e11"%3A{"op"%3A""%2C"val"%3A["${resourceId}"]}}%2C{"op"%3A"and"%2C"e7d69603-9939-11ea-9e7f-f875a44e0e11"%3A{"op"%3A"~"%2C"lang"%3A"en"%2C"val"%3A"ESV"}%2C"e7d69604-9939-11ea-baef-f875a44e0e11"%3A{"op"%3A"~"%2C"lang"%3A"en"%2C"val"%3A""}%2C"e7d69602-9939-11ea-b514-f875a44e0e11"%3A{"op"%3A"eq"%2C"val"%3A""}}]&format=json`
+        )
+        console.log("response", searchResponse)
+        const data = await searchResponse.json()
+        console.log("the data", data)
+        return data.results.hits.hits;
+      };
+  
+      this.getParentTileOptions = async (resourceId) => {
+        const tiles = await this.searchSiteVisits(resourceId);
+        console.log("Site Visit tiles", tiles)
+        this.parentTileOptions(
+          tiles.map((tile, idx) => {
+            return {
+              text: tile?._source.displayname,
+              tile: tile,
+              id: tile._id
+            };
+          })
+        );
+      };
+  
+      this.setAdditionalOpenConfigData = () => {
+        localStorage.setItem(this.OPEN_WORKFLOW_CONFIG, JSON.stringify(this.addtionalConfigData()));
+      };
+
+      this.startNew = async () => {
+        console.log("starting", JSON.stringify(this.addtionalConfigData().activityId))
+        const associatedActivity = {
+            data: {"ea059ab7-83d7-11ea-a3c4-f875a44e0e11":this.addtionalConfigData().activityId},
+            nodegroup_id: 'ea059ab7-83d7-11ea-a3c4-f875a44e0e11',
+            parenttile_id: null,
+            resourceinstance_id: "",
+            tileid: null,
+            sortorder: 0
+          };
+          console.log("about to send", associatedActivity)
+          const associatedActivityTile = await window.fetch(arches.urls.api_tiles(uuid.generate()), {
+            method: 'POST',
+            credentials: 'include',
+            body: JSON.stringify(associatedActivity),
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          });
+
+          const response = await associatedActivityTile.json()
+          console.log("here's response", JSON.stringify(response))
+          this.selectedResource(response.resourceinstance_id)
+          console.log("selected", this.selectedResource())
+      }
+  
+      this.selectedActivity.subscribe((resourceId) => {
+        console.log("selected the activity", resourceId)
+        if (!resourceId) {
+          this.parentTileOptions([]);
+          this.selectedResource(null);
+          return;
+        }
+        this.getParentTileOptions(resourceId);
+        this.addtionalConfigData()['activityId'] = [{"resourceId":resourceId}]
+        this.setAdditionalOpenConfigData()
+
+      });
+  
+      this.selectedResource.subscribe(async (resourceId) => {
+        if (!resourceId){
+            return
+        }
+        console.log("selecting ", resourceId)
+        this.addtionalConfigData()['resourceInstanceId'] = resourceId;
+        const tileData = await this.fetchTileData(resourceId)
+        console.log("resource has tiles", tileData)
+        this.incidentTiles(tileData)
+        this.setAdditionalOpenConfigData();
+      });
+    };
+  
+    return ko.components.register('open-excavation-site-visit-workflow', {
+      viewModel: openWorkflowViewModel,
+      template: pageTemplate
+    });
+  });
+  

--- a/coral/media/js/views/components/plugins/open-excavation-site-visit-workflow.js
+++ b/coral/media/js/views/components/plugins/open-excavation-site-visit-workflow.js
@@ -33,19 +33,15 @@ define([
       };
   
       this.searchSiteVisits = async (resourceId) => {
-        console.log("searching", resourceId)
         const searchResponse = await window.fetch(
             arches.urls.search_results + `?advanced-search=[{"op"%3A"and"%2C"ea059ab7-83d7-11ea-a3c4-f875a44e0e11"%3A{"op"%3A""%2C"val"%3A["${resourceId}"]}}%2C{"op"%3A"and"%2C"e7d69603-9939-11ea-9e7f-f875a44e0e11"%3A{"op"%3A"~"%2C"lang"%3A"en"%2C"val"%3A"ESV"}%2C"e7d69604-9939-11ea-baef-f875a44e0e11"%3A{"op"%3A"~"%2C"lang"%3A"en"%2C"val"%3A""}%2C"e7d69602-9939-11ea-b514-f875a44e0e11"%3A{"op"%3A"eq"%2C"val"%3A""}}]&format=json`
         )
-        console.log("response", searchResponse)
         const data = await searchResponse.json()
-        console.log("the data", data)
         return data.results.hits.hits;
       };
   
       this.getParentTileOptions = async (resourceId) => {
         const tiles = await this.searchSiteVisits(resourceId);
-        console.log("Site Visit tiles", tiles)
         this.parentTileOptions(
           tiles.map((tile, idx) => {
             return {
@@ -62,7 +58,6 @@ define([
       };
 
       this.startNew = async () => {
-        console.log("starting", JSON.stringify(this.addtionalConfigData().activityId))
         const associatedActivity = {
             data: {"ea059ab7-83d7-11ea-a3c4-f875a44e0e11":this.addtionalConfigData().activityId},
             nodegroup_id: 'ea059ab7-83d7-11ea-a3c4-f875a44e0e11',
@@ -71,7 +66,6 @@ define([
             tileid: null,
             sortorder: 0
           };
-          console.log("about to send", associatedActivity)
           const associatedActivityTile = await window.fetch(arches.urls.api_tiles(uuid.generate()), {
             method: 'POST',
             credentials: 'include',
@@ -82,13 +76,10 @@ define([
           });
 
           const response = await associatedActivityTile.json()
-          console.log("here's response", JSON.stringify(response))
           this.selectedResource(response.resourceinstance_id)
-          console.log("selected", this.selectedResource())
       }
   
       this.selectedActivity.subscribe((resourceId) => {
-        console.log("selected the activity", resourceId)
         if (!resourceId) {
           this.parentTileOptions([]);
           this.selectedResource(null);
@@ -104,10 +95,8 @@ define([
         if (!resourceId){
             return
         }
-        console.log("selecting ", resourceId)
         this.addtionalConfigData()['resourceInstanceId'] = resourceId;
         const tileData = await this.fetchTileData(resourceId)
-        console.log("resource has tiles", tileData)
         this.incidentTiles(tileData)
         this.setAdditionalOpenConfigData();
       });

--- a/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.js
+++ b/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.js
@@ -69,7 +69,6 @@ define([
       const tiles = await this.fetchTileData(resourceId);
 
       for (const tile of tiles) {
-        console.log("tile here", tile)
         if (tile.nodegroup === this.LICENCE_NUMBER_NODEGROUP) {
           this.licenceNumber(tile.data[this.LICENCE_NUMBER_NODE]?.en?.value || 'N/A');
         }

--- a/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.js
+++ b/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.js
@@ -13,7 +13,9 @@ define([
 
     this.SELECTED_LICENSE_NODEGROUP_AND_NODE = '879fc326-02f6-11ef-927a-0242ac150006';
 
-    this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE = 'a9f53f00-48b6-11ee-85af-0242ac140007';
+    this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE = 'ea059ab7-83d7-11ea-a3c4-f875a44e0e11';
+    this.SITE_NAME_NODEGROUP_AND_NODE = 'a9f53f00-48b6-11ee-85af-0242ac140007';
+
 
     this.CM_REFERENCE_NODEGROUP = 'b84fa9c6-bad2-11ee-b3f2-0242ac180006';
     this.CM_REFERENCE_NODE = 'b84fb182-bad2-11ee-b3f2-0242ac180006';
@@ -24,6 +26,9 @@ define([
     this.CONTACTS_NODEGROUP = '6d290832-5891-11ee-a624-0242ac120004';
     this.LICENSEE_NODE = '6d294784-5891-11ee-a624-0242ac120004';
 
+    this.LICENCE_NUMBER_NODEGROUP = '6de3741e-c502-11ee-86cf-0242ac180006';
+    this.LICENCE_NUMBER_NODE = '9a9e198c-c502-11ee-af34-0242ac180006';
+
     this.labels = params.labels || [];
 
     this.selectedResource = ko.observable();
@@ -31,6 +36,7 @@ define([
     this.cmNumber = ko.observable();
     this.siteName = ko.observable();
     this.licensee = ko.observable();
+    this.licenceNumber = ko.observable();
 
     this.form
       .card()
@@ -45,7 +51,7 @@ define([
 
     this.tile.data[this.SELECTED_LICENSE_NODEGROUP_AND_NODE].subscribe((value) => {
       if (value && value.length) {
-        const resourceId = value[0].resourceId();
+        const resourceId = value[0].resourceId;
         this.selectedResource(resourceId);
         this.getDetails(resourceId);
       }
@@ -63,19 +69,12 @@ define([
       const tiles = await this.fetchTileData(resourceId);
 
       for (const tile of tiles) {
+        console.log("tile here", tile)
+        if (tile.nodegroup === this.LICENCE_NUMBER_NODEGROUP) {
+          this.licenceNumber(tile.data[this.LICENCE_NUMBER_NODE]?.en?.value || 'N/A');
+        }
         if (tile.nodegroup === this.CM_REFERENCE_NODEGROUP) {
           this.cmNumber(tile.data[this.CM_REFERENCE_NODE]?.en?.value || 'N/A');
-        }
-
-        if (tile.nodegroup === this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE) {
-          const resourceId = tile.data[this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE][0].resourceId;
-          const actTiles = await this.fetchTileData(resourceId);
-          for (const actTile of actTiles) {
-            if (actTile.nodegroup === this.ACTIVITY_NAME_NODEGROUP) {
-              const siteName = actTile.data[this.ACTIVITY_NAME_NODE].en.value;
-              this.siteName(siteName);
-            }
-          }
         }
 
         if (tile.nodegroup === this.CONTACTS_NODEGROUP) {
@@ -87,6 +86,32 @@ define([
         }
       }
     };
+
+    this.findLicense = async function (siteResourceId) {
+      const tiles = await this.fetchTileData(siteResourceId)
+      for (const tile of tiles) {
+        if (tile.nodegroup === this.ACTIVITY_NAME_NODEGROUP) {
+          const siteName = tile.data[this.ACTIVITY_NAME_NODE].en.value;
+          this.siteName(siteName);
+        }
+        if (tile.nodegroup === this.SELECTED_LICENSE_NODEGROUP_AND_NODE) {
+          const preFilled = tile.data[this.SELECTED_LICENSE_NODEGROUP_AND_NODE]
+          this.selectedResource(preFilled[0].resourceId)
+          this.getDetails(preFilled[0].resourceId);
+        }
+      }
+    }
+
+    this.prepareResource = async function () {
+      const tiles = await this.fetchTileData(this.tile.resourceinstance_id)
+      for (const tile of tiles) {
+        if (tile.nodegroup === this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE) {
+          const preFilled = tile.data[this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE]
+          this.findLicense(preFilled[0].resourceId)
+        }
+      }
+    }
+    this.prepareResource()
   }
 
   ko.components.register('get-selected-license-details', {

--- a/coral/plugins/excavation-site-visit-workflow.json
+++ b/coral/plugins/excavation-site-visit-workflow.json
@@ -23,11 +23,24 @@
                     "e7d69602-9939-11ea-b514-f875a44e0e11",
                     "e7d69604-9939-11ea-baef-f875a44e0e11"
                   ],
-                  "nodegroupid": "e7d695ff-9939-11ea-8fff-f875a44e0e11"
+                  "nodegroupid": "e7d695ff-9939-11ea-8fff-f875a44e0e11",
+                  "resourceid": "['initial-step-step']['site-name'][0]['resourceid']['resourceInstanceId']"
+                },
+                "tilesManaged": "one",
+                "componentName": "default-card-util",
+                "uniqueInstanceName": "system-reference"
+              },
+              {
+                "parameters": {
+                  "graphid": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
+                  "hiddenNodes": [
+                    "ea059ab7-83d7-11ea-a3c4-f875a44e0e11"
+                  ],
+                  "nodegroupid": "ea059ab7-83d7-11ea-a3c4-f875a44e0e11"
                 },
                 "tilesManaged": "one",
                 "componentName": "workflow-builder-initial-step",
-                "uniqueInstanceName": "system-reference"
+                "uniqueInstanceName": "site-name"
               }
             ]
           }

--- a/coral/plugins/init-workflow.json
+++ b/coral/plugins/init-workflow.json
@@ -82,7 +82,7 @@
       },
       {
         "workflowid": "d1c8bdf2-11e0-4cf7-b412-c329346f4c48",
-        "slug": "open-workflow?workflow-slug=excavation-site-visit-workflow",
+        "slug": "open-excavation-site-visit-workflow?workflow-slug=excavation-site-visit-workflow",
         "name": "Excavation Site Visit",
         "icon": "fa fa-file-text",
         "bgColor": "#689480",

--- a/coral/plugins/open-excavation-site-visit-workflow.json
+++ b/coral/plugins/open-excavation-site-visit-workflow.json
@@ -1,0 +1,20 @@
+{
+    "pluginid": "ab85dfaf-0449-4295-a51f-6f61af17c239",
+    "name": "Open Excavation Site Visit Workflow",
+    "icon": "fa fa-edit",
+    "component": "views/components/plugins/open-excavation-site-visit-workflow",
+    "componentname": "open-excavation-site-visit-workflow",
+    "config": {
+      "show": false,
+      "openableWorkflows": [
+        {
+          "slug": "excavation-site-visit-workflow",
+          "name": "Excavation Site Visit",
+          "graphIds": ["076f9381-7b00-11e9-8d6b-80000b44d1d9"],
+          "hideRecents": true
+        }
+      ]
+    },
+    "slug": "open-excavation-site-visit-workflow",
+    "sortorder": 0
+  }

--- a/coral/plugins/open-workflow.json
+++ b/coral/plugins/open-workflow.json
@@ -83,13 +83,6 @@
         "searchString": "/search/resources?paging-filter=1&resource-type-filter=[{\"graphid\":\"8d41e49e-a250-11e9-9eab-00224800b26d\",\"inverted\":false}]&sort-results=asc&advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"EVM\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
       },
       {
-        "slug": "excavation-site-visit-workflow",
-        "name": "Excavation Site Visit",
-        "graphIds": ["b9e0701e-5463-11e9-b5f5-000d3ab1e588"],
-        "disableStartNew": true,
-        "searchString": "/search/resources?paging-filter=1&tiles=true&format=tilecsv&reportlink=false&precision=6&total=72&language=*&advanced-search=%5B%7B%22op%22%3A%22and%22%2C%22879fc326-02f6-11ef-927a-0242ac150006%22%3A%7B%22op%22%3A%22not_null%22%2C%22val%22%3A%22%22%7D%7D%5D"
-      },
-      {
         "slug": "add-garden-workflow",
         "name": "Add Garden",
         "graphIds": ["076f9381-7b00-11e9-8d6b-80000b44d1d9"]

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=0, patch=6)
+APP_VERSION = semantic_version.Version(major=5, minor=0, patch=7)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/plugins/open-excavation-site-visit-workflow.htm
+++ b/coral/templates/views/components/plugins/open-excavation-site-visit-workflow.htm
@@ -1,0 +1,69 @@
+  <div class="card-component" style="width: 100%">
+    <div class="row widget-wrapper">
+      <h4 data-bind="text: workflow().name"></h4>
+    </div>
+    <div class="row widget-wrapper">
+      <div
+        data-bind="component: {
+          name: 'resource-instance-select-widget',
+          params: {
+            graphids: ['b9e0701e-5463-11e9-b5f5-000d3ab1e588'],
+            config: {
+              label: 'Select Site',
+              placeholder: 'Please select the Site',
+            },
+            searchString: '/search/resources?paging-filter=1&tiles=true&format=tilecsv&reportlink=false&precision=6&total=72&language=*&advanced-search=%5B%7B%22op%22%3A%22and%22%2C%22879fc326-02f6-11ef-927a-0242ac150006%22%3A%7B%22op%22%3A%22not_null%22%2C%22val%22%3A%22%22%7D%7D%5D',
+            renderContext: 'workflow',
+            value: selectedActivity
+          }
+        }"
+      ></div>
+      <div  style="max-width: 620px !important">
+      <domain-select-widget
+        params="
+          node: {
+            config: {
+              options: parentTileOptions,
+              multiple: false
+            },
+            configKeys: configKeys
+          },
+          config: {
+            placeholder: 'Select a Site Visit or start new',
+            
+            label: 'Selected Site Visit',
+          },
+          value: selectedResource,
+          loading: false,
+          pageVm: $root
+        "
+      ></domain-select-widget>
+        </div>
+    </div>
+    <div class="row widget-wrapper" style="display: flex">
+      <!-- ko if: !workflow().disableStartNew -->
+      <button
+        class="btn btn-shim btn-labeled btn-lg fa fa-check btn-success"
+        style="min-height: 40.56px"
+        data-bind="click: async () => {
+          await startNew().then(async () => {
+            await openWorkflow()
+          });
+        }, disable: !selectedActivity()"
+      >
+        <span>Start New</span>
+      </button>
+      <!-- /ko -->
+       
+      <button
+        class="btn btn-shim btn-labeled btn-lg btn-primary"
+        style="min-height: 40.56px"
+        data-bind="click: async () => {
+          await openWorkflow();
+        }, disable: !selectedResource()"
+      >
+        <span>Open Selected</span>
+      </button>
+    </div>
+  </div>
+  

--- a/coral/templates/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.htm
+++ b/coral/templates/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.htm
@@ -329,7 +329,7 @@
                         <span data-bind="text: cmNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
-                        <span style="font-weight: bold; font-size: 14px">Licensee(s)</span>
+                        <span style="font-weight: bold; font-size: 14px">Nominated Excavation Director(s)</span>
                         <span data-bind="text: licensee" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                 </div>

--- a/coral/templates/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.htm
+++ b/coral/templates/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.htm
@@ -312,31 +312,14 @@
             {% block form_widgets %}
             <form class="widgets" style="margin-bottom: 20px;">
                 <div data-bind="foreach: {
-                        data:card.widgets, as: 'widget'
+                        data:card.widgets, as: 'widget', noChildContext: true
                     }">
-                    <div data-bind='component: {
-                        name: self.form.widgetLookup[widget.widget_id()].name,
-                        params: {
-                            widget: widget,
-                            formData: self.tile.formData,
-                            tile: self.tile,
-                            form: self.form,
-                            config: widget.configJSON,
-                            label: widget.label(),
-                            inResourceEditor: self.inResourceEditor,
-                            value: self.tile.data[widget.node_id()],
-                            node: self.form.nodeLookup[widget.node_id()],
-                            expanded: self.expanded,
-                            graph: self.form.graph,
-                            type: "resource-editor",
-                            disabled: !self.card.isWritable && !self.preview
-                        }
-                    }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
-                }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}
-            }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible'></div>
-                </div>
                 <!-- ko if: selectedResource() -->
                 <div  style="max-width: 600px !important; background: #eee; padding: 8px; border-radius: 6px; margin: 10px 5px 25px 5px; display: flex; flex-direction: column; gap: 12px">
+                    <div style="display: flex; flex-direction: column; gap: 4px">
+                        <span style="font-weight: bold; font-size: 14px">Licence Number</span>
+                        <span data-bind="text: licenceNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
+                    </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
                         <span style="font-weight: bold; font-size: 14px">Site Name</span>
                         <span data-bind="text: siteName" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
@@ -346,7 +329,7 @@
                         <span data-bind="text: cmNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
-                        <span style="font-weight: bold; font-size: 14px">Licensee</span>
+                        <span style="font-weight: bold; font-size: 14px">Licensee(s)</span>
                         <span data-bind="text: licensee" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                 </div>


### PR DESCRIPTION
[Taiga #2158](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2158)

- adds a new plugin open-excavation-site-visit-workflow
- removes logic for the excavation site visit workflow from open-workflow.json as it's not using the standard open-workflow
- open-excavation-site-visit-workflow creates a new resource and adds the "Site" activity as a related activity - this fixes [Taiga #2251](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2251)
- adds a hidden resource select to the initial step which we use to continue using the newly created resource
- removes the resource select for the licence needed to create additional displayed information
- adjusts the licensee label to licensee(s)
- re-creates the selected-licence widget to use the new open logic - this also fixes [Taiga #2247](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2247)



## Testing
stop all containers
`make webpack`
`make manage CMD="plugin register -s coral/plugins/open-excavation-site-visit-workflow.json"` - register the new plugin.
`make manage CMD="coral reload"` - other .json's have changed
follow agreed on test criteria on [Taiga #2158](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2158)
