### PR TITLE
Feat/#1753/print all tabs of report

### DIFF
--- a/coral/media/js/views/components/reports/activity.js
+++ b/coral/media/js/views/components/reports/activity.js
@@ -37,6 +37,8 @@ define([
             self.activityArchive = ko.observableArray();
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.activityArchiveConfig = {
                 ...self.defaultTableConfig,

--- a/coral/media/js/views/components/reports/application-area.js
+++ b/coral/media/js/views/components/reports/application-area.js
@@ -42,6 +42,8 @@ define([
             }
 
             self.applicationAreas = ko.observableArray();
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'application area',

--- a/coral/media/js/views/components/reports/archive-source.js
+++ b/coral/media/js/views/components/reports/archive-source.js
@@ -29,6 +29,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'archive source',

--- a/coral/media/js/views/components/reports/area.js
+++ b/coral/media/js/views/components/reports/area.js
@@ -38,6 +38,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'area',

--- a/coral/media/js/views/components/reports/artefact.js
+++ b/coral/media/js/views/components/reports/artefact.js
@@ -46,6 +46,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'artefact',

--- a/coral/media/js/views/components/reports/bibliographic-source.js
+++ b/coral/media/js/views/components/reports/bibliographic-source.js
@@ -32,6 +32,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('source');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.publicationTableConfig = {
                 ...self.defaultTableConfig,

--- a/coral/media/js/views/components/reports/consultation.js
+++ b/coral/media/js/views/components/reports/consultation.js
@@ -32,6 +32,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('details');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'consultation',

--- a/coral/media/js/views/components/reports/digital-object.js
+++ b/coral/media/js/views/components/reports/digital-object.js
@@ -28,6 +28,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {};
 

--- a/coral/media/js/views/components/reports/heritage-area.js
+++ b/coral/media/js/views/components/reports/heritage-area.js
@@ -38,6 +38,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'heritage area',

--- a/coral/media/js/views/components/reports/heritage-asset.js
+++ b/coral/media/js/views/components/reports/heritage-asset.js
@@ -33,6 +33,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'heritage asset',

--- a/coral/media/js/views/components/reports/heritage-story.js
+++ b/coral/media/js/views/components/reports/heritage-story.js
@@ -28,6 +28,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 parent: 'parent story'

--- a/coral/media/js/views/components/reports/historic-aircraft.js
+++ b/coral/media/js/views/components/reports/historic-aircraft.js
@@ -36,6 +36,8 @@ define([
             self.activeSection = ko.observable('name');
             self.flights = ko.observableArray();
             self.lastFlight = ko.observableArray();
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.flightsTableConfig = {
                 ...self.defaultTableConfig,

--- a/coral/media/js/views/components/reports/historic-landscape-characterization.js
+++ b/coral/media/js/views/components/reports/historic-landscape-characterization.js
@@ -31,6 +31,8 @@ define([
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
             self.historicLandscapeClassificationPhase = ko.observableArray();
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.visible = {
                 historicLandscapeClassificationPhase: ko.observable(true)

--- a/coral/media/js/views/components/reports/maritime-vessel.js
+++ b/coral/media/js/views/components/reports/maritime-vessel.js
@@ -54,6 +54,8 @@ define([
             self.nationalities = ko.observableArray();
             self.owners = ko.observableArray();
             self.voyages = ko.observableArray();
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.classificationDataConfig = {
                 maritimeProduction: 'construction phases',

--- a/coral/media/js/views/components/reports/monument.js
+++ b/coral/media/js/views/components/reports/monument.js
@@ -33,6 +33,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'monument',

--- a/coral/media/js/views/components/reports/organization.js
+++ b/coral/media/js/views/components/reports/organization.js
@@ -32,6 +32,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'names',

--- a/coral/media/js/views/components/reports/period.js
+++ b/coral/media/js/views/components/reports/period.js
@@ -30,6 +30,8 @@ define([
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
             self.names = ko.observableArray();
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameTableConfig = {
                 ...self.defaultTableConfig,

--- a/coral/media/js/views/components/reports/person.js
+++ b/coral/media/js/views/components/reports/person.js
@@ -37,6 +37,7 @@ define([
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
             self.names = ko.observableArray();
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
 
             self.contactPointsTable = {
                 ...self.defaultTableConfig,

--- a/coral/media/js/views/components/reports/place.js
+++ b/coral/media/js/views/components/reports/place.js
@@ -28,6 +28,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+
 
             self.nameDataConfig = {
                 name: 'names',

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=7, patch=35)
+APP_VERSION = semantic_version.Version(major=5, minor=8, patch=35)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/base-manager.htm
+++ b/coral/templates/base-manager.htm
@@ -1,0 +1,625 @@
+{% extends "base.htm" %}
+{% load static %}
+{% load template_tags %}
+{% load i18n %}
+
+{% block body %}
+
+    <!-- ko if: alert() -->
+    <div data-bind="visible: alert().active" style="display: none;" class="relative">
+        <div id="card-alert-panel" data-bind="css: 'ep-form-alert ' + (alert() ? alert().type() : '')">
+            <div style="display: flex;">
+                <h4 style="flex: 1" class="ep-form-alert-title" data-bind="text: alert().title"></h4>
+                <div class="ep-form-alert-default-dismiss">
+                    <i class="fa fa-times-circle" data-bind="click: alert().close"></i>
+                </div>
+            </div>
+            <p class="ep-form-alert-text" data-bind="html: alert().text"></p>
+
+            <div class="ep-form-alert-buttons">
+                <!-- ko if: alert().cancel -->
+                <button class="btn btn-sm btn-danger btn-labeled fa fa-times" data-bind="click: alert().cancel"><span>{% trans "Cancel" %}</span></button>
+                <!-- /ko -->
+                <!-- ko if: alert().ok -->
+                <button class="btn btn-sm btn-primary btn-labeled fa fa-check" data-bind="click: alert().ok"><span>{% trans "OK" %}</span></button>
+                <!-- /ko -->
+            </div>
+        </div>
+    </div>
+    <!-- /ko -->
+
+    <div id="skip-link-holder"><a id="skip-link" data-bind="text: $root.translations.skipToContent" href="#skiptocontent"></a></div>
+
+    <div id="container" class="base-manager-grid effect aside-left aside-bright navbar-fixed sidenav-sm"
+        data-bind="css: {'mainnav-in': tabsActive() && showTabs(), 'sidenav-sm': !navExpanded(), 'sidenav-lg': navExpanded()}">
+
+        <nav class="sidenav" role="navigation" id="arches-navigation">
+            {% block navheader %}
+            <a href="#" class="sidenav-brand" data-bind="onEnterkeyClick, onSpaceClick, click: function () { navExpanded(!navExpanded()) },
+                attr: {
+                    'aria-label': $root.translations.toggleNavigation, 
+                    'aria-description': $root.translations.toggleNavigationDescription, 
+                    'aria-expanded': navExpanded().toString()
+                }
+            ">
+                <img src="{{ STATIC_URL }}img/arches_logo_light.png" class="brand-icon" alt="">
+                <div class="brand-title">
+                    <h1 class="brand-text" style="margin-top: 15px;">{{ app_name }}</h1>
+                </div>
+            </a>
+            {% endblock navheader %}
+            {% block mainnav %}
+            <div class="mainnav-container">
+                <div class="sidenav-menu">
+                    {% block navbar %}
+                    <ul class="list-group" data-bind="attr: {'aria-label': $root.translations.mainMenu}">
+        
+                        <!-- Home. -->
+                        <li>
+                            <a href="{% url 'home' %}" aria-labelledby="index-link-label" data-bind="click:function () { navigate('{% url 'home' %}') }">
+                                <i class="ti-home"></i>
+                                <span class="menu-title">
+                                    <strong id="index-link-label">{% trans "Home" %}</strong>
+                                </span>
+                            </a>
+                        </li>
+
+                        <!-- Tools -->
+                        <div id="tools-header-label" class="list-header">{% trans "Tools" %}</div>
+
+                        <ul aria-labelledby="tools-header-label">
+                            <!-- System Settings list item -->
+                            {% if request.user|has_group:"System Administrator" %}
+                            <li {% if "views/resource" in main_script and is_system_settings is True %} class="active-sub" {% endif %} data-bind="click: navigate.bind(this, '{% url 'config' %}')">
+                                <a href="{% url 'config' %}" aria-labelledby="system-settings-link-label">
+                                    <i class="ti-alarm-clock"></i>
+                                    <span class="menu-title">
+                                        <strong id="system-settings-link-label">{% trans "Manage System Settings" %}</strong>
+                                    </span>
+                                </a>
+                                <ul class="collapse" data-bind="css:{'in': navExpanded()}" aria-labelledby="system-settings-link-label">
+                                    <li class="link-submenu-item">
+                                        <a class="link-submenu" href="{% url 'config' %}"
+                                            data-bind="click: navigate.bind(this, '{% url 'config' %}')">{% trans "System Settings" %}</a>
+                                    </li>
+                                    <li class="link-submenu-item">
+                                        <a class="link-submenu" href="{% url 'graph' system_settings_graphid %}"
+                                            data-bind="click: navigate.bind(this, '{% url 'graph_designer' system_settings_graphid %}'), clickBubble: false">{% trans "System Settings Graph" %}</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            {% endif %}
+
+                            <!-- Search -->
+                            <li {% if "views/search" in main_script %} class="active-sub" {% endif %}>
+                                <a href="{% url 'search_home' %}" aria-labelledby="search-link-label"
+                                    data-bind="click:function () { navigate('{% url 'search_home' %}') }">
+                                    <i class="fa fa-search"></i>
+                                    <span class="menu-title">
+                                        <strong id="search-link-label">{% trans "Search" %}</strong>
+                                    </span>
+                                </a>
+                            </li>
+
+                            <!-- New Resource -->
+                            {% if user_can_edit %}
+                            <li
+                                {% if "views/resource" in main_script and is_system_settings is None %}
+                                    class="active-sub" 
+                                {% endif %}
+                            >
+                                <a href="{% url 'resource' %}" aria-labelledby="new-resource-link-label">
+                                    <i class="fa fa-building-o"></i>
+                                    <span class="menu-title">
+                                        <strong id="new-resource-link-label">{% trans "Add New Resource" %}</strong>
+                                    </span>
+                                </a>
+                                <ul class="collapse" data-bind="css:{'in': navExpanded()}" aria-labelledby="new-resource-link-label">
+                                    <!-- ko foreach: createableResources -->
+                                    <li class="link-submenu-item">
+                                        <a 
+                                            class="link-submenu" 
+                                            data-bind="
+                                                css: { 'arches-menu-item-disabled': disable_instance_creation },
+                                                attr: {
+                                                    href: disable_instance_creation ? '#' : ('{% url 'add_resource' 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' %}'.replace('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', graphid))
+                                                }"
+                                        >
+                                            <i 
+                                                class="fa arches-menu-icon"
+                                                data-bind="css: iconclass || 'fa fa-question'"
+                                            ></i> 
+                                            <span data-bind="text:name"></span>
+                                        </a>
+                                    </li>
+                                    <!-- /ko -->
+                                </ul>
+                            </li>
+                            {% endif %}
+
+                            <!-- Graph Designer -->
+                            {% if request.user|has_group:"Graph Editor" %}
+                            <li {% if "views/graph" in main_script %} class="active-sub" {% endif %}
+                                data-bind="click: navigate.bind(this, '{% url 'graph' '' %}')">
+                                <a href="#" aria-labelledby="designer-link-label">
+                                    <i class="fa fa-bookmark"></i>
+                                    <span class="menu-title">
+                                        <strong id="designer-link-label">{% trans "Arches Designer" %}</strong>
+                                    </span>
+                                </a>
+                                <ul class="collapse" data-bind="css:{'in': navExpanded()}" aria-labelledby="designer-link-label">
+                                    <li class="link-submenu-item">
+                                        <a class="link-submenu" href="{% url 'graph' '' %}"
+                                            data-bind="click: navigate.bind(this, '{% url 'graph' '' %}')">{% trans "Resource Models" %}</a>
+                                    </li>
+                                    <li class="link-submenu-item">
+                                        <a class="link-submenu" href="{% url 'graph' '' %}#branches"
+                                            data-bind="click: navigate.bind(this, '{% url 'graph' '' %}#branches')">{% trans "Branches" %}</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            {% endif %}
+
+                            <!-- Map Layer Manager -->
+                            {% if request.user|has_group:"Application Administrator" %}
+                            <li {% if "views/map-layer-manager" in main_script %} class="active-sub" {% endif %} data-bind="click: navigate.bind(this, '{% url 'map_layer_manager' %}')">
+                                <a href="{% url 'map_layer_manager' %}" aria-labelledby="map-layer-manager-link-label">
+                                    <i class="fa fa-server"></i>
+                                    <span class="menu-title">
+                                        <strong id="map-layer-manager-link-label">{% trans "Map Layer Manager" %}</strong>
+                                    </span>
+                                </a>
+                                <ul class="collapse"  data-bind="css:{'in': navExpanded()}" aria-labelledby="map-layer-manager-link-label">
+                                    <li class="link-submenu-item">
+                                        <a class="link-submenu" href="{% url 'map_layer_manager' %}"
+                                            data-bind="click: navigate.bind(this, '{% url 'map_layer_manager' %}')">{% trans "Resource Layers" %}</a>
+                                    </li>
+                                    <li class="link-submenu-item">
+                                        <a class="link-submenu"
+                                            href="{% url 'map_layer_manager' %}#basemaps"
+                                            data-bind="click: navigate.bind(this, '{% url 'map_layer_manager' %}#basemaps')">{% trans "Basemaps" %}</a>
+                                    </li>
+                                    <li class="link-submenu-item">
+                                        <a class="link-submenu"
+                                            href="{% url 'map_layer_manager' %}#overlays"
+                                            data-bind="click: navigate.bind(this, '{% url 'map_layer_manager' %}#overlays')">{% trans "Overlays" %}</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            {% endif %}
+
+
+                            <!-- Recently Added -->
+                            {% if user_can_edit %}
+                            <li {% if 'edit-history' in main_script %} class="active-sub" {% endif %}>
+                                <a href="{% url 'edit_history' %}" aria-labelledby="recent-edits-link-label"
+                                    data-bind="click: navigate.bind(this, '{% url 'edit_history' %}') ">
+                                    <i class="ti-ticket"></i>
+                                    <span class="menu-title">
+                                        <strong id="recent-edits-link-label">{% trans "Recent Edits" %}</strong>
+                                    </span>
+                                </a>
+                            </li>
+                            {% endif %}
+
+                            <!-- Profile Manager -->
+                            {% if user.is_authenticated and request.user.username != 'anonymous' %}
+                            <li {% if "user-profile-manager" in main_script %} class="active-sub" {% endif %}>
+                                <a href="{% url 'user_profile_manager' %}" aria-labelledby="profile-link-label"
+                                    data-bind="click: navigate.bind(this, '{% url 'user_profile_manager' %}') ">
+                                    <i class="fa fa-user"></i>
+                                    <span class="menu-title">
+                                        <strong id="profile-link-label">{% trans "Profile Manager" %}</strong>
+                                    </span>
+                                </a>
+                            </li>
+                            {% endif %}
+                            <!-- Profile Manager -->
+                            {% if user.is_authenticated and request.user.username != 'anonymous' %}
+                            <li {% if "user-profile-manager" in main_script %} class="active-sub" {% endif %}>
+                                <a href="{% url 'user_profile_manager' %}" aria-labelledby="profile-link-label"
+                                    data-bind="click: navigate.bind(this, '{% url 'user_profile_manager' %}') ">
+                                    <i class="fa fa-user"></i>
+                                    <span class="menu-title">
+                                        <strong id="profile-link-label">{% trans "Profile Manager" %}</strong>
+                                    </span>
+                                </a>
+                            </li>
+                            {% endif %}
+                        </ul>
+
+                        {% if request.user|has_group:"RDM Administrator" or plugins|length > 0 %}
+                        <hr class="list-divider-dark"></hr>
+
+                        <!-- Modules -->
+                        <div id="modules-header-label" class="list-header">{% trans "Modules" %}</div>
+
+                        <ul aria-labelledby="modules-header-label">
+
+                            {% if request.user|has_group:"RDM Administrator" %}
+                            <!-- Reference Data Manager -->
+                            <li {% if main_script == "rdm" %} class="active-sub" {% endif %} aria-labelledby="rdm-link-label">
+                                <a href="{% url 'rdm' '' %}"
+                                    data-bind="click: navigate.bind(this, '{% url 'rdm' '' %}') ">
+                                    <i class="fa fa-align-left"></i>
+                                    <span class="menu-title">
+                                        <strong id="rdm-link-label">{% trans "Reference Data Manager" %}</strong>
+                                    </span>
+                                </a>
+                            </li>
+                            {% endif %}
+
+                            {% for p in plugins %}
+                                {% if p.config is not None %}
+                                    {% if p.config.show is not False %}
+                                    <!-- ko let: {uid: Math.random().toString()} -->
+                                    <li {% if main_script == "views/plugin" and plugin.pluginid == p.pluginid %} class="active-sub" {% endif %}>
+                                        {% if p.slug is not None %}
+                                        <a href="{% url 'plugins' p.slug %}" data-bind="click: navigate.bind(this, '{% url 'plugins' p.slug %}'), attr: {'aria-labelledby': uid}">
+                                        {% else %}
+                                        <a href="{% url 'plugins' p.pluginid %}" data-bind="click: navigate.bind(this, '{% url 'plugins' p.pluginid %}'), attr: {'aria-labelledby': uid}">
+                                        {% endif %}
+                                            <i class="{{p.icon}}"></i>
+                                            <span class="menu-title">
+                                                <strong data-bind="attr: {id: uid}">{{p.name}}</strong>
+                                            </span>
+                                        </a>
+                                    </li>
+                                    <!-- /ko -->
+                                    {% endif %}
+                                {% else %}
+                                <!-- ko let: {uid: Math.random().toString()} -->
+                                <li {% if main_script == "views/plugin" and plugin.pluginid == p.pluginid %} class="active-sub" {% endif %}>
+                                    {% if p.slug is not None %}
+                                    <a href="{% url 'plugins' p.slug %}" data-bind="click: navigate.bind(this, '{% url 'plugins' p.slug %}'), attr: {'aria-labelledby': uid}">
+                                    {% else %}
+                                    <a href="{% url 'plugins' p.pluginid %}" data-bind="click: navigate.bind(this, '{% url 'plugins' p.pluginid %}'), attr: {'aria-labelledby': uid}">
+                                    {% endif %}
+                                        <i class="{{p.icon}}"></i>
+                                        <span class="menu-title">
+                                            <strong data-bind="attr: {id: uid}">{{p.name}}</strong>
+                                        </span>
+                                    </a>
+                                </li>
+                                <!-- /ko -->
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+
+                    </ul>
+                    {% endblock navbar %}
+                </div>
+                {% if app_settings.DEBUG %}
+                <div class="debug-notice">
+                    <div>{% trans 'DEBUG' %}</div>
+                    <div>Arches</div>
+                    <div>{{ app_settings.VERSION }}</div>
+                    {% if app_settings.APP_VERSION %}
+                        <div>{% trans 'Project' %}</div>
+                        <div>{{ app_settings.APP_VERSION }}</div>
+                    {% endif %}
+                </div>
+                {% endif %}
+            </div>
+            {% endblock mainnav %}
+        </nav>
+        
+        <header class="header">
+            
+            {% block header %}
+            <div class="ep-toolbar">
+
+                <div class="col-xs-12 col-sm-8 flex">
+
+                    <!-- Tools Menu -->
+                    {% if nav.menu %}
+                        <nav id="manage-top-left-nav" aria-label="{% trans 'Graph and Resource Management' %}">
+                            <button id="menu-control" class="ep-tools ep-tool-title"
+                                data-bind="click:function(data, event) { 
+                                        menuActive(!menuActive()); 
+                                        handleEscKey(event.currentTarget, '.ep-menu-list'); 
+                                    }, attr: {
+                                        'aria-expanded': menuActive().toString(),
+                                        'aria-controls': '#menu-panel'
+                                    }
+                                "
+                            >
+                                <div class="flex">{% trans "Manage" %}
+                                    <i class="ion-more" style="padding: 0px 5px;"></i>
+                                </div>
+                            </button>
+                        </nav>
+                        {% if main_script == 'views/resource/editor' %}
+                            {% include 'navbar/resource-manage-menu.htm' %}
+                        {% elif main_script == 'views/graph/function-manager' %}
+                            {% include 'navbar/function-manage-menu.htm' %}
+                        {% else %}
+                            {% include 'navbar/graph-designer-menu.htm' %}
+                        {% endif %}
+                    {% endif %}
+
+                    {% block graph_title %}
+                    <!-- Page Title and Icon -->
+                    <div class="ep-tools-title">
+                        <h1 class="page-header text-overflow ep-graph-title">
+                            <i class="fa {{graph.iconclass|default:nav.icon}} text-center icon-wrap bg-gray ep-graph-title-icon"></i>
+                            <span>{% trans nav.title %}</span>
+                        </h1>
+                    </div>
+                    {% endblock graph_title %}
+
+                </div>
+
+                <!-- Top Right Nav  -->
+                <nav class="col-xs-12 col-sm-4" id="user-actions-top-right-nav"> 
+
+                    <ul class="top-right-nav" aria-label="{% trans 'User and User Actions Navigation' %}">
+                        
+                        <!-- Welcome -->
+                        {% if nav.login and user.username != 'anonymous' %}
+                        <li class="hidden-xs">
+                            <a href="{% url 'user_profile_manager' %}"
+                                class="ep-tools ep-tools-login">
+                                <div data-placement="bottom"
+                                    data-toggle="tooltip"
+                                    data-original-title="{% trans 'Profile' %}">
+                                    <!-- ko let: {user: '{{ user.first_name|default:user.username }}' }  -->
+                                    <span class="hidden-xs h5" data-bind="attr: {'aria-label': $root.translations.welcomeUserEditProfile(user) }"
+                                    >{% trans "Welcome" %}, {{ user.first_name|default:user.username }}</span>
+                                    <!-- /ko -->
+                                </div>
+                            </a>
+                        </li>
+                        {% endif %}
+
+                        {% if show_language_swtich %}
+                        {% get_current_language as LANGUAGE_CODE %}
+                        <li aria-label="{% trans 'Choose your language' %}">
+                            <div class="lang-switch ep-tools ep-tools-right" style="max-width: none;" data-bind='component: {
+                                name: "views/components/language-switcher",
+                                params: {
+                                    current_language: "{{LANGUAGE_CODE}}"
+                                }
+                            }'></div>
+                        </li>
+                        {% endif %}
+
+                        <!-- Notifications -->
+                        {% if nav.notifs %}
+                        <li>
+                            <button id="ep-notifs-button" class="ep-tools ep-notifs-toggle ep-tools-right" data-toggle="collapse" data-target="#ep-notifs-panel"
+                                aria-label="{% trans 'Show recent notifications' %}" aria-controls="ep-notifs-panel"
+                                data-bind="click: function(data, event) { 
+                                    openNotifs(event.currentTarget, '#ep-notifs-panel', '#ep-close-notifs-button'); 
+                                }, attr: {'aria-expanded': notifsOpen().toString()},
+                            ">
+                                <div data-placement="bottom" data-toggle="tooltip"
+                                    data-original-title="{% trans 'Notifications' %}">
+                                    <div>
+                                        <div data-bind="visible: unreadNotifs()" id="circle-outline"></div>
+                                        <div data-bind="visible: unreadNotifs()" id="circle"></div>
+                                        <i class="fa fa-bell"></i>
+                                    </div>
+                                </div>
+                            </button>
+                        </li>
+                        {% endif %}
+
+                        <!-- Search Bar -->
+                        {% if nav.search %}
+                        <li>
+                            <a href="{% url 'search_home' %}" class="ep-tools ep-tools-right" aria-label="{% trans 'Visit the Search page' %}"
+                                data-bind="click:function () { navigate('{% url 'search_home' %}') }">
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Search" %}">
+                                    <i class="ion-search"></i>
+
+                                </div>
+                            </a>
+                        </li>
+                        {% endif %}
+
+                        <!-- Prov edit history-->
+                        {% if user_is_reviewer == False and user_can_edit %}
+                        <li>
+                            <button id="ep-edits-button" class="ep-edits-toggle ep-tools ep-tools-right" data-toggle="collapse" data-target="#ep-edits-panel"
+                                aria-label="{% trans 'Show my recent edits' %}" aria-controls="ep-edits-panel"
+                                data-bind="click:function (data, event) { 
+                                    openEdits(event.currentTarget, '#ep-edits-panel', '#ep-close-edits-button');
+                                }, attr: {'aria-expanded': editsOpen().toString()},
+                            ">
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "My Recent Edits" %}">
+                                    <i class="ion-clock"></i>
+                                </div>
+                            </button>
+                        </li>
+                        {% endif %}
+
+                        {% if nav.res_edit and user_can_edit %}
+                        <li>
+                            <a href="{% url 'resource_editor' resourceid %}" class="ep-tools ep-tools-right"
+                                data-bind="click:function () { navigate('{% url 'resource_editor' resourceid %}') }" aria-label="{% trans 'Edit Resource' %}">
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Edit Resource" %}">
+                                    <i class="ion-edit"></i>
+                                </div>
+                            </a>
+                        </li>
+                        {% endif %}
+
+                        {% if nav.report_view %}
+                        <li>
+                            <a href="{% url 'resource_report' resourceid %}" class="ep-tools ep-tools-right"
+                                data-bind="click:function () { navigate('{% url 'resource_report' resourceid %}') }" aria-label="{% trans 'View Report' %}">
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "View Report" %}">
+                                    <i class="ion-android-document"></i>
+                                </div>
+                            </a>
+                        </li>
+                        {% endif %}
+
+                        {% if nav.print %}
+                        <li>
+                            <button class="ep-tools ep-tools-right" data-bind="click: function() { location.href = location.href + '?print' }" aria-label="{% trans 'Print the page' %}">
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Print" %}">
+                                    <i class="ion-printer"></i>
+                                </div>
+                            </button>
+                        </li>
+                        {% endif %}
+
+                        {% if nav.help %}
+                        <li>
+                            <button id="ep-help-button" class="ep-help-toggle ep-tools ep-tools-right" data-toggle="collapse" data-target="#ep-help-panel"
+                                aria-label="{% trans 'Show help' %}" aria-controls="ep-help-panel"
+                                data-bind="click: function(data, event){ 
+                                    openHelp({{ nav.help.templates }}, event.currentTarget, '#ep-help-panel', '#ep-close-help-button');
+                                }, attr: { 'aria-expanded': helpOpen().toString()},
+                            ">
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Help" %}">
+                                    <i class="ion-help"></i>
+                                </div>
+                            </button>
+                        </li>
+                        {% endif %}
+
+                        <!-- Login / Logout -->
+                        <li>
+                            <!-- Login -->
+                            {% if user.username == 'anonymous' %}
+                            <a href="{% url 'auth' %}?next={{ request.get_full_path }}"
+                                class="ep-help-toggle ep-tools ep-tools-right"
+                                aria-label="{% trans 'Login' %}"
+                            >
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans 'Login' %}">
+                                    <i class="ion-log-in"></i>
+                                </div>
+                            </a>
+                            <!-- Logout -->
+                            {% else %}
+                            <a href="{% url 'auth' %}?next={{ request.get_full_path }}&logout=true"
+                                class="ep-help-toggle ep-tools ep-tools-right"
+                                aria-label="{% trans 'Logout' %}"
+                            >
+                                <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans 'Logout' %}">
+                                    <i class="ion-log-out"></i>
+                                </div>
+                            </a>
+                            {% endif %}
+                        </li>
+
+                    </ul>
+
+                </nav>
+
+            <!-- Notifications Panel -->
+            <div id="ep-notifs-panel" tabindex="-1" class="ep-notifs" style="display:none;" aria-label="{% trans 'Notifications' %}"
+                data-bind="slide: notifsOpen, duration: 400, direction: {direction: 'right'}, easing: 'slide'"
+            >
+                <div class="ep-edits-header">
+                    <div class="ep-help-title">
+                        <span>{% trans 'Notifications' %}</span>
+                    </div>
+                    <a href="javascript:void(0);" id="ep-close-notifs-button" role="button" aria-label="{% trans 'Close Notifications' %}"
+                        class="ep-notifs-toggle ep-notifs-close ep-tools ep-tools-right" data-bind="click: closeNotifs"
+                    >
+                        <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Close" %}">
+                            <i class="fa fa-times-circle fa-lg"></i>
+                        </div>
+                    </a>
+                </div>
+
+                <div class="ep-edits-body provisional-edit-history" style="float:left"
+                    data-bind="css: {'loading-mask': helploading()}">
+                    <div class="ep-edits-content">
+                        {% include 'views/notifications-list.htm' %}
+                    </div>
+                </div>
+            </div>
+
+            <!-- Edits Panel -->
+            <div id="ep-edits-panel" tabindex="-1" class="ep-edits" style="display:none;" aria-label="{% trans 'Edit History' %}"
+                data-bind="slide: editsOpen, duration: 400, direction: {direction: 'right'}, easing: 'slide'"
+            >
+                <div class="ep-edits-header">
+                    <div class="ep-edits-title">
+                        <span>{% trans 'My Edit History' %}</span>
+                    </div>
+                    <a href="javascript:void(0);" id="ep-close-edits-button" role="button" style="border:none;" aria-label="{% trans 'Close Edit History' %}"
+                        class="ep-edits-toggle ep-edits-close ep-tools ep-tools-right" data-bind="click: closeEdits"
+                    >
+                        <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Close" %}">
+                            <i class="fa fa-times-circle fa-lg"></i>
+                        </div>
+                    </a>
+                </div>
+
+                <div class="ep-edits-body provisional-edit-history" style="float:left"
+                    data-bind="css: {'loading-mask': helploading()}">
+                    <div class="ep-edits-content">
+                        {% include 'views/provisional-history-list.htm' %}
+                    </div>
+                </div>
+            </div>
+
+            <!-- Help Panel -->
+            <div id="ep-help-panel" tabindex="-1" class="ep-help" style="display: none" aria-label="{% trans 'Site Help' %}"
+                data-bind="slide: helpOpen, duration: 400, direction: {direction: 'right'}, easing: 'slide'">
+                <div class="ep-edits-header">
+                    <div class="ep-help-title">
+                        <span>{% trans nav.help.title %}</span>
+                    </div>
+                    <a href="javascript:void(0);" id="ep-close-help-button" role="button" style="border:none" aria-label="{% trans 'Close Help' %}"
+                        class="ep-help-toggle ep-help-close ep-tools ep-tools-right" data-bind="click: closeHelp"
+                    >
+                        <div data-placement="bottom" data-toggle="tooltip" data-original-title="{% trans "Close Help" %}">
+                            <i class="fa fa-times-circle fa-lg"></i>
+                        </div>
+                    </a>
+                </div>
+
+                <!-- help content loaded from contextually referenced template -->
+                <div class="ep-help-body" data-bind="css: {'loading-mask': helploading()}">
+                    <!-- content gets inserted into this div -->
+                    <div class="ep-help-content"></div>
+                    <hr>
+                    <span class="h5">{% trans "for more documentation, visit" %} <a href="https://arches.readthedocs.io/"
+                            target="_blank">arches.readthedocs.io <i class="fa fa-external-link-square" aria-hidden="true"></i></a>
+                    </span>
+                </div>
+            </div>
+            {% endblock header %}
+
+        </header>
+        
+        <main id="main-content" role="main">
+            <p id="skip-target-holder">
+                <a id="skiptocontent" name="skiptocontent" class="skip" tabindex="-1" data-bind="attr:{
+                    'aria-label': $root.translations.skipToContent,
+                    innertext: $root.translations.skipToContent}"></a>
+            </p>
+            {% block main_content %}
+            {% endblock main_content %}
+        </main>
+
+    </div>
+
+    <button id="backToTopBtn" aria-hidden="true" data-bind="attr: {'aria-label': $root.translations.goToTop}, click: backToTopHandler, event:{keyup: backToTopHandler}">
+        <i class="fa fa-chevron-up"></i>
+    </button>
+
+{% endblock body %}
+
+
+{% block pre_require_js %}
+    <div 
+        id="viewData"
+        style="display: none;"
+        viewData='{
+            "graphs": {{graphs}},
+            "createableResources": {{createable_resources}},
+            "help": "{{nav.help.template}}",
+            "userCanEditResources": "{{ user_can_edit }}",
+            "userCanReadResources": "{{ user_can_read }}"
+        }'
+    ></div>
+{% endblock pre_require_js %}

--- a/coral/templates/views/components/reports/activity.htm
+++ b/coral/templates/views/components/reports/activity.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+        <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Activity" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+        <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -70,7 +75,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -81,7 +86,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -90,7 +95,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -100,7 +105,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'archive'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'archive' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.activityArchive)}, css: {'fa-angle-double-right': visible.activityArchive(), 'fa-angle-double-up': !visible.activityArchive()}"  class="fa toggle"></i> {% trans "Activity Archive Material" %}</h2>
                     <a data-bind="{if: cards.activityArchive, click: function(){addNewTile(cards.activityArchive)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Archive Material" %}</a>
@@ -153,7 +158,7 @@
                 </div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/application-area.htm
+++ b/coral/templates/views/components/reports/application-area.htm
@@ -7,17 +7,21 @@
     <div class="relative">
 
         <!-- Title Block -->
+         <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Application Area" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
-
+        <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
     </div>
     {% endblock report_title_bar %}
 
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +31,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +42,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +52,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -59,7 +63,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -70,7 +74,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -128,7 +132,7 @@
                 </div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -139,7 +143,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -148,7 +152,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'communication' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/coral/templates/views/components/reports/application-area.htm
+++ b/coral/templates/views/components/reports/application-area.htm
@@ -168,7 +168,9 @@
 
 {% block summary %}
 <div class="aher-summary-report-header">
-    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Application Area)" %}</span></h1>
+    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span>
+        <!-- <span class="aher-report-name pad-lft-sm">{% trans "(Application Area)" %}</span> -->
+    </h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">

--- a/coral/templates/views/components/reports/archive-source.htm
+++ b/coral/templates/views/components/reports/archive-source.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+        <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Archive Source" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+        <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Archive Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'archive'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'archive' || print()">
                 <div>
                     <h2 class="aher-report-section-subtitle" style="display: block; margin-bottom: 5px;"><i data-bind="click: function() {toggleVisibility(visible.archiveHolding)}, css: {'fa-angle-double-right': visible.archiveHolding(), 'fa-angle-double-up': !visible.archiveHolding()}" class="fa toggle"></i> <span>{% trans "Archive Holding" %}</span></h2>
                     <div data-bind="visible: visible.archiveHolding">
@@ -101,7 +106,7 @@
                 </div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'images' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -112,7 +117,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -123,7 +128,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/archive-source.htm
+++ b/coral/templates/views/components/reports/archive-source.htm
@@ -143,7 +143,9 @@
 
 {% block summary %}
 <div class="aher-summary-report-header">
-    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Archive Source)" %}</span></h1>
+    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span>
+        <!-- <span class="aher-report-name pad-lft-sm">{% trans "(Archive Source)" %}</span> -->
+    </h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">

--- a/coral/templates/views/components/reports/area.htm
+++ b/coral/templates/views/components/reports/area.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+        <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Area" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+        <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -71,7 +76,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -81,7 +86,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -91,7 +96,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'images' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -101,7 +106,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -111,7 +116,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -122,7 +127,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/artefact.htm
+++ b/coral/templates/views/components/reports/artefact.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Artefact" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -71,7 +76,7 @@
                 }"></div>
             </div>
             <!-- Publication Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'publication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'publication' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/copyright',
                     params: {
@@ -81,7 +86,7 @@
                 }"></div>
             </div>
             <!-- Discovery Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'discovery'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'discovery' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.discovery)}, css: {'fa-angle-double-right': visible.discovery(), 'fa-angle-double-up': !visible.discovery()}" class="fa toggle"></i> {% trans "Discovery" %}</h2>
                     <a class="aher-report-a" data-bind="{if: cards.discovery, event:{ mousedown:function(d, e){addNewTile(cards.discovery, e)}}}"><i class="fa fa-mail-reply"></i> <span data-bind="if: discovery().length">{% trans "Edit Discovery" %}</span><span data-bind="ifnot: discovery().length">{% trans "Add Discovery" %}</span></a>
@@ -184,7 +189,7 @@
                 </div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -195,7 +200,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -206,7 +211,7 @@
                 }"></div>
             </div>
             <!-- Archive Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'archive'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'archive' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/archive',
                     params: {
@@ -217,7 +222,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -228,7 +233,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/bibliographic-source.htm
+++ b/coral/templates/views/components/reports/bibliographic-source.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Bibliographic Source" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'source'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'source' || print()">
 
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.sourceNames)}, css: {'fa-angle-double-right': visible.sourceNames(), 'fa-angle-double-up': !visible.sourceNames()}" class="fa toggle"></i> {% trans "Names" %}</h2>
@@ -101,7 +106,7 @@
                 </div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -111,7 +116,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -122,7 +127,7 @@
                 }"></div>
             </div>
             <!-- Publication Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'publication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'publication' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.publication)}, css: {'fa-angle-double-right': visible.publication(), 'fa-angle-double-up': !visible.publication()}" class="fa toggle"></i> {% trans "Publication" %}</h2>
                     <span data-bind="if: cards.publication && (!publication().length || cards.publication.cardinality == 'n')">
