### PR TITLE
Feat/2297 excavation dashboard notifications

### DIFF
--- a/coral/functions/notify_excavation.py
+++ b/coral/functions/notify_excavation.py
@@ -52,11 +52,11 @@ details = {
     'classname': 'NotifyExcavation',
     'component': '',
 }
+
 class NotifyExcavation(BaseFunction):
     def post_save(self, tile, request, context):
         from arches_orm.models import Person
         with admin():
-
             nodegroup_id = str(tile.nodegroup_id)
 
             user = request.user
@@ -174,6 +174,7 @@ class ReportStrategy(NotificationStrategy):
     def send_notification(self, user, tile):
         from arches_orm.models import Group
         with admin():
+
             name, resource_instance_id = self.get_resource_details(tile, 'Excavation Licence')
 
             message = f"A new report has been added to {name}"
@@ -212,6 +213,7 @@ class ApplicationDetailsStrategy(NotificationStrategy):
 
         soa_id = tile.data[STAGE_OF_APPLICATION]
 
+
         if soa_id:
             soa_string = self.get_domain_value_string(soa_id, STAGE_OF_APPLICATION)
             message = f"The Stage of Application for {name} has been updated to {soa_string}"
@@ -227,6 +229,7 @@ class TransferOfLicenceStrategy(NotificationStrategy):
 
         grade_e_decision = tile.data[TRANSFER_GRADE_E_DECISION]
         grade_d_decision = tile.data[TRANSFER_GRADE_D_DECISION]
+        groups_to_notify = [ADMIN_GROUP]
 
         if not (grade_d_decision or grade_e_decision):
             groups_to_notify = [ADMIN_GROUP, CUR_D_GROUP, CUR_E_GROUP]
@@ -239,10 +242,10 @@ class TransferOfLicenceStrategy(NotificationStrategy):
             decision_string = self.get_domain_value_string(grade_e_decision, TRANSFER_GRADE_E_DECISION)
             message = f"The Cur Grade E Decision for the Transfer of Licence  {name} has been updated to {decision_string}"
             groups_to_notify = [ADMIN_GROUP, CUR_D_GROUP]
-            
+        
+
         notification = self.create_notification(message, name, resource_instance_id, EXCAVATION_SLUG)
-                                    
-        groups_to_notify = [ADMIN_GROUP]
+        
         self.notify_groups(user, groups_to_notify, notification)
 
 class ExtensionOfLicenceStrategy(NotificationStrategy):
@@ -251,6 +254,7 @@ class ExtensionOfLicenceStrategy(NotificationStrategy):
 
         grade_e_decision = tile.data[EXTENSION_GRADE_E_DECISION]
         grade_d_decision = tile.data[EXTENSION_GRADE_D_DECISION]
+        groups_to_notify = [ADMIN_GROUP]
 
         if not (grade_d_decision or grade_e_decision):
             groups_to_notify = [ADMIN_GROUP, CUR_D_GROUP, CUR_E_GROUP]
@@ -266,7 +270,6 @@ class ExtensionOfLicenceStrategy(NotificationStrategy):
             
         notification = self.create_notification(message, name, resource_instance_id, EXCAVATION_SLUG)
                                     
-        groups_to_notify = [ADMIN_GROUP]
         self.notify_groups(user, groups_to_notify, notification)
 
 class NotificationManager():

--- a/coral/functions/notify_excavation.py
+++ b/coral/functions/notify_excavation.py
@@ -22,6 +22,7 @@ RESOURCE_ID = '991c49b2-48b6-11ee-85af-0242ac140007'
 GRADE_E_DECISION = 'a68fa38c-c430-11ee-bc4b-0242ac180006'
 GRADE_D_DECISION = '2a5151f0-c42e-11ee-94bf-0242ac180006'
 CLASSIFICATION_TYPE = '8d13575c-dc70-11ee-8def-0242ac120006'
