### PR TITLE
Fix(#2107 | License | Monument | Monument Revision | Activity | transfer_license_function | init-workflow | excavation-site-visit-workflow | file_template | open_workflow) licence typo fix

### DIFF
--- a/coral/functions/transfer_license_function.py
+++ b/coral/functions/transfer_license_function.py
@@ -5,7 +5,7 @@ from arches.app.models import models
 from arches_orm.models import Person, Group
 import uuid
 
-TRANSFER_OF_LICENSE_NODEGROUP_ID = "6397b05c-c443-11ee-94bf-0242ac180006"
+TRANSFER_OF_LICENCE_NODEGROUP_ID = "6397b05c-c443-11ee-94bf-0242ac180006"
 FORMER_LICENSEE_FIELD_ID = "43ec68d6-c445-11ee-8be7-0242ac180006"
 NEW_LICENSEE_FIELD_ID = "ab2db0ec-c448-11ee-94bf-0242ac180006"
 
@@ -14,16 +14,16 @@ LICENSEES_NODE_ID = "6d294784-5891-11ee-a624-0242ac120004"
 
 details = {
     "functionid": "9b955a8d-64b0-4139-9470-1085d802475f",
-    "name": "Transfer License Function",
+    "name": "Transfer Licence Function",
     "type": "node",
-    "description": "Will handle re-assigning the licensees during a transfer of license ",
-    "defaultconfig": {"triggering_nodegroups": [TRANSFER_OF_LICENSE_NODEGROUP_ID]},
-    "classname": "TransferOfLicenseFunction",
+    "description": "Will handle re-assigning the licensees during a transfer of licence ",
+    "defaultconfig": {"triggering_nodegroups": [TRANSFER_OF_LICENCE_NODEGROUP_ID]},
+    "classname": "TransferOfLicenceFunction",
     "component": "",
 }
 
 
-class TransferOfLicenseFunction(BaseFunction):
+class TransferOfLicenceFunction(BaseFunction):
     def post_save(self, tile, request, context):
         resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
 
@@ -60,13 +60,13 @@ class TransferOfLicenseFunction(BaseFunction):
             )
 
         if not former_licensee_resource_id:
-            raise Exception("You must provide a Former Licensee to transfer a license.")
+            raise Exception("You must provide a Former Licensee to transfer a licence.")
         
         if former_licensee_resource_id not in original_licensee_resource_ids:
             raise Exception("You provided a Former licensee who is not part of the Nominated Excavation Directors found on the Application Details page.")
 
         if not new_licensee_resource_id:
-            raise Exception("You must provide a new Nominated Excavation Director to transfer a license.")
+            raise Exception("You must provide a new Nominated Excavation Director to transfer a licence.")
 
 
 