@@ -234,7 +239,7 @@
                 }"></div>
             </div>
            <!-- Resources Tab -->
-           <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+           <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                <div data-bind="component: {
                    name: 'views/components/reports/scenes/resources',
                    params: {
@@ -245,7 +250,7 @@
                }"></div>
            </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/consultation.htm
+++ b/coral/templates/views/components/reports/consultation.htm
@@ -818,7 +818,9 @@
 
 {% block summary %}
 <div class="aher-summary-report-header">
-    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Consultation)" %}</span></h1>
+    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span>
+        <!-- <span class="aher-report-name pad-lft-sm">{% trans "(Consultation)" %}</span> -->
+    </h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">

--- a/coral/templates/views/components/reports/consultation.htm
+++ b/coral/templates/views/components/reports/consultation.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Consultation" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Consultation Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'details'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'details' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -59,7 +64,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -76,7 +81,7 @@
                 }"></div>
             </div>
             <!-- Planning Reference Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'references'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'references' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.references)}, css: {'fa-angle-double-right': visible.references(), 'fa-angle-double-up': !visible.references()}"  class="fa toggle"></i> {% trans "External Cross References" %}</h2>
                     <a data-bind="{if: cards['external cross references'], click: function(){addNewTile(cards['external cross references'])}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add external cross references" %}</a>