+STAGE_OF_APPLICATION = 'a79fedae-bad5-11ee-900d-0242ac180006'
 
 #response slugs
 EXCAVATION_SLUG = 'licensing-workflow'
@@ -192,7 +193,19 @@ class ReportStrategy(NotificationStrategy):
 
 class ApplicationDetailsStrategy(NotificationStrategy):
     def send_notification(self, user, tile):
-        pass
+        name, resource_instance_id = self.get_resource_details(tile)
+        name = name.removeprefix('Excavation Licence').strip()
+
+        soa_id = tile.data[STAGE_OF_APPLICATION]
+
+        if soa_id:
+            soa_string = self.get_domain_value_string(soa_id, STAGE_OF_APPLICATION)
+            message = f"The Stage of Application for {name} has been updated to {soa_string}"
+
+            notification = self.create_notification(message, name, resource_instance_id, EXCAVATION_SLUG)
+                                        
+            groups_to_notify = [ADMIN_GROUP]
+            self.notify_groups(user, groups_to_notify, notification)
 
 class NotificationManager():
     strategy_registry = {

--- a/coral/functions/notify_excavation.py
+++ b/coral/functions/notify_excavation.py
@@ -1,0 +1,127 @@
+from arches.app.functions.base import BaseFunction
+from arches.app.models import models
+from arches.app.models.resource import Resource
+from arches_orm.adapter import admin
+
+# tiles
+SYSTEM_REFERENCE = '991c3c74-48b6-11ee-85af-0242ac140007'
+REPORT = 'f060583a-6120-11ee-9fd1-0242ac120003'
+CUR_E_DECISON = '69f2eb3c-c430-11ee-94bf-0242ac180006'
+CUR_D_DECISION = 'c9f504b4-c42d-11ee-94bf-0242ac180006'
+APPLICATION_DETAILS = '4f0f655c-48cf-11ee-8e4e-0242ac140007'
+
+# groups
+ADMIN_GROUP = '4fbe3955-ccd3-4c5b-927e-71672c61f298'
+CUR_D_GROUP = '751d8543-8e5e-4317-bcb8-700f1b421a90'
+CUR_E_GROUP = '214900b1-1359-404d-bba0-7dbd5f8486ef'
+
+#nodes
+RESOURCE_ID = '991c49b2-48b6-11ee-85af-0242ac140007'
+
+details = {
+    "functionid": "e3ec9aa7-dad3-444a-bb44-9d71a8eaf017",
+    'name': 'Notify Excavation',
+    'type': 'node',
+    'description': 'Will send notifications to the Excavation team when certain nodes are changed',
+    'defaultconfig': {
+        'triggering_nodegroups': [SYSTEM_REFERENCE, REPORT, CUR_E_DECISON, CUR_D_DECISION, APPLICATION_DETAILS ],
+    },
+    'classname': 'NotifyExcavation',
+    'component': '',
+}
+class NotifyExcavation(BaseFunction):
+    def post_save(self, tile, request, context):
+        from arches_orm.models import Person
+
+        resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
+        nodegroup_id = str(tile.nodegroup_id)
+
+        user = request.user
+        user_resource = Person.where(user_account=user.id)[0] if user and Person.where(user_account=user.id) else None
+
+        notification_manager = NotificationManager(nodegroup_id, user_resource, tile, resource_instance_id)
+
+        notification_manager.notify()
+
+class SystemReferenceStrategy:
+    def send_notification(self, user, tile, resource_instance_id):
+        name = tile.data[RESOURCE_ID].get("en").get("value")
+        message = f"A new excavation licence {name} has been started and requires attention"
+        groups_to_notify = [ADMIN_GROUP, CUR_E_GROUP, CUR_D_GROUP]
+
+        utils = Utilities()
+
+        for group_id in groups_to_notify:
+            utils.notify_group(group_id, message, resource_instance_id)
+
+class ReportStrategy:
+    def send_notification(self, user, resource_instance_id):
+        pass
+
+class CurDDecisionStrategy:
+    def send_notification(self, user, resource_instance_id):
+        pass
+
+class CurEDecisionStrategy:
+    def send_notification(self, user, resource_instance_id):
+        pass
+
+class ApplicationDetailsStrategy:
+    def send_notification(self, user, resource_instance_id):
+        pass
+
+class NotificationManager:
+    strategy_registry = {
+        SYSTEM_REFERENCE : SystemReferenceStrategy, 
+        REPORT : ReportStrategy, 
+        CUR_D_DECISION : CurDDecisionStrategy, 
+        CUR_E_DECISON : CurEDecisionStrategy, 
+        APPLICATION_DETAILS : ApplicationDetailsStrategy 
+    }
+
+    def __init__(self, node_group_id, user, tile, resource_instance_id):
+        self.user = user
+        self.node_group_id = node_group_id
+        self.tile = tile
+        self.resource_instance_id = resource_instance_id
+        self.strategy = self._select_strategy(node_group_id)
+
+    def _select_strategy(self, node_group_id):
+        strategy_class = self.strategy_registry.get(node_group_id)
+        if strategy_class:
+            return strategy_class()
+        else:
+            raise ValueError(f"No strategy found for node group id: {node_group_id}")
+        
+    def notify(self):
+        self.strategy.send_notification(self.user, self.tile, self.resource_instance_id)
+
+
+class Utilities:
+    def notify_group(self, group_id, message, resource_instance_id):
+        from arches_orm.models import Group, Person
+        
+        with admin():
+            group = Group.find(group_id)
+            person_list = [Person.find(member.id) for member in group.members if isinstance(member, Person)]
+
+            for person in person_list:
+                self.notify_user(person, message, resource_instance_id)
+        
+    def notify_user(self, user, message, resource_instance_id):
+        user = user.user_account
+
+        notification = models.Notification(
+                message = message,
+                context = {
+                    "resource_instance_id": resource_instance_id,
+                },
+            )
+        
+        notification.save()
+
+        user_x_notification = models.UserXNotification(
+            notif = notification,
+            recipient = user
+        )
+        user_x_notification.save()

--- a/coral/pkg/graphs/resource_models/Licence.json
+++ b/coral/pkg/graphs/resource_models/Licence.json
@@ -7170,6 +7170,20 @@
                 },
                 {
                     "config": {
+                        "triggering_nodegroups": [
+                            "991c3c74-48b6-11ee-85af-0242ac140007",
+                            "f060583a-6120-11ee-9fd1-0242ac120003",
+                            "69f2eb3c-c430-11ee-94bf-0242ac180006",
+                            "c9f504b4-c42d-11ee-94bf-0242ac180006",
+                            "4f0f655c-48cf-11ee-8e4e-0242ac140007"
+                        ]
+                    },
+                    "function_id": "e3ec9aa7-dad3-444a-bb44-9d71a8eaf017",
+                    "graph_id": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
+                    "id": "3fee3322-ff13-46a0-9ef3-e9a37b9039d3"
+                },
+                {
+                    "config": {
                         "descriptor_types": {
                             "description": {
                                 "nodegroup_id": "",

--- a/coral/templates/views/components/notification.htm
+++ b/coral/templates/views/components/notification.htm
@@ -60,6 +60,19 @@
             </a>
         </div>
         <!-- /ko -->
+        <!-- ko if: state.fields_cache.notif.context.resource_id -->
+        <div class='entry'>
+            <a data-bind="click: () => {
+                openFlagged(state.fields_cache.notif.context.resource_instance_id, state.fields_cache.notif.context.response_slug)
+              } " 
+              target="_blank" style="color: steelblue"
+            >
+                <button class='btn btn-notifs-download btn-labeled btn-sm fa fa-link'>
+                    <span data-bind="text: 'Open ' + state.fields_cache.notif.context.resource_id"></span>
+                </button>
+            </a>
+        </div>
+        <!-- /ko -->
     </div>
 
     <div class='entry relative'>

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -251,7 +251,7 @@ class PlanningTaskStrategy(TaskStrategy):
     
 class ExcavationTaskStrategy(TaskStrategy):
     def get_tasks(self, groupId, userResourceId, sort_by='issuedate', sort_order='asc'):
-        from arches_orm.models import Licence
+        from arches_orm.models import License
         utilities = Utilities()
         #states
         is_admin = groupId == EXCAVATION_ADMIN_GROUP
@@ -262,7 +262,7 @@ class ExcavationTaskStrategy(TaskStrategy):
 
         resources = [] 
 
-        licences_all = Licence.all()
+        licences_all = License.all()
 
         licences =[l for l in licences_all if l.system_reference_numbers.uuid.resourceid.startswith('EL/')]
 
@@ -279,7 +279,7 @@ class ExcavationTaskStrategy(TaskStrategy):
 
     
     def build_data(self, licence, groupId):
-        from arches_orm.models import Licence
+        from arches_orm.models import License
         utilities = Utilities()
 
         activity_list = utilities.node_check(lambda: licence.associated_activities)
@@ -321,7 +321,7 @@ class ExcavationTaskStrategy(TaskStrategy):
             'validuntildate': valid_until_date,
             'employingbody': employing_body_name_list,
             'nominateddirectors': nominated_directors_name_list,
-            'reportstatus': utilities.domain_value_string_lookup(Licence, 'classification_type', report_status),
+            'reportstatus': utilities.domain_value_string_lookup(License, 'classification_type', report_status), ## will need changed after Taiga #2199 is complete
             'licencenumber': licence_number,
             'responseslug': response_slug
         }

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -251,7 +251,7 @@ class PlanningTaskStrategy(TaskStrategy):
     
 class ExcavationTaskStrategy(TaskStrategy):
     def get_tasks(self, groupId, userResourceId, sort_by='issuedate', sort_order='asc'):
-        from arches_orm.models import License
+        from arches_orm.models import Licence
         utilities = Utilities()
         #states
         is_admin = groupId == EXCAVATION_ADMIN_GROUP
@@ -262,7 +262,7 @@ class ExcavationTaskStrategy(TaskStrategy):
 
         resources = [] 
 
-        licences_all = License.all()
+        licences_all = Licence.all()
 
         licences =[l for l in licences_all if l.system_reference_numbers.uuid.resourceid.startswith('EL/')]
 
@@ -279,7 +279,7 @@ class ExcavationTaskStrategy(TaskStrategy):
 
     
     def build_data(self, licence, groupId):
-        from arches_orm.models import License ## will need changed after Taiga #2199 is complete
+        from arches_orm.models import Licence
         utilities = Utilities()
 
         activity_list = utilities.node_check(lambda: licence.associated_activities)
@@ -321,7 +321,7 @@ class ExcavationTaskStrategy(TaskStrategy):
             'validuntildate': valid_until_date,
             'employingbody': employing_body_name_list,
             'nominateddirectors': nominated_directors_name_list,
-            'reportstatus': utilities.domain_value_string_lookup(License, 'classification_type', report_status), ## will need changed after Taiga #2199 is complete
+            'reportstatus': utilities.domain_value_string_lookup(Licence, 'classification_type', report_status),
             'licencenumber': licence_number,
             'responseslug': response_slug
         }


### PR DESCRIPTION
## Description
Sends notifications when certain fields are changed in the excavation licence workflow

All strategies have been added and have been tested locally.
Needs a second run through

## Test
Go through the notes on the taiga below (might need to copy to a MD reader) this lists each scenario and who should be notified. Will need to create users and add them to the groups, these are in the front end pr. 

I've added more info into the taiga for the logic [Taiga #2297](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2297) 