### PR TITLE
Fix/2388 prevent remap validating ha numbers

### DIFF
--- a/coral/functions/ha_number_function.py
+++ b/coral/functions/ha_number_function.py
@@ -18,6 +18,9 @@ details = {
 
 class HaNumberFunction(BaseFunction):
     def post_save(self, tile, request, context):
+        if context and context.get('escape_function', False):
+            return
+
         resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
         id_number = tile.data.get(SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID, None)
 

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=5, patch=28)
+APP_VERSION = semantic_version.Version(major=5, minor=5, patch=29)
 
 GROUPINGS = {
     "groups": {

--- a/coral/utils/merge_resources.py
+++ b/coral/utils/merge_resources.py
@@ -80,7 +80,7 @@ class MergeResources:
                         data={},
                         nodegroup=tile.parenttile.nodegroup,
                     )
-                    parent_tile.save()
+                    parent_tile.save(context={"escape_function": True})
                     parent_merge_data["base_tiles"].append(parent_tile)
 
             # Check for an existing parent tile that was indexed aganist
@@ -95,7 +95,7 @@ class MergeResources:
                         data={},
                         nodegroup=tile.parenttile.nodegroup,
                     )
-                    parent_tile.save()
+                    parent_tile.save(context={"escape_function": True})
                     self.parent_tiles_map[merge_parent_tile_id] = parent_tile
                 else:
                     parent_tile = self.parent_tiles_map[merge_parent_tile_id]
@@ -356,7 +356,7 @@ class MergeResources:
                         data=merge_tile.data,
                         nodegroup=merge_tile.nodegroup,
                     )
-                    new_tile.save()
+                    new_tile.save(context={"escape_function": True})
                     continue
 
                 # Merge data from base tile over the merge tile and update
@@ -366,7 +366,7 @@ class MergeResources:
                         base_tile.data, merge_tile.data
                     )
                     base_tile.data = merged_tile_data
-                    base_tile.save()
+                    base_tile.save(context={"escape_function": True})
                     continue
             # Create the additional tiles for the base resource
             if merge_data["cardinality"] == "n":
@@ -383,7 +383,7 @@ class MergeResources:
                         data=tile.data,
                         nodegroup=tile.nodegroup,
                     )
-                    new_tile.save()
+                    new_tile.save(context={"escape_function": True})
 
         # Create a new tile for the merge tracker and
         # relate the two resources used in the merge

--- a/coral/utils/remap_resources.py
+++ b/coral/utils/remap_resources.py
@@ -153,7 +153,7 @@ class RemapResources:
             data={},
             nodegroup=destination_parent_nodegroup,
         )
-        parent_tile.save()
+        parent_tile.save(context={"escape_function": True})
         self.created_parent_tiles[target_parent_tile_id] = parent_tile
 
         return parent_tile
@@ -274,7 +274,7 @@ class RemapResources:
                         nodegroup=destination_nodegroup,
                     )
 
-                destination_tile.save()
+                destination_tile.save(context={"escape_function": True})
 
                 # If this is true, it means the parent tile had data and needed
                 # that data to be remapped. We then add into the created parent


### PR DESCRIPTION
**Description**

After you've started the designation workflow and create a copy of a Monument. You'll finish the workflow updating what you want but on the last step where you apply the revision. This process needs to copy all the data back into a temporary Monument so that it can all be merged back into the original. This causes problems because the HA Number must be unique to resolve this I've re-used the escape function logic to prevent those functions from firing.