@@ -179,7 +184,7 @@
                 </div>
             </div>
             <!-- Contacts Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'contacts'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'contacts' || print()">
                 <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.contacts)}, css: {'fa-angle-double-right': visible.contacts(), 'fa-angle-double-up': !visible.contacts()}" class="fa toggle"></i> {% trans "Contacts" %}</h2>
                 <a data-bind="{if: cards.contacts, click: function(){ addNewTile(cards.contacts) }}" class="aher-report-a">
                     <i class="fa fa-mail-reply"></i>
@@ -260,7 +265,7 @@
             </div>
 
             <!-- Consultation Progression Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'progression'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'progression' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.proposal)}, css: {'fa-angle-double-right': visible.proposal(), 'fa-angle-double-up': !visible.proposal()}"  class="fa toggle"></i> {% trans "Proposal" %}</h2>
                     <a data-bind="{if: cards.proposal, click: function(){addNewTile(cards.proposal)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add proposal" %}</a>
@@ -484,7 +489,7 @@
                 </div>
             </div>
             <!-- Correspondence Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'correspondence'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'correspondence' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.correspondence)}, css: {'fa-angle-double-right': visible.correspondence(), 'fa-angle-double-up': !visible.correspondence()}"  class="fa toggle"></i> {% trans "Correspondence" %}</h2>
                     <a data-bind="{if: cards.correspondence, click: function(){addNewTile(cards.correspondence)}}" class="aher-report-a"><i class="fa fa-mail-reply"></i> {% trans "Add Correspondence" %}</a>
