### PR TITLE
Fix(API): add the generated SMR as an alias

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=4, patch=26)
+APP_VERSION = semantic_version.Version(major=5, minor=4, patch=27)
 
 GROUPINGS = {
     "groups": {

--- a/coral/wkrm.toml
+++ b/coral/wkrm.toml
@@ -91,7 +91,12 @@ model_name = "Monument"
 graphid = "076f9381-7b00-11e9-8d6b-80000b44d1d9"
 
 [Monument.remapping]
+nismr_numbering_type = "nismr_numbering_type"
 generated_smr = "generated_smr"
+show_ihr_number = "show_ihr_number"
+show_smr_number = "show_smr_number"
+show_historic_parks_and_gardens_number = "show_historic_parks_and_gardens_number"
+show_hb_number = "show_hb_number"
 
 ["Monument Revision"]
 model_name = "Monument Revision"

--- a/coral/wkrm.toml
+++ b/coral/wkrm.toml
@@ -90,6 +90,9 @@ graphid = "d9318eb6-f28d-427c-b061-6fe3021ce8aa"
 model_name = "Monument"
 graphid = "076f9381-7b00-11e9-8d6b-80000b44d1d9"
 
+[Monument.remapping]
+generated_smr = "generated_smr"
+
 ["Monument Revision"]
 model_name = "Monument Revision"
 graphid = "65b1be1a-dfa4-49cf-a736-a1a88c0bb289"


### PR DESCRIPTION
After digging into the ORM, there is no sensible way to do this without properly implementing support for a card-defined structure. Basically, `nismr_numbering_type` is not a semantic node, it is a concept, and the structure of the ORM cannot simultaneously handle it being both without some breaking hacking. For now, this works OK to remap the generated SMR to a top-level string field, `generatedSmr` or `generated_smr` (depending on GraphQL or Python).