### PR TITLE
Fix(#2158): revert back to licensees

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=3, patch=10)
+APP_VERSION = semantic_version.Version(major=5, minor=3, patch=11)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.htm
+++ b/coral/templates/views/components/workflows/excavation-site-visit-workflow/get-selected-license-details.htm
@@ -329,7 +329,7 @@
                         <span data-bind="text: cmNumber" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                     <div style="display: flex; flex-direction: column; gap: 4px">
-                        <span style="font-weight: bold; font-size: 14px">Nominated Excavation Director(s)</span>
+                        <span style="font-weight: bold; font-size: 14px">Licensee(s)</span>
                         <span data-bind="text: licensee" style="background: white; padding: 4px 10px; border-radius: 4px"></span>
                     </div>
                 </div>


### PR DESCRIPTION
**Description**

Does what it says.

**Tests**
- Check that the component will render as licensees and not nominated excavation directors (refer to changes)