@@ -593,7 +598,7 @@
                 </div>
             </div>
             <!-- Site Visit Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'sitevisits'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'sitevisits' || print()">
                 <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.siteVisits)}, css: {'fa-angle-double-right': visible.siteVisits(), 'fa-angle-double-up': !visible.siteVisits()}" class="fa toggle"></i> {% trans "Site Visits" %}</h2>
                 <a data-bind="{if: cards['site visits'], click: function(){ addNewTile(cards['site visits']) }}" class="aher-report-a">
                     <i class="fa fa-mail-reply"></i>
@@ -787,7 +792,7 @@
                 </div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -798,7 +803,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/digital-object.htm
+++ b/coral/templates/views/components/reports/digital-object.htm
@@ -124,7 +124,9 @@
 
 {% block summary %}
 <div class="aher-summary-report-header">
-    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Digital Object)" %}</span></h1>
+    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span>
+        <!-- <span class="aher-report-name pad-lft-sm">{% trans "(Digital Object)" %}</span> -->
+    </h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">

--- a/coral/templates/views/components/reports/digital-object.htm
+++ b/coral/templates/views/components/reports/digital-object.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Digital Object" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
     
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +53,7 @@
                 }"></div>
             </div>
             <!-- Publication Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'publication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'publication' print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/copyright',
                     params: {
@@ -58,7 +63,7 @@
                 }"></div>
             </div>
             <!-- File Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'file'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'file' print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}"  class="fa toggle"></i> {% trans "Files" %}</h2>
                     <a data-bind="{if: cards['file'], click: function(){addNewTile(cards['file'])}}" class="aher-report-a">