--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -17,20 +17,20 @@ define([
       this.componentName = 'licensing-workflow';
       this.stepConfig = [
         {
-          title: 'Initialise Excavation License',
+          title: 'Initialise Excavation Licence',
           name: 'init-step',
           required: true,
           workflowstepclass: 'workflow-form-component',
           hiddenWorkflowButtons: ['undo'],
           informationboxdata: {
             heading: 'Important Information',
-            text: 'Please note that it could take up to a minute to complete the initialisation for the License application. If something goes wrong during the process an error will be displayed to you.'
+            text: 'Please note that it could take up to a minute to complete the initialisation for the Licence application. If something goes wrong during the process an error will be displayed to you.'
           },
           layoutSections: [
             {
               componentConfigs: [
                 {
-                  componentName: 'license-initial-step',
+                  componentName: 'licence-initial-step',
                   uniqueInstanceName: 'app-id',
                   tilesManaged: 'one',
                   parameters: {
@@ -108,7 +108,7 @@ define([
                   }
                 },
                 {
-                  componentName: 'fetch-generated-license-number',
+                  componentName: 'fetch-generated-licence-number',
                   uniqueInstanceName: 'application-details',
                   tilesManaged: 'one',
                   parameters: {
@@ -314,7 +314,7 @@ define([
                   }
                 },
                 {
-                  componentName: 'fetch-generated-license-number',
+                  componentName: 'fetch-generated-licence-number',
                   uniqueInstanceName: 'grade-d-decision',
                   tilesManaged: 'one',
                   parameters: {
@@ -326,7 +326,7 @@ define([
                 },
                 {
                   componentName: 'fetch-updated-dates',
-                  uniqueInstanceName: 'license-valid-timespan',
+                  uniqueInstanceName: 'licence-valid-timespan',
                   tilesManaged: 'one',
                   parameters: {
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
@@ -336,7 +336,7 @@ define([
                   }
                 },
                 {
-                  componentName: 'fetch-generated-license-number',
+                  componentName: 'fetch-generated-licence-number',
                   uniqueInstanceName: 'application-details',
                   tilesManaged: 'one',
                   parameters: {
@@ -353,7 +353,7 @@ define([
                 },
                 {
                   componentName: 'default-card',
-                  uniqueInstanceName: 'license-number',
+                  uniqueInstanceName: 'licence-number',
                   tilesManaged: 'one',
                   parameters: {
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
@@ -424,10 +424,10 @@ define([
               componentConfigs: [
                 {
                   componentName: 'default-card',
-                  uniqueInstanceName: 'transfer-of-license',
+                  uniqueInstanceName: 'transfer-of-licence',
                   tilesManaged: 'many',
                   parameters: {
-                    title: 'Transfer of License',
+                    title: 'Transfer of Licence',
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '6397b05c-c443-11ee-94bf-0242ac180006',
                     resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
@@ -435,10 +435,10 @@ define([
                 },
                 {
                   componentName: 'default-card-util',
-                  uniqueInstanceName: 'extension-of-license',
+                  uniqueInstanceName: 'extension-of-licence',
                   tilesManaged: 'many',
                   parameters: {
-                    title: 'Extension of License',
+                    title: 'Extension of Licence',
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '69b2738e-c4d2-11ee-b171-0242ac180006',
                     resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
@@ -477,7 +477,7 @@ define([
                   /**
                    * Using custom component to handle the creation of Digital
                    * Objects that will then be automatically named and related
-                   * to the Excavation License model.
+                   * to the Excavation Licence model.
                    */
                   componentName: 'related-document-upload',
                   uniqueInstanceName: 'report-documents',
@@ -496,7 +496,7 @@ define([
         },
         {
           title: 'Summary',
-          name: 'license-complete',
+          name: 'licence-complete',
           required: false,
           informationboxdata: {
             heading: 'Workflow Complete: Review your work',
@@ -506,8 +506,8 @@ define([
             {
               componentConfigs: [
                 {
-                  componentName: 'license-final-step',
-                  uniqueInstanceName: 'license-final',
+                  componentName: 'licence-final-step',
+                  uniqueInstanceName: 'licence-final',
                   tilesManaged: 'none',
                   parameters: {
                     resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"

--- a/coral/media/js/views/components/widgets/check-open-applications.js
+++ b/coral/media/js/views/components/widgets/check-open-applications.js
@@ -17,7 +17,7 @@ define([
 
     this.applicationData = ko.observable({});
     this.totalOpenApplications = ko.observable();
-    this.totalLicenses = ko.observable();
+    this.totalLicences = ko.observable();
     this.currentState = ko.observable();
 
     this.limit = ko.observable(params.config().limit);
@@ -73,12 +73,12 @@ define([
         }
       }, true);
 
-    this.totalLicensesMessage = (resourceId) =>
+    this.totalLicencesMessage = (resourceId) =>
       ko.computed(() => {
         if (!this.applicationData()?.[resourceId]) return '';
         return `This licensee has had ${
-          this.applicationData()[resourceId].totalLicenses
-        } licenses approved.`;
+          this.applicationData()[resourceId].totalLicences
+        } licences approved.`;
       }, true);
 
     this.colour = (state) =>
@@ -111,7 +111,7 @@ define([
           resourceId: ko.unwrap(resource.resourceId),
           state: null,
           totalOpenApplications: null,
-          totalLicenses: null,
+          totalLicences: null,
           name: null
         };
       });
@@ -121,7 +121,7 @@ define([
         await Promise.all([
           new Promise(async (resolve) => {
             const result = await this.checkTotalApplications(data.resourceId);
-            applicationData[data.resourceId].totalLicenses = result;
+            applicationData[data.resourceId].totalLicences = result;
             resolve();
           }),
           new Promise(async (resolve) => {
@@ -142,7 +142,7 @@ define([
     };
 
     this.openApplicationsRequest = null;
-    this.totalLicensesRequest = null;
+    this.totalLicencesRequest = null;
     this.getNameRequest = null;
 
     this.checkOpenApplications = async (personResourceId) => {
@@ -274,7 +274,7 @@ define([
     this.checkTotalApplications = async (personResourceId) => {
       let result = null;
 
-      this.totalLicensesRequest = await $.ajax({
+      this.totalLicencesRequest = await $.ajax({
         type: 'GET',
         url: arches.urls.search_results,
         data: {
@@ -379,7 +379,7 @@ define([
         error: function (response, status, error) {
           console.log('checkTotalApplications PROMISES error');
 
-          if (this.totalLicensesRequest.statusText !== 'abort') {
+          if (this.totalLicencesRequest.statusText !== 'abort') {
             console.log(response, status, error);
             params.pageVm.alert(
               new AlertViewModel(
@@ -392,7 +392,7 @@ define([
         },
         complete: function (request, status) {
           console.log('checkTotalApplications PROMISES complete');
-          this.totalLicensesRequest = undefined;
+          this.totalLicencesRequest = undefined;
         }
       });
 
@@ -414,7 +414,7 @@ define([
           result = response.results.hits.hits?.[0]?.['_source']['displayname'];
         },
         error: function (response, status, error) {
-          if (this.totalLicensesRequest.statusText !== 'abort') {
+          if (this.totalLicencesRequest.statusText !== 'abort') {
             console.log(response, status, error);
             params.pageVm.alert(
               new AlertViewModel(

--- a/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.js
+++ b/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.js
@@ -11,7 +11,7 @@ define([
   function viewModel(params) {
     CardComponentViewModel.apply(this, [params]);
 
-    this.SELECTED_LICENSE_NODEGROUP_AND_NODE = '879fc326-02f6-11ef-927a-0242ac150006';
+    this.SELECTED_LICENCE_NODEGROUP_AND_NODE = '879fc326-02f6-11ef-927a-0242ac150006';
 
     this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE = 'ea059ab7-83d7-11ea-a3c4-f875a44e0e11';
     this.SITE_NAME_NODEGROUP_AND_NODE = 'a9f53f00-48b6-11ee-85af-0242ac140007';
@@ -49,7 +49,7 @@ define([
         });
       });
 
-    this.tile.data[this.SELECTED_LICENSE_NODEGROUP_AND_NODE].subscribe((value) => {
+    this.tile.data[this.SELECTED_LICENCE_NODEGROUP_AND_NODE].subscribe((value) => {
       if (value && value.length) {
         const resourceId = ko.unwrap(value[0].resourceId);
         this.selectedResource(resourceId);
@@ -113,7 +113,7 @@ define([
     this.prepareResource()
   }
 
-  ko.components.register('get-selected-license-details', {
+  ko.components.register('get-selected-licence-details', {
     viewModel: viewModel,
     template: template
   });

--- a/coral/media/js/views/components/workflows/heritage-asset-designation-workflow/ha-summary.js
+++ b/coral/media/js/views/components/workflows/heritage-asset-designation-workflow/ha-summary.js
@@ -2,7 +2,7 @@ define([
   'knockout',
   'views/components/workflows/summary-step',
   'templates/views/components/workflows/heritage-asset-designation-workflow/ha-summary.htm'
-], function (ko, SummaryStep, licenseFinalStepTemplate) {
+], function (ko, SummaryStep, licenceFinalStepTemplate) {
   function viewModel(params) {
     SummaryStep.apply(this, [params]);
 
@@ -67,10 +67,10 @@ define([
     this.getData = async () => {
       await this.renderResourceIds(this.resourceid, this.heritageAssetNodes);
 
-      // let digitalFileResourceIds = this.getResourceIds(this.licenseNodes.id, 'digitalFiles');
+      // let digitalFileResourceIds = this.getResourceIds(this.licenceNodes.id, 'digitalFiles');
 
       // await this.renderResourceIds(
-      //   this.getResourceIds(this.licenseNodes.id, 'associatedActivities'),
+      //   this.getResourceIds(this.licenceNodes.id, 'associatedActivities'),
       //   this.activityNodes
       // );
       // await this.renderResourceIds(
@@ -87,7 +87,7 @@ define([
 
       // this.coverLetterHtml(
       //   this.getDisplayValue(
-      //     this.licenseNodes.id,
+      //     this.licenceNodes.id,
       //     'coverLetter',
       //     '72e0fc96-53d5-11ee-844f-0242ac130008'
       //   )
@@ -101,7 +101,7 @@ define([
 
   ko.components.register('ha-summary', {
     viewModel: viewModel,
-    template: licenseFinalStepTemplate
+    template: licenceFinalStepTemplate
   });
   return viewModel;
 });

--- a/coral/media/js/views/components/workflows/licensing-workflow/fetch-generated-license-number.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/fetch-generated-license-number.js
@@ -9,7 +9,7 @@ define([
   'js-cookie'
 ], function (_, ko, koMapping, uuid, arches, componentTemplate, AlertViewModel, Cookies) {
   function viewModel(params) {
-    this.LICENSE_NUMBER_NODE = '9a9e198c-c502-11ee-af34-0242ac180006';
+    this.LICENCE_NUMBER_NODE = '9a9e198c-c502-11ee-af34-0242ac180006';
 
     this.STATUS_NODEGROUP = '4f0f655c-48cf-11ee-8e4e-0242ac140007';
     this.STATUS_NODE = 'a79fedae-bad5-11ee-900d-0242ac180006';
@@ -35,8 +35,8 @@ define([
       return data.tiles;
     };
 
-    this.fetchLicenseNumberTile = async () => {
-      const tiles = await this.fetchTileData(this.resourceId(), this.LICENSE_NUMBER_NODE);
+    this.fetchLicenceNumberTile = async () => {
+      const tiles = await this.fetchTileData(this.resourceId(), this.LICENCE_NUMBER_NODE);
 
       if (tiles.length === 1) {
         return tiles[0];
@@ -103,14 +103,14 @@ define([
       });
     };
 
-    this.storeLicenseNumberTile = async (tile) => {
+    this.storeLicenceNumberTile = async (tile) => {
       const searchParams = new URLSearchParams(window.location.search);
       const workflowId = searchParams.get('workflow-id');
 
       const history = await this.getWorkflowHistoryData(workflowId);
 
       const componentId =
-        history.stepdata['record-decision-step']['componentIdLookup']['license-number'];
+        history.stepdata['record-decision-step']['componentIdLookup']['licence-number'];
 
       await this.setToWorkflowHistory(componentId, workflowId, 'value', {
         tileData: JSON.stringify(tile.data),
@@ -120,7 +120,7 @@ define([
       });
     };
 
-    this.processLicenseNumberTile = async () => {
+    this.processLicenceNumberTile = async () => {
       let tile = null;
       switch (self.tile().nodegroup_id) {
         case this.STATUS_NODEGROUP:
@@ -151,21 +151,21 @@ define([
           break;
       }
 
-      const licenseNumberTile = await this.fetchLicenseNumberTile();
-      if (!licenseNumberTile) {
+      const licenceNumberTile = await this.fetchLicenceNumberTile();
+      if (!licenceNumberTile) {
         params.form.complete(true);
         params.form.saving(false);
         return;
       }
-      await this.storeLicenseNumberTile(licenseNumberTile);
-      const licenseNumber =
-        licenseNumberTile.data[this.LICENSE_NUMBER_NODE][arches.activeLanguage].value;
+      await this.storeLicenceNumberTile(licenceNumberTile);
+      const licenceNumber =
+        licenceNumberTile.data[this.LICENCE_NUMBER_NODE][arches.activeLanguage].value;
 
       params.pageVm.alert(
         new AlertViewModel(
           'ep-alert-blue',
-          `Application status is "Granted". License Number: ${licenseNumber}. Click "Ok" to continue.`,
-          `This application's status has been moved to "Granted". With that a license number has been genereated that will now be used to identify this application. Example 'Excavation License ${licenseNumber}', please use this to find the file in the future. The old application ID will still work on the search page.`,
+          `Application status is "Granted". Licence Number: ${licenceNumber}. Click "Ok" to continue.`,
+          `This application's status has been moved to "Granted". With that a licence number has been genereated that will now be used to identify this application. Example 'Excavation Licence ${licenceNumber}', please use this to find the file in the future. The old application ID will still work on the search page.`,
           null,
           () => {
             params.form.complete(true);
@@ -183,11 +183,11 @@ define([
         resourceInstanceId: self.tile().resourceinstance_id,
         nodegroupId: self.tile().nodegroup_id
       });
-      await this.processLicenseNumberTile();
+      await this.processLicenceNumberTile();
     };
   }
 
-  ko.components.register('fetch-generated-license-number', {
+  ko.components.register('fetch-generated-licence-number', {
     viewModel: viewModel,
     template: componentTemplate
   });

--- a/coral/media/js/views/components/workflows/licensing-workflow/fetch-updated-dates.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/fetch-updated-dates.js
@@ -9,20 +9,20 @@ define([
   ], function (_, ko, koMapping, uuid, arches, CardComponentViewModel, componentTemplate) {
     function viewModel(params) {
 
-    LICENSE_TIMESPAN_NODEGROUP_ID = "1887f678-c42d-11ee-bc4b-0242ac180006"
+    LICENCE_TIMESPAN_NODEGROUP_ID = "1887f678-c42d-11ee-bc4b-0242ac180006"
     ISSUE_DATE_NODE = "1887faf6-c42d-11ee-bc4b-0242ac180006"
     VALID_UNTIL_NODE = "1887fc86-c42d-11ee-bc4b-0242ac180006"
     
-    LICENSE_NUMBER_NODEGROUP = "6de3741e-c502-11ee-86cf-0242ac180006"
-    LICENSE_NUMBER_VALUE_NODE = "9a9e198c-c502-11ee-af34-0242ac180006"
+    LICENCE_NUMBER_NODEGROUP = "6de3741e-c502-11ee-86cf-0242ac180006"
+    LICENCE_NUMBER_VALUE_NODE = "9a9e198c-c502-11ee-af34-0242ac180006"
 
     CardComponentViewModel.apply(this, [params]);
 
-      this.hasLicenseNumber = ko.observable(false)
+      this.hasLicenceNumber = ko.observable(false)
 
       if (this.tile.data[ISSUE_DATE_NODE] && ko.isObservable(this.tile.data[ISSUE_DATE_NODE])) {
         this.tile.data[ISSUE_DATE_NODE].subscribe(issueDate => {
-          if (this.hasLicenseNumber()) return
+          if (this.hasLicenceNumber()) return
           const validUntilDate = this.addSixMonths(issueDate)
           this.tile.data[VALID_UNTIL_NODE](validUntilDate)
         })
@@ -38,28 +38,28 @@ define([
         return data.tiles;
       };
       
-      this.fetchLicenseNumberTile = async () => {
-        const tiles = await this.fetchTileData(this.tile.resourceinstance_id, LICENSE_NUMBER_NODEGROUP);
+      this.fetchLicenceNumberTile = async () => {
+        const tiles = await this.fetchTileData(this.tile.resourceinstance_id, LICENCE_NUMBER_NODEGROUP);
 
         if (tiles.length === 1){
           return tiles[0];
         }
       };
       
-      this.checkForLicenseNumberValue = async () => {
-        const licenseNumberTile = await this.fetchLicenseNumberTile()
+      this.checkForLicenceNumberValue = async () => {
+        const licenceNumberTile = await this.fetchLicenceNumberTile()
 
-        if (!licenseNumberTile) {
+        if (!licenceNumberTile) {
           return false
         }
-        if (licenseNumberTile.data[LICENSE_NUMBER_VALUE_NODE]) {
+        if (licenceNumberTile.data[LICENCE_NUMBER_VALUE_NODE]) {
           return true;
         }
         return false
       }
 
-      this.checkForLicenseNumberValue().then(result => {
-        this.hasLicenseNumber(result)
+      this.checkForLicenceNumberValue().then(result => {
+        this.hasLicenceNumber(result)
         console.log(result)
       })
 

--- a/coral/media/js/views/components/workflows/licensing-workflow/license-cover-letter.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/license-cover-letter.js
@@ -5,7 +5,7 @@ define([
   'arches',
   'templates/views/components/workflows/licensing-workflow/license-cover-letter.htm',
   // 'plugins/knockout-select2'
-], function (ko, koMapping, _, arches, licenseCoverTemplate) {
+], function (ko, koMapping, _, arches, licenceCoverTemplate) {
   function viewModel(params) {
     const self = this;
 
@@ -82,7 +82,7 @@ define([
         seniorInspectorName: ko.observable(data?.seniorInspectorName || createTextObject()),
         signedName: ko.observable(data?.signedName || createTextObject()),
         hasAdditonalFiles: ko.observable(data?.hasAdditonalFiles || false),
-        licenseNumber: ko.observable(data?.licenseNumber || ''),
+        licenceNumber: ko.observable(data?.licenceNumber || ''),
         cmReference: ko.observable(data?.cmReference || ''),
         selectedAddress: ko.observable(data?.selectedAddress || 'applicant'),
         decisionBy: {
@@ -105,12 +105,12 @@ define([
     self.coverLetterData = self.loadCoverLetterData();
 
     this.activityResourceData = ko.observable();
-    this.licenseResourceData = ko.observable();
+    this.licenceResourceData = ko.observable();
     this.actorTileData = ko.observable();
     this.actorReportData = ko.observable([]);
     this.reportVals = {};
 
-    this.licenseNo = ko.observable(createTextObject(''));
+    this.licenceNo = ko.observable(createTextObject(''));
     this.bFileNumber = ko.observable(createTextObject(''));
 
     /**
@@ -144,7 +144,7 @@ define([
         createTextObject(
           `
           <div>Dear [recipient]</div>
-          <div>Further to your application on [Date], please find attached an Excavation License for the above mentioned location.</div>
+          <div>Further to your application on [Date], please find attached an Excavation Licence for the above mentioned location.</div>
           <br />
           <div>Please note that under the terms of the Licence you must, on completion of the excavation, furnish:</div>
           <br />
@@ -190,7 +190,7 @@ define([
         .replace('[site]', self.getTextValue(self.coverLetterData.siteName) || '[site]')
         .replace('[site_address]', self.getTextValue(self.coverLetterData.addresses.site.fullAddress) || '')
         .replace('[site_county]', self.getTextValue(self.coverLetterData.addresses.site.county) || '[site_county]')
-        .replace('[licence_no]', self.getTextValue(self.coverLetterData.licenseNumber) || '[licence_no]')
+        .replace('[licence_no]', self.getTextValue(self.coverLetterData.licenceNumber) || '[licence_no]')
         .replace('[send_date]',self.coverLetterData.dates.sendDate() || '[send_date]')
         .replace('[cmref]',self.getTextValue(self.coverLetterData.cmReference())|| '[cmref]')
         .replace('[decision_by]', self.getTextValue(self.coverLetterData.decisionBy) || '[decision_by]')
@@ -220,9 +220,9 @@ define([
       <div><span>Date: [send_date]</div></span>
       </div>`
     )
-    // if (self.getTextValue(self.coverLetterData.licenseNumber)) {
+    // if (self.getTextValue(self.coverLetterData.licenceNumber)) {
     //   result += `<span>Licence Number: ${self.getTextValue(
-    //     self.coverLetterData.licenseNumber
+    //     self.coverLetterData.licenceNumber
     //   )}</span>`;
     // }
     self.getAddressValue = (value) => {
@@ -487,10 +487,10 @@ define([
     self.loadData = async () => {
       self.loading(true);
       try {
-        const licenseTiles = await self.fetchTileData(self.resourceId());
+        const licenceTiles = await self.fetchTileData(self.resourceId());
 
-        const licenseNo = self.getValueFromTiles(
-          licenseTiles,
+        const licenceNo = self.getValueFromTiles(
+          licenceTiles,
           '280b75bc-4e4d-11ee-a340-0242ac140007',
           (tile) => {
             return (
@@ -499,12 +499,12 @@ define([
             );
           }
         );
-        if (licenseNo) {
-          self.coverLetterData.licenseNumber(licenseNo.value);
+        if (licenceNo) {
+          self.coverLetterData.licenceNumber(licenceNo.value);
         }
 
         const additionalFiles = self.getValueFromTiles(
-          licenseTiles,
+          licenceTiles,
           '8c5356f4-48ce-11ee-8e4e-0242ac140007'
         );
         if (additionalFiles?.value.length) {
@@ -513,8 +513,8 @@ define([
 
 
         const contacts = [
-          self.getValueFromTiles(licenseTiles, '6d2924b6-5891-11ee-a624-0242ac120004'),
-          self.getValueFromTiles(licenseTiles, '6d292f88-5891-11ee-a624-0242ac120004')
+          self.getValueFromTiles(licenceTiles, '6d2924b6-5891-11ee-a624-0242ac120004'),
+          self.getValueFromTiles(licenceTiles, '6d292f88-5891-11ee-a624-0242ac120004')
         ];
         if (contacts?.length) {
           for (const contact of contacts) {
@@ -569,7 +569,7 @@ define([
         }
 
         const decisionByDate = self.getValueFromTiles(
-          licenseTiles,
+          licenceTiles,
           '4c58921e-48cc-11ee-9081-0242ac140007'
         );
         if (decisionByDate) {
@@ -577,7 +577,7 @@ define([
         }
 
         const decisionBy = self.getValueFromTiles(
-          licenseTiles,
+          licenceTiles,
           'f3dcbf02-48cb-11ee-9081-0242ac140007'
         );
         if (decisionBy?.value.length) {
@@ -590,7 +590,7 @@ define([
         }
 
         const associatedActivitys = self.getValueFromTiles(
-          licenseTiles,
+          licenceTiles,
           'a9f53f00-48b6-11ee-85af-0242ac140007'
         );
         if (associatedActivitys?.value.length) {
@@ -631,7 +631,7 @@ define([
         }
 
         const acknowledgedDate = self.getValueFromTiles(
-          licenseTiles,
+          licenceTiles,
           '0a914884-48b4-11ee-90a8-0242ac140007'
         );
         if (acknowledgedDate) {
@@ -639,7 +639,7 @@ define([
         }
 
         const receivedDate = self.getValueFromTiles(
-          licenseTiles,
+          licenceTiles,
           '6b96c722-48c7-11ee-ba3a-0242ac140007'
         );
         if (receivedDate) {
@@ -693,7 +693,7 @@ define([
         self.textBody(
           createTextObject(
           `<div>Dear [recipient]</div>
-          <div>Further to your application on [Date], please find attached an Excavation License for the above mentioned location.</div>
+          <div>Further to your application on [Date], please find attached an Excavation Licence for the above mentioned location.</div>
           <br />
           <div>Please note that under the terms of the Licence you must, on completion of the excavation, furnish:</div>
           <br />
@@ -733,7 +733,7 @@ define([
           } else if (temp === 'licence-extension-letter') {
             self.textBody(
               createTextObject(
-              `<div>The Department for Communities for Northern Ireland (hereinafter referred to as “the Department”), in exercise of its power under Section 41 of the above-mentioned Order, hereby extends the license of <strong>[recipient]</strong>  (hereinafter referred to as “the Licensee”) to dig or excavate for purposes of archaeological evaluation in or under part of the Townland (town) of <strong>[town]</strong> in the County of <strong>[county]</strong> being the archaeological site or reputed site known as <strong>[site]</strong>  for a further period of <strong>[duration], commencing on [valid_from] and ceasing on [valid_to].</strong></div>
+              `<div>The Department for Communities for Northern Ireland (hereinafter referred to as “the Department”), in exercise of its power under Section 41 of the above-mentioned Order, hereby extends the licence of <strong>[recipient]</strong>  (hereinafter referred to as “the Licensee”) to dig or excavate for purposes of archaeological evaluation in or under part of the Townland (town) of <strong>[town]</strong> in the County of <strong>[county]</strong> being the archaeological site or reputed site known as <strong>[site]</strong>  for a further period of <strong>[duration], commencing on [valid_from] and ceasing on [valid_to].</strong></div>
               <br />
               <div><strong>All conditions stated in the original Licence are applicable to this Extension. In addition, the Department also requires that:</strong></div>
               <br />
@@ -767,9 +767,9 @@ define([
     }
   }
 
-  ko.components.register('license-cover-letter', {
+  ko.components.register('licence-cover-letter', {
     viewModel: viewModel,
-    template: licenseCoverTemplate
+    template: licenceCoverTemplate
   });
   return viewModel;
 });

--- a/coral/media/js/views/components/workflows/licensing-workflow/license-final-step.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/license-final-step.js
@@ -2,7 +2,7 @@ define([
   'knockout',
   'views/components/workflows/summary-step',
   'templates/views/components/workflows/licensing-workflow/license-final-step.htm'
-], function (ko, SummaryStep, licenseFinalStepTemplate) {
+], function (ko, SummaryStep, licenceFinalStepTemplate) {
   function viewModel(params) {
     SummaryStep.apply(this, [params]);
 
@@ -19,9 +19,9 @@ define([
      * }
      */
 
-    this.licenseNodes = {
-      id: 'license',
-      label: 'License',
+    this.licenceNodes = {
+      id: 'licence',
+      label: 'Licence',
       contacts: {
         label: 'Contacts',
         nodegroupId: '6d290832-5891-11ee-a624-0242ac120004',
@@ -82,7 +82,7 @@ define([
       externalRef: {
         label: 'External Reference',
         nodegroupId: '280b6cfc-4e4d-11ee-a340-0242ac140007',
-        renderNodeIds: [{ nodeId: '280b75bc-4e4d-11ee-a340-0242ac140007', label: 'License Number' }]
+        renderNodeIds: [{ nodeId: '280b75bc-4e4d-11ee-a340-0242ac140007', label: 'Licence Number' }]
       },
       excavationType: {
         label: 'Excavation Type',
@@ -190,12 +190,12 @@ define([
     this.coverLetterHtml = ko.observable();
 
     this.getData = async () => {
-      await this.renderResourceIds(this.resourceid, this.licenseNodes);
+      await this.renderResourceIds(this.resourceid, this.licenceNodes);
 
-      let digitalFileResourceIds = this.getResourceIds(this.licenseNodes.id, 'digitalFiles');
+      let digitalFileResourceIds = this.getResourceIds(this.licenceNodes.id, 'digitalFiles');
 
       await this.renderResourceIds(
-        this.getResourceIds(this.licenseNodes.id, 'associatedActivities'),
+        this.getResourceIds(this.licenceNodes.id, 'associatedActivities'),
         this.activityNodes
       );
       await this.renderResourceIds(
@@ -212,21 +212,21 @@ define([
 
       this.coverLetterHtml(
         this.getDisplayValue(
-          this.licenseNodes.id,
+          this.licenceNodes.id,
           'coverLetter',
           '72e0fc96-53d5-11ee-844f-0242ac130008'
         )
       );
 
-      console.log('License Final Step: ', this.renderedNodegroups());
+      console.log('Licence Final Step: ', this.renderedNodegroups());
     };
 
     this.loadData();
   }
 
-  ko.components.register('license-final-step', {
+  ko.components.register('licence-final-step', {
     viewModel: viewModel,
-    template: licenseFinalStepTemplate
+    template: licenceFinalStepTemplate
   });
   return viewModel;
 });

--- a/coral/media/js/views/components/workflows/licensing-workflow/license-initial-step.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/license-initial-step.js
@@ -21,16 +21,16 @@ define([
 
     self.actSysRefTileId = params.form.savedData()?.actSysRefTileId;
     self.activityLocationTileId = params.form.savedData()?.activityLocationTileId;
-    self.actLicenseRelationshipTileId = params.form.savedData()?.actLicenseRelationshipTileId;
+    self.actLicenceRelationshipTileId = params.form.savedData()?.actLicenceRelationshipTileId;
     self.actResourceId = params.form.savedData()?.activityResourceId;
-    self.licenseNameTileId = params.form.savedData()?.licenseNameTileId;
+    self.licenceNameTileId = params.form.savedData()?.licenceNameTileId;
     self.decisionTileId = params.form.savedData()?.decisionTileId;
     self.applicationDetailsTileId = params.form.savedData()?.applicationDetailsTileId;
     self.cmRefTileId = params.form.savedData()?.cmRefTileId;
-    // self.licenseNumberTileId = params.form.savedData()?.licenseNumberTileId;
+    // self.licenceNumberTileId = params.form.savedData()?.licenceNumberTileId;
     self.applicationId = '';
 
-    self.licenseSysRefNodeId = '991c49b2-48b6-11ee-85af-0242ac140007';
+    self.licenceSysRefNodeId = '991c49b2-48b6-11ee-85af-0242ac140007';
 
     params.form.save = async () => {
       await self.tile().save(); // Resource ID has now been created and is in self.resourceId()
@@ -41,11 +41,11 @@ define([
        */
       self.applicationId = self
         .tile()
-        ?.data[self.licenseSysRefNodeId][arches.activeLanguage]?.value();
+        ?.data[self.licenceSysRefNodeId][arches.activeLanguage]?.value();
 
       try {
         /**
-         * Configuring the name is no longer needed as the license number
+         * Configuring the name is no longer needed as the licence number
          * function will handle it. If we configured the name from here after
          * the function we would get a cardinality error.
          */
@@ -53,7 +53,7 @@ define([
         const activityResponse = await saveActivitySystemRef();
         if (activityResponse.ok) {
           responses = await Promise.all([
-            // getLicenseRefTileId(),
+            // getLicenceRefTileId(),
             saveActivityLocation(),
             saveRelationship(),
             saveDecisionTile(),
@@ -67,14 +67,14 @@ define([
               resourceInstanceId: self.tile().resourceinstance_id,
               nodegroupId: self.tile().nodegroup_id,
               actSysRefTileId: self.actSysRefTileId,
-              actLicenseRelationshipTileId: self.actLicenseRelationshipTileId,
+              actLicenceRelationshipTileId: self.actLicenceRelationshipTileId,
               activityResourceId: self.actResourceId,
               activityLocationTileId: self.activityLocationTileId,
               decisionTileId: self.decisionTileId,
               applicationDetailsTileId: self.applicationDetailsTileId,
               cmRefTileId: self.cmRefTileId,
 
-              // licenseNumberTileId: self.licenseNumberTileId
+              // licenceNumberTileId: self.licenceNumberTileId
             });
             params.form.complete(true);
             params.form.saving(false);
@@ -116,7 +116,7 @@ define([
       }
     };
 
-    // const getLicenseRefTileId = async () => {
+    // const getLicenceRefTileId = async () => {
     //   const response = await window.fetch(
     //     arches.urls.api_resources(self.resourceId() + '?format=json&compact=false')
     //   );
@@ -124,13 +124,13 @@ define([
     //   if (response.ok) {
     //     const data = await response.json();
     //     if (data.resource['External Cross References']) {
-    //       const licenseNumberRef = data.resource['External Cross References'].find((ref) => {
+    //       const licenceNumberRef = data.resource['External Cross References'].find((ref) => {
     //         if (ref['External Cross Reference Source']['@value'] === 'Excavation') {
     //           return ref;
     //         }
     //       });
-    //       self.licenseNumberTileId =
-    //         licenseNumberRef['External Cross Reference Number']['@tile_id'];
+    //       self.licenceNumberTileId =
+    //         licenceNumberRef['External Cross Reference Number']['@tile_id'];
     //     }
     //   }
     //   return response;
@@ -221,8 +221,8 @@ define([
       }
     };
 
-    const saveLicenseName = async () => {
-      const licenseNameNode = '59d6676c-48b9-11ee-84da-0242ac140007';
+    const saveLicenceName = async () => {
+      const licenceNameNode = '59d6676c-48b9-11ee-84da-0242ac140007';
       const nameTemplate = {
         tileid: '',
         data: {
@@ -232,7 +232,7 @@ define([
           '59d665c8-48b9-11ee-84da-0242ac140007': '8a96a261-cd79-48e2-9f12-74924c152b00',
           '59d6691a-48b9-11ee-84da-0242ac140007': 'a0e096e2-f5ae-4579-950d-3040714713b4',
           '59d66df2-48b9-11ee-84da-0242ac140007': '5a88136a-bf3a-4b48-a830-a7f42000dd24',
-          [licenseNameNode]: null
+          [licenceNameNode]: null
         },
         nodegroup_id: '59d65ec0-48b9-11ee-84da-0242ac140007',
         parenttile_id: null,
@@ -240,20 +240,20 @@ define([
         sortorder: 0
       };
 
-      nameTemplate.data[licenseNameNode] = {
+      nameTemplate.data[licenceNameNode] = {
         en: {
           direction: 'ltr',
-          value: 'Excavation License ' + self.applicationId
+          value: 'Excavation Licence ' + self.applicationId
         }
       };
 
-      if (!self.licenseNameTileId) {
-        self.licenseNameTileId = uuid.generate();
+      if (!self.licenceNameTileId) {
+        self.licenceNameTileId = uuid.generate();
       } else {
-        nameTemplate.tileid = self.licenseNameTileId;
+        nameTemplate.tileid = self.licenceNameTileId;
       }
 
-      const nameTile = await window.fetch(arches.urls.api_tiles(self.licenseNameTileId), {
+      const nameTile = await window.fetch(arches.urls.api_tiles(self.licenceNameTileId), {
         method: 'POST',
         credentials: 'include',
         body: JSON.stringify(nameTemplate),
@@ -264,7 +264,7 @@ define([
 
       if (nameTile?.ok) {
         const nameTileResult = await nameTile.json();
-        self.licenseNameTileId = nameTileResult.tileid;
+        self.licenceNameTileId = nameTileResult.tileid;
         return nameTile;
       }
     };
@@ -380,7 +380,7 @@ define([
 
     const saveRelationship = async () => {
       const activityNodeNodeGroup = 'a9f53f00-48b6-11ee-85af-0242ac140007';
-      const licenseActivityTileTemplate = {
+      const licenceActivityTileTemplate = {
         tileid: '',
         data: {
           [activityNodeNodeGroup]: [
@@ -397,33 +397,33 @@ define([
         sortorder: 0
       };
 
-      if (!self.actLicenseRelationshipTileId) {
-        self.actLicenseRelationshipTileId = uuid.generate();
+      if (!self.actLicenceRelationshipTileId) {
+        self.actLicenceRelationshipTileId = uuid.generate();
       } else {
-        licenseActivityTileTemplate.tileid = self.actLicenseRelationshipTileId;
+        licenceActivityTileTemplate.tileid = self.actLicenceRelationshipTileId;
       }
 
-      const licenseTile = await window.fetch(
-        arches.urls.api_tiles(self.actLicenseRelationshipTileId),
+      const licenceTile = await window.fetch(
+        arches.urls.api_tiles(self.actLicenceRelationshipTileId),
         {
           method: 'POST',
           credentials: 'include',
-          body: JSON.stringify(licenseActivityTileTemplate),
+          body: JSON.stringify(licenceActivityTileTemplate),
           headers: {
             'Content-Type': 'application/json'
           }
         }
       );
 
-      if (licenseTile?.ok) {
-        const licenseTileResult = await licenseTile.json();
-        self.actLicenseRelationshipTileId = licenseTileResult.tileid;
-        return licenseTile;
+      if (licenceTile?.ok) {
+        const licenceTileResult = await licenceTile.json();
+        self.actLicenceRelationshipTileId = licenceTileResult.tileid;
+        return licenceTile;
       }
     };
   }
 
-  ko.components.register('license-initial-step', {
+  ko.components.register('licence-initial-step', {
     viewModel: viewModel,
     template: initialStep
   });

--- a/coral/media/js/views/components/workflows/related-document-upload.js
+++ b/coral/media/js/views/components/workflows/related-document-upload.js
@@ -151,7 +151,7 @@ define([
 
     const saveRelationship = async () => {
       /**
-       * In the example of excavation license the `Files (D1)` nodegroup
+       * In the example of excavation licence the `Files (D1)` nodegroup
        * has two identical uuids. One refers to the nodegroup and the other
        * to the node. This is used twice to provide the resource relationship.
        *

--- a/coral/pkg/graphs/resource_models/Activity.json
+++ b/coral/pkg/graphs/resource_models/Activity.json
@@ -1200,7 +1200,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "Associated License"
+                        "en": "Associated Licence"
                     },
                     "nodegroup_id": "879fc326-02f6-11ef-927a-0242ac150006",
                     "sortorder": null,
@@ -3623,11 +3623,11 @@
                     "card_id": "c59d428f-ce76-4298-82c2-14a13bae7934",
                     "config": {
                         "defaultValue": null,
-                        "label": "License Holder Present"
+                        "label": "Licence Holder Present"
                     },
                     "id": "7817ed19-feaa-46e2-bc91-ec4039944b9d",
                     "label": {
-                        "en": "License Holder Present"
+                        "en": "Licence Holder Present"
                     },
                     "node_id": "4dfe8c68-02f3-11ef-a4eb-0242ac150006",
                     "sortorder": 0,
@@ -7185,14 +7185,14 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Associated Licenses",
+                        "label": "Associated Licences",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "c05e3c87-494e-4170-9f35-613e314123cd",
                     "label": {
-                        "en": "Associated Licenses"
+                        "en": "Associated Licences"
                     },
                     "node_id": "879fc326-02f6-11ef-927a-0242ac150006",
                     "sortorder": 0,
@@ -12648,7 +12648,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "license_holder_present",
+                    "alias": "licence_holder_present",
                     "config": {
                         "falseLabel": {
                             "en": "No"
@@ -12674,7 +12674,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "License Holder Present",
+                    "name": "Licence Holder Present",
                     "nodegroup_id": "4dfe8c68-02f3-11ef-a4eb-0242ac150006",
                     "nodeid": "4dfe8c68-02f3-11ef-a4eb-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E13_Attribute_Assignment",
@@ -14031,13 +14031,13 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "associated_license",
+                    "alias": "associated_licence",
                     "config": {
                         "graphs": [
                             {
                                 "graphid": "cc5da227-24e7-4088-bb83-a564c4331efd",
                                 "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "name": "License",
+                                "name": "Licence",
                                 "relationshipCollection": "00000000-0000-0000-0000-000000000005",
                                 "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
                                 "useOntologyRelationship": false
@@ -14056,7 +14056,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Associated License",
+                    "name": "Associated Licence",
                     "nodegroup_id": "879fc326-02f6-11ef-927a-0242ac150006",
                     "nodeid": "879fc326-02f6-11ef-927a-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",

--- a/coral/pkg/graphs/resource_models/License.json
+++ b/coral/pkg/graphs/resource_models/License.json
@@ -9598,14 +9598,14 @@
                                 "id": "e36ebf43-b00e-4e12-a8a1-eb8843a0a926",
                                 "selected": false,
                                 "text": {
-                                    "en": "Do not grant licensc"
+                                    "en": "Do not grant licence"
                                 }
                             },
                             {
                                 "id": "5e82bfd8-a455-4a2b-90d2-abe5854b537a",
                                 "selected": false,
                                 "text": {
-                                    "en": "Grant licensc"
+                                    "en": "Grant licence"
                                 }
                             }
                         ]
@@ -9820,7 +9820,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "licensc_names",
+                    "alias": "licence_names",
                     "config": {
                         "en": ""
                     },
@@ -9834,7 +9834,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Licensc Names",
+                    "name": "Licence Names",
                     "nodegroup_id": "59d65ec0-48b9-11ee-84da-0242ac140007",
                     "nodeid": "59d65ec0-48b9-11ee-84da-0242ac140007",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
@@ -10025,7 +10025,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "transfer_of_licensc",
+                    "alias": "transfer_of_licence",
                     "config": {
                         "en": ""
                     },
@@ -10039,7 +10039,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Transfer of Licensc",
+                    "name": "Transfer of Licence",
                     "nodegroup_id": "6397b05c-c443-11ee-94bf-0242ac180006",
                     "nodeid": "6397b05c-c443-11ee-94bf-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E11_Modification",

--- a/coral/pkg/graphs/resource_models/License.json
+++ b/coral/pkg/graphs/resource_models/License.json
@@ -51,7 +51,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "License Number"
+                        "en": "Licence Number"
                     },
                     "nodegroup_id": "6de3741e-c502-11ee-86cf-0242ac180006",
                     "sortorder": null,
@@ -78,7 +78,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "License Valid Timespan"
+                        "en": "Licence Valid Timespan"
                     },
                     "nodegroup_id": "1887f678-c42d-11ee-bc4b-0242ac180006",
                     "sortorder": null,
@@ -159,7 +159,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "Extension of License"
+                        "en": "Extension of Licence"
                     },
                     "nodegroup_id": "69b2738e-c4d2-11ee-b171-0242ac180006",
                     "sortorder": null,
@@ -269,7 +269,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "License Names"
+                        "en": "Licence Names"
                     },
                     "nodegroup_id": "59d65ec0-48b9-11ee-84da-0242ac140007",
                     "sortorder": null,
@@ -622,7 +622,7 @@
                     },
                     "is_editable": true,
                     "name": {
-                        "en": "Transfer of License"
+                        "en": "Transfer of Licence"
                     },
                     "nodegroup_id": "6397b05c-c443-11ee-94bf-0242ac180006",
                     "sortorder": null,
@@ -4330,7 +4330,7 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "License Number Source",
+                        "label": "Licence Number Source",
                         "options": [],
                         "placeholder": {
                             "en": "Select an option"
@@ -4338,7 +4338,7 @@
                     },
                     "id": "cbaad49c-8492-49a5-95da-0533c2a9736f",
                     "label": {
-                        "en": "License Number Source"
+                        "en": "Licence Number Source"
                     },
                     "node_id": "c57348bc-c502-11ee-86cf-0242ac180006",
                     "sortorder": 1,
@@ -4673,7 +4673,7 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "License Number",
+                        "label": "Licence Number",
                         "maxLength": "",
                         "placeholder": {
                             "en": ""
@@ -4683,7 +4683,7 @@
                     },
                     "id": "e8a07826-31a0-408e-a671-0bf0dab6ad38",
                     "label": {
-                        "en": "License Number"
+                        "en": "Licence Number"
                     },
                     "node_id": "9a9e198c-c502-11ee-af34-0242ac180006",
                     "sortorder": 0,
@@ -7209,7 +7209,7 @@
             "isresource": true,
             "jsonldcontext": null,
             "name": {
-                "en": "License"
+                "en": "Licence"
             },
             "nodegroups": [
                 {
@@ -7666,14 +7666,14 @@
                                 "id": "5e82bfd8-a455-4a2b-90d2-abe5854b537a",
                                 "selected": false,
                                 "text": {
-                                    "en": "Grant license"
+                                    "en": "Grant licence"
                                 }
                             },
                             {
                                 "id": "e36ebf43-b00e-4e12-a8a1-eb8843a0a926",
                                 "selected": false,
                                 "text": {
-                                    "en": "Do not grant license"
+                                    "en": "Do not grant licence"
                                 }
                             }
                         ]
@@ -7784,7 +7784,7 @@
                     "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": true,
-                    "fieldname": "LicenseCom",
+                    "fieldname": "LicenceCom",
                     "graph_id": "cc5da227-24e7-4088-bb83-a564c4331efd",
                     "hascustomalias": false,
                     "is_collector": false,
@@ -7961,7 +7961,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "license_valid_timespan",
+                    "alias": "licence_valid_timespan",
                     "config": {
                         "en": ""
                     },
@@ -7975,7 +7975,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "License Valid Timespan",
+                    "name": "Licence Valid Timespan",
                     "nodegroup_id": "1887f678-c42d-11ee-bc4b-0242ac180006",
                     "nodeid": "1887f678-c42d-11ee-bc4b-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span",
@@ -9129,7 +9129,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "license_valid_timespan_n1",
+                    "alias": "licence_valid_timespan_n1",
                     "config": {
                         "en": ""
                     },
@@ -9143,7 +9143,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "License Valid Timespan",
+                    "name": "Licence Valid Timespan",
                     "nodegroup_id": "69b2738e-c4d2-11ee-b171-0242ac180006",
                     "nodeid": "4128fca0-c4d5-11ee-90c5-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span",
@@ -9598,14 +9598,14 @@
                                 "id": "e36ebf43-b00e-4e12-a8a1-eb8843a0a926",
                                 "selected": false,
                                 "text": {
-                                    "en": "Do not grant license"
+                                    "en": "Do not grant licensc"
                                 }
                             },
                             {
                                 "id": "5e82bfd8-a455-4a2b-90d2-abe5854b537a",
                                 "selected": false,
                                 "text": {
-                                    "en": "Grant license"
+                                    "en": "Grant licensc"
                                 }
                             }
                         ]
@@ -9820,7 +9820,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "license_names",
+                    "alias": "licensc_names",
                     "config": {
                         "en": ""
                     },
@@ -9834,7 +9834,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "License Names",
+                    "name": "Licensc Names",
                     "nodegroup_id": "59d65ec0-48b9-11ee-84da-0242ac140007",
                     "nodeid": "59d65ec0-48b9-11ee-84da-0242ac140007",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E41_Appellation",
@@ -10025,7 +10025,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "transfer_of_license",
+                    "alias": "transfer_of_licensc",
                     "config": {
                         "en": ""
                     },
@@ -10039,7 +10039,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Transfer of License",
+                    "name": "Transfer of Licensc",
                     "nodegroup_id": "6397b05c-c443-11ee-94bf-0242ac180006",
                     "nodeid": "6397b05c-c443-11ee-94bf-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E11_Modification",
@@ -10600,7 +10600,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "extension_of_license",
+                    "alias": "extension_of_licence",
                     "config": {
                         "en": ""
                     },
@@ -10614,7 +10614,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Extension of License",
+                    "name": "Extension of Licence",
                     "nodegroup_id": "69b2738e-c4d2-11ee-b171-0242ac180006",
                     "nodeid": "69b2738e-c4d2-11ee-b171-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E11_Modification",
@@ -11427,7 +11427,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "license_number",
+                    "alias": "licence_number",
                     "config": {
                         "en": ""
                     },
@@ -11441,7 +11441,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "License Number",
+                    "name": "Licence Number",
                     "nodegroup_id": "6de3741e-c502-11ee-86cf-0242ac180006",
                     "nodeid": "6de3741e-c502-11ee-86cf-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
@@ -12002,7 +12002,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": true,
-                    "name": "License",
+                    "name": "Licence",
                     "nodegroup_id": null,
                     "nodeid": "957cf8ec-48b1-11ee-abd1-0242ac140007",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
@@ -12321,21 +12321,21 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "license_number_value",
+                    "alias": "licence_number_value",
                     "config": {
                         "en": ""
                     },
                     "datatype": "string",
                     "description": null,
                     "exportable": true,
-                    "fieldname": "LicenseNum",
+                    "fieldname": "LicenceNum",
                     "graph_id": "cc5da227-24e7-4088-bb83-a564c4331efd",
                     "hascustomalias": false,
                     "is_collector": false,
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "License Number Value",
+                    "name": "Licence Number Value",
                     "nodegroup_id": "6de3741e-c502-11ee-86cf-0242ac180006",
                     "nodeid": "9a9e198c-c502-11ee-af34-0242ac180006",
                     "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
@@ -12377,14 +12377,14 @@
                                 "id": "e36ebf43-b00e-4e12-a8a1-eb8843a0a926",
                                 "selected": false,
                                 "text": {
-                                    "en": "Do not grant license"
+                                    "en": "Do not grant licence"
                                 }
                             },
                             {
                                 "id": "5e82bfd8-a455-4a2b-90d2-abe5854b537a",
                                 "selected": false,
                                 "text": {
-                                    "en": "Grant license"
+                                    "en": "Grant licence"
                                 }
                             }
                         ]
@@ -13026,7 +13026,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "license_number_source",
+                    "alias": "licence_number_source",
                     "config": {
                         "rdmCollection": "06bbe5d2-93e8-43df-a4f4-5667648fd2ef"
                     },
@@ -13040,7 +13040,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "License Number Source",
+                    "name": "Licence Number Source",
                     "nodegroup_id": "6de3741e-c502-11ee-86cf-0242ac180006",
                     "nodeid": "c57348bc-c502-11ee-86cf-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E32_Authority_Document",
@@ -13933,7 +13933,7 @@
                 "isrequired": false,
                 "issearchable": true,
                 "istopnode": true,
-                "name": "License",
+                "name": "Licence",
                 "nodegroup_id": null,
                 "nodeid": "957cf8ec-48b1-11ee-abd1-0242ac140007",
                 "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E7_Activity",
@@ -13942,7 +13942,7 @@
             },
             "slug": null,
             "subtitle": {
-                "en": "Designed to support fields required to manage the creation of Licenses, including their dates, communications and people involved"
+                "en": "Designed to support fields required to manage the creation of Licences, including their dates, communications and people involved"
             },
             "template_id": "50000000-0000-0000-0000-000000000001",
             "version": ""

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -1252,7 +1252,7 @@
                     },
                     "is_editable": false,
                     "name": {
-                        "en": "Excavation License Reference"
+                        "en": "Excavation Licence Reference"
                     },
                     "nodegroup_id": "0132f890-1f4c-11ef-ac74-0242ac150006",
                     "sortorder": null,
@@ -12079,7 +12079,7 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Excavation License",
+                        "label": "Excavation Licence",
                         "maxLength": null,
                         "placeholder": {
                             "en": "Enter text"
@@ -12089,7 +12089,7 @@
                     },
                     "id": "c5c99cb1-b6a2-4300-8525-0cf8c850dc74",
                     "label": {
-                        "en": "Excavation License"
+                        "en": "Excavation Licence"
                     },
                     "node_id": "21a323d4-1f4c-11ef-ac74-0242ac150006",
                     "sortorder": 0,
@@ -22065,7 +22065,7 @@
                             {
                                 "graphid": "cc5da227-24e7-4088-bb83-a564c4331efd",
                                 "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "name": "License",
+                                "name": "Licence",
                                 "relationshipCollection": "00000000-0000-0000-0000-000000000005",
                                 "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
                                 "useOntologyRelationship": false
@@ -22251,7 +22251,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "excavation_license_reference",
+                    "alias": "excavation_licence_reference",
                     "config": {
                         "en": ""
                     },
@@ -22265,7 +22265,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Excavation License Reference",
+                    "name": "Excavation Licence Reference",
                     "nodegroup_id": "0132f890-1f4c-11ef-ac74-0242ac150006",
                     "nodeid": "0132f890-1f4c-11ef-ac74-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
@@ -24418,7 +24418,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "excavation_license_reference_number",
+                    "alias": "excavation_licence_reference_number",
                     "config": {
                         "en": ""
                     },
@@ -24432,7 +24432,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Excavation License Reference Number",
+                    "name": "Excavation Licence Reference Number",
                     "nodegroup_id": "0132f890-1f4c-11ef-ac74-0242ac150006",
                     "nodeid": "21a323d4-1f4c-11ef-ac74-0242ac150006",
                     "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -267,7 +267,7 @@
                     },
                     "is_editable": false,
                     "name": {
-                        "en": "Excavation License Reference"
+                        "en": "Excavation Licence Reference"
                     },
                     "nodegroup_id": "a05d0dd0-1f4b-11ef-ac74-0242ac150006",
                     "sortorder": null,
@@ -14474,7 +14474,7 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Excavation License",
+                        "label": "Excavation Licence",
                         "maxLength": null,
                         "placeholder": {
                             "en": "Enter text"
@@ -14484,7 +14484,7 @@
                     },
                     "id": "ddd28394-1b65-4738-8707-db8980b49232",
                     "label": {
-                        "en": "Excavation License"
+                        "en": "Excavation Licence"
                     },
                     "node_id": "e29ba81e-1f4b-11ef-ac74-0242ac150006",
                     "sortorder": 0,
@@ -22347,7 +22347,7 @@
                             {
                                 "graphid": "cc5da227-24e7-4088-bb83-a564c4331efd",
                                 "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
-                                "name": "License",
+                                "name": "Licence",
                                 "relationshipCollection": "00000000-0000-0000-0000-000000000005",
                                 "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
                                 "useOntologyRelationship": false
@@ -35100,7 +35100,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "excavation_license_reference",
+                    "alias": "excavation_licence_reference",
                     "config": {
                         "en": ""
                     },
@@ -35114,7 +35114,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Excavation License Reference",
+                    "name": "Excavation Licence Reference",
                     "nodegroup_id": "a05d0dd0-1f4b-11ef-ac74-0242ac150006",
                     "nodeid": "a05d0dd0-1f4b-11ef-ac74-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
@@ -38321,7 +38321,7 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "excavation_license_reference_number",
+                    "alias": "excavation_licence_reference_number",
                     "config": {
                         "en": ""
                     },
@@ -38335,7 +38335,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Excavation License Reference Number",
+                    "name": "Excavation Licence Reference Number",
                     "nodegroup_id": "a05d0dd0-1f4b-11ef-ac74-0242ac150006",
                     "nodeid": "e29ba81e-1f4b-11ef-ac74-0242ac150006",
                     "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",

--- a/coral/plugins/excavation-site-visit-workflow.json
+++ b/coral/plugins/excavation-site-visit-workflow.json
@@ -74,14 +74,14 @@
               },
               {
                 "parameters": {
-                  "labels": [["Associated Licenses", "License Number"]],
+                  "labels": [["Associated Licences", "Licence Number"]],
                   "graphid": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "879fc326-02f6-11ef-927a-0242ac150006"
                 },
                 "tilesManaged": "one",
-                "componentName": "get-selected-license-details",
-                "uniqueInstanceName": "license-resource"
+                "componentName": "get-selected-licence-details",
+                "uniqueInstanceName": "licence-resource"
               },
               {
                 "parameters": {
@@ -110,7 +110,7 @@
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",
-                "uniqueInstanceName": "license-holder-present"
+                "uniqueInstanceName": "licence-holder-present"
               },
               {
                 "parameters": {

--- a/coral/plugins/init-workflow.json
+++ b/coral/plugins/init-workflow.json
@@ -78,7 +78,7 @@
         "icon": "fa fa-file-text",
         "bgColor": "#689480",
         "circleColor": "#79b59a",
-        "desc": "Create or edit a License for an Excavation Activity"
+        "desc": "Create or edit a Licence for an Excavation Activity"
       },
       {
         "workflowid": "d1c8bdf2-11e0-4cf7-b412-c329346f4c48",

--- a/coral/templates/views/components/plugins/open-incident-report-workflow.htm
+++ b/coral/templates/views/components/plugins/open-incident-report-workflow.htm
@@ -35,7 +35,7 @@
         params: {
           graphids: graphIds(),
           config: {
-            label: 'Select License',
+            label: 'Select Licence',
             placeholder: 'Please select a Monument',
           },
           renderContext: 'workflow',

--- a/coral/templates/views/components/plugins/open-state-care-condition-survey-workflow.htm
+++ b/coral/templates/views/components/plugins/open-state-care-condition-survey-workflow.htm
@@ -35,7 +35,7 @@
           params: {
             graphids: graphIds(),
             config: {
-              label: 'Select License',
+              label: 'Select Heritage Asset',
               placeholder: 'Please select a Heritage Asset',
             },
             renderContext: 'workflow',

--- a/coral/templates/views/components/plugins/open-workflow.htm
+++ b/coral/templates/views/components/plugins/open-workflow.htm
@@ -14,7 +14,7 @@
         params: {
           graphids: graphIds(),
           config: {
-            label: 'Select License',
+            label: 'Select Licence',
             placeholder: selectResourcePlaceholder,
           },
           searchString: searchString(),

--- a/coral/templates/views/components/widgets/check-open-applications.htm
+++ b/coral/templates/views/components/widgets/check-open-applications.htm
@@ -39,7 +39,7 @@
         </div>
         <!-- ko if: applicationData() -->
         <!-- ko foreach: { data: Object.values(applicationData()), as: 'appData', noChildContext: true } -->
-            <!-- ko if: appData.resourceId && appData.name && appData.totalLicenses !== null && appData.totalOpenApplications !== null && appData.state -->
+            <!-- ko if: appData.resourceId && appData.name && appData.totalLicences !== null && appData.totalOpenApplications !== null && appData.state -->
             <div style="padding: 8px; color: white; max-width: 600px; margin-top: 8px; border-radius: 4px" data-bind="style: { background: colour(appData.state) }">
                 <div style="display: flex">
                     <div data-bind="text: title(appData.state)" style="font-size: 14px; font-weight: 700"></div>
@@ -48,7 +48,7 @@
                 <div data-bind="text: message(appData.resourceId, appData.state)" style="font-size: 13px; font-weight: 600"></div>
             </div>
             <div style="padding: 8px; color: white; max-width: 600px; margin-top: 8px; border-radius: 4px; color: black; background: #ddd">
-                <div data-bind="text: totalLicensesMessage(appData.resourceId)" style="font-size: 13px; font-weight: 600"></div>
+                <div data-bind="text: totalLicencesMessage(appData.resourceId)" style="font-size: 13px; font-weight: 600"></div>
             </div>
             <!-- /ko -->
         <!-- /ko -->

--- a/coral/templates/views/components/workflows/assign-consultation-workflow/pc-summary.htm
+++ b/coral/templates/views/components/workflows/assign-consultation-workflow/pc-summary.htm
@@ -8,7 +8,7 @@
         <a data-bind="attr: { href: urls.resource + '/' + resourceid}" target="_blank">
           <div
             class="summary-value"
-            data-bind="text: displayName() + ' ({% trans 'License Resource Instance' %})'"
+            data-bind="text: displayName() + ' ({% trans 'Licence Resource Instance' %})'"
           ></div>
         </a>
       </div>

--- a/coral/templates/views/components/workflows/heritage-asset-designation-workflow/ha-summary.htm
+++ b/coral/templates/views/components/workflows/heritage-asset-designation-workflow/ha-summary.htm
@@ -8,7 +8,7 @@
         <a data-bind="attr: { href: urls.resource + '/' + resourceid}" target="_blank">
           <div
             class="summary-value"
-            data-bind="text: displayName() + ' ({% trans 'License Resource Instance' %})'"
+            data-bind="text: displayName() + ' ({% trans 'Licence Resource Instance' %})'"
           ></div>
         </a>
       </div>

--- a/coral/templates/views/components/workflows/licensing-workflow/license-cover-letter.htm
+++ b/coral/templates/views/components/workflows/licensing-workflow/license-cover-letter.htm
@@ -532,8 +532,8 @@
           <!-- ko if: getTextValue(areaName) -->
           <span data-bind="text: 'Site: ' + getTextValue(areaName)"></span>
           <!-- /ko -->
-          <!-- ko if: getTextValue(licenseNo) -->
-          <span data-bind="text: 'License No: ' + getTextValue(licenseNo)"></span>
+          <!-- ko if: getTextValue(licenceNo) -->
+          <span data-bind="text: 'Licence No: ' + getTextValue(licenceNo)"></span>
           <!-- /ko -->
         </div>
         <!-- BODY -->

--- a/coral/templates/views/components/workflows/licensing-workflow/license-final-step.htm
+++ b/coral/templates/views/components/workflows/licensing-workflow/license-final-step.htm
@@ -8,7 +8,7 @@
         <a data-bind="attr: { href: urls.resource + '/' + resourceid}" target="_blank">
           <div
             class="summary-value"
-            data-bind="text: displayName() + ' ({% trans 'License Resource Instance' %})'"
+            data-bind="text: displayName() + ' ({% trans 'Licence Resource Instance' %})'"
           ></div>
         </a>
       </div>
@@ -19,7 +19,7 @@
       data-bind="component: {
         name: 'render-nodes',
         params: {
-          resourceNodes: renderedNodegroups()['license']
+          resourceNodes: renderedNodegroups()['licence']
         }
       }"
     ></div>

--- a/coral/views/file_template.py
+++ b/coral/views/file_template.py
@@ -1094,37 +1094,6 @@ class LicenceTemplateProvider:
         print(self.mapping)
         return self.mapping
 
-
-
-# class ExampleTemplateProvider:
-
-#     def __init__(self, resource_instance):
-#         self.resource_instance = resource_instance
-#         self.datatype_factory = DataTypeFactory()
-#         self.tiles = resource_instance.tiles
-#         self.mapping = {
-#             "Example Title": "",
-#         }
-#         self.node_ids = {}
-
-#     def get_value_from_tile(self, tile, node_id):
-#         current_node = models.Node.objects.get(nodeid=node_id)
-#         datatype = self.datatype_factory.get_instance(current_node.datatype)
-#         returnvalue = datatype.get_display_value(tile, current_node)
-#         return "" if returnvalue is None else returnvalue
-
-#     def get_mapping(self):
-#         for tile in self.tiles:
-#             nodegroup_id = str(tile.nodegroup_id)
-#             # if nodegroup_id == self.LICENSE_NUMBER_NODEGROUP:
-#             #     self.mapping["License Number"] = self.get_value_from_tile(
-#             #         tile, self.LICENSE_NUMBER_NODE
-#             #     )
-
-#         return self.mapping
-
-
-
 class DocumentHTMLParser(HTMLParser):
     def __init__(self, paragraph, document):
 

--- a/coral/views/open_workflow.py
+++ b/coral/views/open_workflow.py
@@ -170,23 +170,23 @@ class OpenWorkflow(View):
                 self.nodegroups[nodegroup_id] = node.nodegroup
 
     def setup_licensing_workflow(self):
-        LICENSE_SYSTEM_REFERENCE_NODEGROUP = "991c3c74-48b6-11ee-85af-0242ac140007"
-        LICENSE_RESOURCE_ID_NODE = "991c49b2-48b6-11ee-85af-0242ac140007"
-        LICENSE_DECISION_NODEGROUP = "2749ea5a-48cb-11ee-be76-0242ac140007"
-        LICENSE_APPLICATION_DETAILS = "4f0f655c-48cf-11ee-8e4e-0242ac140007"
-        LICENSE_CM_REFERENCE_NODEGROUP = "b84fa9c6-bad2-11ee-b3f2-0242ac180006"
+        LICENCE_SYSTEM_REFERENCE_NODEGROUP = "991c3c74-48b6-11ee-85af-0242ac140007"
+        LICENCE_RESOURCE_ID_NODE = "991c49b2-48b6-11ee-85af-0242ac140007"
+        LICENCE_DECISION_NODEGROUP = "2749ea5a-48cb-11ee-be76-0242ac140007"
+        LICENCE_APPLICATION_DETAILS = "4f0f655c-48cf-11ee-8e4e-0242ac140007"
+        LICENCE_CM_REFERENCE_NODEGROUP = "b84fa9c6-bad2-11ee-b3f2-0242ac180006"
         ACTIVITY_SYSTEM_REFERENCE_NODEGROUP = "e7d695ff-9939-11ea-8fff-f875a44e0e11"
         ACTIVITY_RESOURCE_ID_NODE = "e7d69603-9939-11ea-9e7f-f875a44e0e11"
         ACTIVITY_LOCATION_DATA_NODEGROUP = "a5416b49-f121-11eb-8e2c-a87eeabdefba"
 
-        # Get the application id used for the license and activity
+        # Get the application id used for the licence and activity
 
-        license_system_reference_tile = Tile.objects.filter(
-            resourceinstance=self.resource, nodegroup=LICENSE_SYSTEM_REFERENCE_NODEGROUP
+        licence_system_reference_tile = Tile.objects.filter(
+            resourceinstance=self.resource, nodegroup=LICENCE_SYSTEM_REFERENCE_NODEGROUP
         ).first()
 
         app_id = (
-            license_system_reference_tile.data.get(LICENSE_RESOURCE_ID_NODE)
+            licence_system_reference_tile.data.get(LICENCE_RESOURCE_ID_NODE)
             .get("en")
             .get("value")
         )
@@ -215,20 +215,20 @@ class OpenWorkflow(View):
         )
         decision_tile, success = Tile.objects.get_or_create(
             resourceinstance=self.resource,
-            nodegroup=LICENSE_DECISION_NODEGROUP,
+            nodegroup=LICENCE_DECISION_NODEGROUP,
         )
         application_details_tile, success = Tile.objects.get_or_create(
             resourceinstance=self.resource,
-            nodegroup=LICENSE_APPLICATION_DETAILS,
+            nodegroup=LICENCE_APPLICATION_DETAILS,
         )
         cm_reference_tile, success = Tile.objects.get_or_create(
             resourceinstance=self.resource,
-            nodegroup=LICENSE_CM_REFERENCE_NODEGROUP,
+            nodegroup=LICENCE_CM_REFERENCE_NODEGROUP,
         )
 
         # Store the tile IDs in an object
 
-        self.additional_saved_values[LICENSE_SYSTEM_REFERENCE_NODEGROUP] = {
+        self.additional_saved_values[LICENCE_SYSTEM_REFERENCE_NODEGROUP] = {
             "activityResourceId": activity_resource_id,
             "activityLocationTileId": str(location_data_tile.tileid),
             "decisionTileId": str(decision_tile.tileid),


### PR DESCRIPTION
[Taiga #2107](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2107?milestone=401865)

This PR corrects the licence typo everywhere apart from file names and imports.
Once this is tested and merged there will be another pr just for renaming files and changing their respective imports.

Initial testing has been promising, 


## commands
### models
Obviously unloading then reloading models
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/License.json'`
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Activity.json'`
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Monument.json'`
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Monument Revision.json'`

### functions
open_workflow.py seems to be fine without reloading it.

Transfer Licence function didn't work until I unregistered and re-registered it because a class name had changed. (I also removed and readded it to the model using the function manager but am not sure that's necessary.)

`make manage CMD="fn unregister -n \"Transfer License\""`
`make manage CMD="fn register -s coral/functions/transfer_license_function.py"`

file_template.py I haven't tested yet.

### plugins / workflows
Quite a few of these plugins have changed their registered names
- fetch-generated-licence-number
- licence-cover-letter
- licence-final-step
- licence-initial-step

This doesn't seem to have broken any of them. 

