### PR TITLE
Feat/excavation dashboard backend

### DIFF
--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -20,6 +20,9 @@ HB_GROUP = 'f240895c-edae-4b18-9c3b-875b0bf5b235'
 HM_MANAGER = '905c40e1-430b-4ced-94b8-0cbdab04bc33'
 HB_MANAGER = '9a88b67b-cb12-4137-a100-01a977335298'
 
+EXCAVATION_ADMIN_GROUP = "214900b1-1359-404d-bba0-7dbd5f8486ef"
+EXCAVATION_USER_GROUP = "751d8543-8e5e-4317-bcb8-700f1b421a90"
+
 STATUS_CLOSED = '56ac81c4-85a9-443f-b25e-a209aabed88e'
 STATUS_OPEN = 'a81eb2e8-81aa-4588-b5ca-cab2118ca8bf'
 STATUS_HB_DONE = '71765587-0286-47de-96b4-4391aa6b99ef'
@@ -115,6 +118,8 @@ class Dashboard(View):
     def select_strategy(self, groupId):
         if groupId in [PLANNING_GROUP, HM_GROUP, HB_GROUP, HM_MANAGER, HB_MANAGER]:
             return PlanningTaskStrategy()
+        elif groupId in [EXCAVATION_ADMIN_GROUP, EXCAVATION_USER_GROUP]:
+            return ExcavationTaskStrategy()
         return
 
 class TaskStrategy:


### PR DESCRIPTION
### Description
This builds the data structure for the Excavation Licence tasks.

### Test
Complete several Excavation Licence workflows and populate the following fields:
- Issue Date
- Valid Until Date
- Employing Body
- Nominated Directors (multiple)
- Classification Type

Create a new user
Add them to the Excavation Admin group as a member
Log in as the new user
Navigate to this url: "http://localhost:8000/dashboard/resources?page=1&itemsPerPage=4&sortBy=issuedate&sortOrder=asc&update=true"

Check that sort options show:
Issue Date and Valid Until

Check that the response shows a list of the recently created resources

Check that each input is filled with the data

Check the resources are organised by the issue date

Change the sortBy in the url to say validuntildate

Check that the resources are organised by the valid until date

Generate a licence number for one of the resources

Check that the licence number field updates

Check that the display name has updated to include the licence number

Add a new classification type to the many tile

Check that the report status is showing the latest classification type