@@ -104,7 +109,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/heritage-area.htm
+++ b/coral/templates/views/components/reports/heritage-area.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Heritage Area" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
     
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -71,7 +76,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -81,7 +86,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -91,7 +96,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'images' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -101,7 +106,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -111,7 +116,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -122,7 +127,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/heritage-asset.htm
+++ b/coral/templates/views/components/reports/heritage-asset.htm
@@ -7,11 +7,11 @@
     <div class="relative">
 
         <!-- Title Block -->
-                  <!-- ko if: !print()-->
+        <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Heritage Asset" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
-                <!-- /ko -->
+        <!-- /ko -->
         <!-- ko else -->
         <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         <!-- /ko -->
@@ -151,7 +151,9 @@
 
 {% block summary %}
 <div class="aher-summary-report-header">
-    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Heritage Asset)" %}</span></h1>
+    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span>
+        <!-- <span class="aher-report-name pad-lft-sm">{% trans "(Heritage Asset)" %}</span> -->
+    </h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">

--- a/coral/templates/views/components/reports/heritage-asset.htm
+++ b/coral/templates/views/components/reports/heritage-asset.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Heritage Asset" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
     
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -70,7 +75,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -80,7 +85,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -90,7 +95,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'images' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -100,7 +105,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -110,7 +115,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -121,7 +126,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -130,7 +135,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'communication' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/coral/templates/views/components/reports/heritage-story.htm
+++ b/coral/templates/views/components/reports/heritage-story.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Heritage Story" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
     
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -71,7 +76,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/historic-aircraft.htm
+++ b/coral/templates/views/components/reports/historic-aircraft.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Historic Aircraft" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -37,7 +42,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +53,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -59,7 +64,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -69,7 +74,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -79,7 +84,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -89,7 +94,7 @@
                 }"></div>
             </div>
             <!-- Status/Owner Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'status'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'status' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -98,7 +103,7 @@
                 }"></div>
             </div>
             <!-- Journeys -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'journey'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'journey' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.flights)}, css: {'fa-angle-double-right': visible.flights(), 'fa-angle-double-up': !visible.flights()}" class="fa toggle"></i> {% trans "Flights" %}</h2>
                     <a class="aher-report-a" data-bind="{if: cards.flights, event:{ mousedown:function(d, e){addNewTile(cards.flights, e)}}}"><i class="fa fa-mail-reply"></i> <span data-bind="if: flights().length">{% trans "Edit Flight" %}</span><span data-bind="ifnot: flights().length">{% trans "Add Flight" %}</span></a>
@@ -258,7 +263,7 @@
                 </div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -268,7 +273,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -279,7 +284,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/historic-landscape-characterization.htm
+++ b/coral/templates/views/components/reports/historic-landscape-characterization.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Historic Landscape Characterization" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -70,7 +75,7 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'hlc-attributes'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'hlc-attributes' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -79,7 +84,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <!-- HLC Phase section -->
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.historicLandscapeClassificationPhase)}, css: {'fa-angle-double-right': visible.historicLandscapeClassificationPhase(), 'fa-angle-double-up': !visible.historicLandscapeClassificationPhase()}" class="fa toggle"></i> {% trans "HLC Phase" %}</h2>
@@ -163,7 +168,7 @@
                 </div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -172,7 +177,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'communication' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/coral/templates/views/components/reports/historic-landscape-characterization.htm
+++ b/coral/templates/views/components/reports/historic-landscape-characterization.htm
@@ -193,7 +193,9 @@
 
 {% block summary %}
 <div class="aher-summary-report-header">
-    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Historic Landscape Characterization)" %}</span></h1>
+    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span>
+        <!-- <span class="aher-report-name pad-lft-sm">{% trans "(Historic Landscape Characterization)" %}</span> -->
+    </h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">

--- a/coral/templates/views/components/reports/maritime-vessel.htm
+++ b/coral/templates/views/components/reports/maritime-vessel.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Maritime Vessel" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -37,7 +42,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +53,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -59,7 +64,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -69,7 +74,7 @@
                 }"></div>
             </div>
             <!-- Status/Owner Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'status'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'status' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -183,7 +188,7 @@
             </div>
 
             <!-- Journeys -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'journey'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'journey' || print()">
                 <div class="aher-report-section">
                     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.voyages)}, css: {'fa-angle-double-right': visible.voyages(), 'fa-angle-double-up': !visible.voyages()}" class="fa toggle"></i> {% trans "Voyages" %}</h2>
                     <a class="aher-report-a" data-bind="{if: cards.voyages, event:{ mousedown:function(d, e){addNewTile(cards.voyages, e)}}}"><i class="fa fa-mail-reply"></i> <span>{% trans "Add Voyage" %}</span></a>
@@ -266,7 +271,7 @@
                 </div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -276,7 +281,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -286,7 +291,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'images' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -296,7 +301,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -306,7 +311,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -317,7 +322,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -326,7 +331,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'communication' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/coral/templates/views/components/reports/maritime-vessel.htm
+++ b/coral/templates/views/components/reports/maritime-vessel.htm
@@ -9,7 +9,7 @@
         <!-- Title Block -->
                   <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
-            <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Maritime Vessel" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+            <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
                 <!-- /ko -->
         <!-- ko else -->
@@ -347,7 +347,7 @@
 
 {% block summary %}
 <div class="aher-summary-report-header">
-    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Maritime Vessel)" %}</span></h1>
+    <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">

--- a/coral/templates/views/components/reports/monument.htm
+++ b/coral/templates/views/components/reports/monument.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Monument" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -49,7 +54,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -60,7 +65,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -70,7 +75,7 @@
                 }"></div>
             </div>
             <!-- Designation/Protection Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'protection'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'protection' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/protection',
                     params: {
@@ -80,7 +85,7 @@
                 }"></div>
             </div>
             <!-- Assessments Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'assessments' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/assessments',
                     params: {
@@ -90,7 +95,7 @@
                 }"></div>
             </div>
             <!-- Images Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'images'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'images' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/images',
                     params: {
@@ -100,7 +105,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/people',
                     params: {
@@ -110,7 +115,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -121,7 +126,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {
@@ -130,7 +135,7 @@
                 }"></div>
             </div>
             <!-- Communication Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'communication'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'communication' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/communication',
                     params: {

--- a/coral/templates/views/components/reports/organization.htm
+++ b/coral/templates/views/components/reports/organization.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Place" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
     
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -39,7 +44,7 @@
             </div>
 
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -57,7 +62,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -68,7 +73,7 @@
                 }"></div>
             </div>
             <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/resources',
                     params: {
@@ -79,7 +84,7 @@
                 }"></div>
             </div>
             <!-- People Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'people'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'people' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -88,7 +93,7 @@
                 }"></div>
             </div>
             <!-- Contact Details Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'contact'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'contact' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/contact',
                     params: {
@@ -98,7 +103,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -109,7 +114,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/period.htm
+++ b/coral/templates/views/components/reports/period.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+                  <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Period" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
 
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -50,7 +55,7 @@
             </div>
 
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -61,7 +66,7 @@
                 }"></div>
             </div>
             <!-- Period Names Tab -->
-            <div class="afs-report-page" data-bind="if: activeSection() === 'period'">
+            <div class="afs-report-page" data-bind="if: activeSection() === 'period' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/default',
                     params: {
@@ -118,7 +123,7 @@
                 </div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -129,7 +134,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {

--- a/coral/templates/views/components/reports/person.htm
+++ b/coral/templates/views/components/reports/person.htm
@@ -6,10 +6,14 @@
     <div class="relative">
 
         <!-- Title Block -->
-        <div class="aher-report-toolbar" data-bind="if: !print()">
+                  <!-- ko if: !print()-->
+        <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Person" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
-        <h1 class="aher-report-toolbar-title" data-bind="if: print()"><span class="aher-report-name">{% trans "Person" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+                <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}

--- a/coral/templates/views/components/reports/place.htm
+++ b/coral/templates/views/components/reports/place.htm
@@ -7,9 +7,14 @@
     <div class="relative">
 
         <!-- Title Block -->
+        <!-- ko if: !print()-->
         <div class="aher-report-toolbar">
             <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Place" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
         </div>
+        <!-- /ko -->
+        <!-- ko else -->
+        <h1 class="aher-report-toolbar-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        <!-- /ko -->
 
     </div>
     {% endblock report_title_bar %}
@@ -17,7 +22,7 @@
     
     {% block body %}
     <!-- Link nav -->
-    <div class="aher-report-anchor-container">
+    <div class="aher-report-anchor-container" data-bind="if: !print()">
         <ol class="aher-report-anchors breadcrumb">
             <!-- ko foreach: {data: sections, as: 'section'} -->
             <li tabindex="0" data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }"></li>
@@ -27,7 +32,7 @@
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
             <!-- Names Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/name',
                     params: {
@@ -38,7 +43,7 @@
                 }"></div>
             </div>
             <!-- Description Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/description',
                     params: {
@@ -48,7 +53,7 @@
                 }"></div>
             </div>
             <!-- Classification Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'classifications' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/classifications',
                     params: {
@@ -59,7 +64,7 @@
                 }"></div>
             </div>
             <!-- Location Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div class="aher-report-page" data-bind="if: activeSection() === 'location' || print()">
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
@@ -70,7 +75,7 @@
                 }"></div>
             </div>
              <!-- JSON Tab -->
-            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json'">
+            <div class="aher-report-page aher-flex-col" data-bind="if: activeSection() === 'json' || print()">
                 <div class="aher-flex-col" data-bind="component: {
                     name: 'views/components/reports/scenes/json',
                     params: {


### PR DESCRIPTION
This replaces the report js and htm files. It also creates a local version of base-manager.htm so that I was able to change the print button

## test
test available at [Taiga 1753](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/1753?milestone=403553)