### PR TITLE
Feat/#1758/update designation workflow

### DIFF
--- a/coral/media/js/views/components/plugins/workflow-builder-loader.js
+++ b/coral/media/js/views/components/plugins/workflow-builder-loader.js
@@ -23,7 +23,7 @@ define([
   'views/components/workflows/heritage-asset-designation-workflow/approval-summary',
   'views/components/workflows/heritage-asset-designation-workflow/start-remap-and-merge',
   'views/components/workflows/assign-consultation-workflow/pc-summary',
-  'views/components/workflows/excavation-license-workflow/excavation-report-step',
+  'views/components/workflows/excavation-licence-workflow/excavation-report-step',
   'views/components/workflows/fetch-latest-tile',
 ], function (ko, arches, OpenableWorkflow, workflowTemplate) {
   return ko.components.register('workflow-builder-loader', {

--- a/coral/media/js/views/components/workflows/excavation-licence-workflow/excavation-report-step.js
+++ b/coral/media/js/views/components/workflows/excavation-licence-workflow/excavation-report-step.js
@@ -1,0 +1,34 @@
+define([
+  'underscore',
+  'knockout',
+  'knockout-mapping',
+  'uuid',
+  'arches',
+  '../default-card-util.js',
+  'templates/views/components/workflows/default-card-util.htm',
+], function (_, ko, koMapping, uuid, arches, DefaultCardUtilViewModel, componentTemplate) {
+  function viewModel(params) {
+
+  DefaultCardUtilViewModel.apply(this, [params]);
+
+  this.DOCUMENT_REFERENCE_NODE = "d8f74d42-dc6e-11ee-8def-0242ac120006"
+
+      params.disableAdd(true)
+
+      this.tile.data[this.DOCUMENT_REFERENCE_NODE].subscribe((newValue) => {
+          if (newValue.en.value != ""){
+
+              params.disableAdd(false)
+          }
+      })
+
+
+  }
+
+  ko.components.register('excavation-report-step', {
+    viewModel: viewModel,
+    template: componentTemplate
+  });
+
+  return viewModel;
+});

--- a/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-licence-details.js
+++ b/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-licence-details.js
@@ -86,15 +86,15 @@ define([
       }
     };
 
-    this.findLicense = async function (siteResourceId) {
+    this.findLicence = async function (siteResourceId) {
       const tiles = await this.fetchTileData(siteResourceId)
       for (const tile of tiles) {
         if (tile.nodegroup === this.ACTIVITY_NAME_NODEGROUP) {
           const siteName = tile.data[this.ACTIVITY_NAME_NODE].en.value;
           this.siteName(siteName);
         }
-        if (tile.nodegroup === this.SELECTED_LICENSE_NODEGROUP_AND_NODE) {
-          const preFilled = tile.data[this.SELECTED_LICENSE_NODEGROUP_AND_NODE]
+        if (tile.nodegroup === this.SELECTED_LICENCE_NODEGROUP_AND_NODE) {
+          const preFilled = tile.data[this.SELECTED_LICENCE_NODEGROUP_AND_NODE]
           this.selectedResource(preFilled[0].resourceId)
           this.getDetails(preFilled[0].resourceId);
         }
@@ -106,7 +106,7 @@ define([
       for (const tile of tiles) {
         if (tile.nodegroup === this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE) {
           const preFilled = tile.data[this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE]
-          this.findLicense(preFilled[0].resourceId)
+          this.findLicence(preFilled[0].resourceId)
         }
       }
     }

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -2333,6 +2333,28 @@
                     "widget_id": "10000000-0000-0000-0000-000000000001"
                 },
                 {
+                    "card_id": "67712ce4-378e-11ef-9263-0242ac150006",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Land Use Site",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "67714256-378e-11ef-9263-0242ac120006",
+                    "label": {
+                        "en": "Land Use Site"
+                    },
+                    "node_id": "5782bd48-6aa6-11ef-b2e2-0242ac120006",
+                    "sortorder": 6,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                },
+                {
                     "card_id": "280b2f9d-e879-4e5f-984e-157ae4f8ffbd",
                     "config": {
                         "defaultResourceInstance": [],
@@ -21948,7 +21970,7 @@
                     "nodeid": "5782bd48-6aa6-11ef-b2e2-0242ac120006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E15_Identifier_Assignment",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
-                    "sortorder": 3,
+                    "sortorder": 9,
                     "sourcebranchpublication_id": null
                 },
                 {
@@ -28858,7 +28880,7 @@
                 {
                     "alias": "county_value",
                     "config": {
-                        "rdmCollection": "02458080-9b7a-4a02-b298-f7ea61f60dbb"
+                        "rdmCollection": "763ba635-3800-324a-8d54-c1427bcaa5aa"
                     },
                     "datatype": "concept",
                     "description": null,

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -2306,6 +2306,27 @@
                 {
                     "card_id": "0e47da02-80e7-4763-b036-5e5ea193fa45",
                     "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Listing Criteria",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "0c69ba9c-56ea-4bf4-8e67-a1a88c0bb289",
+                    "label": {
+                        "en": "Listing Criteria"
+                    },
+                    "node_id": "f4c393ac-6aa6-11ef-b1e8-a1a88c0bb289",
+                    "sortorder": 4,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                },
+                {
+                    "card_id": "0e47da02-80e7-4763-b036-5e5ea193fa45",
+                    "config": {
                         "defaultValue": {
                             "en": {
                                 "direction": "ltr",
@@ -15111,6 +15132,15 @@
                 {
                     "description": null,
                     "domainnode_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
+                    "edgeid": "448093b0-9df6-4e18-9c3d-3a8d4d61ae9c",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "f4c393ac-6aa6-11ef-b1e8-a1a88c0bb289"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
                     "edgeid": "5ffa0842-97b9-4f1a-ad91-3a8d4d61ae9c",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "name": null,
@@ -21944,6 +21974,29 @@
                 }
             ],
             "nodes": [
+                {
+                    "alias": "listing_criteria",
+                    "config": {
+                        "rdmCollection": "ddb92162-2508-4900-a8d5-92c0ec7769af"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Listing Criteria",
+                    "nodegroup_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
+                    "nodeid": "f4c393ac-6aa6-11ef-b1e8-a1a88c0bb289",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 4,
+                    "sourcebranchpublication_id": null
+                },
                 {
                     "alias": "land_use_site",
                     "config": {

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -3458,19 +3458,13 @@
                 {
                     "card_id": "c225523c-a711-4088-9b11-89f31c2d1243",
                     "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
                         "i18n_properties": [
                             "placeholder"
                         ],
                         "label": "County ",
                         "maxLength": null,
                         "placeholder": {
-                            "en": "Enter text"
+                            "en": "Select an option"
                         },
                         "uneditable": false,
                         "width": "100%"

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -2333,7 +2333,7 @@
                     "widget_id": "10000000-0000-0000-0000-000000000001"
                 },
                 {
-                    "card_id": "67712ce4-378e-11ef-9263-0242ac150006",
+                    "card_id": "0e47da02-80e7-4763-b036-5e5ea193fa45",
                     "config": {
                         "defaultValue": "",
                         "i18n_properties": [
@@ -2875,7 +2875,7 @@
                     "widget_id": "10000000-0000-0000-0000-000000000001"
                 },
                 {
-                    "card_id": "67712ce4-378e-11ef-9263-0242ac150006",
+                    "card_id": "0e47da02-80e7-4763-b036-5e5ea193fa45",
                     "config": {
                         "defaultValue": "",
                         "i18n_properties": [
@@ -15110,7 +15110,7 @@
             "edges": [
                 {
                     "description": null,
-                    "domainnode_id": "67712762-378e-11ef-9263-0242ac150006",
+                    "domainnode_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
                     "edgeid": "5ffa0842-97b9-4f1a-ad91-3a8d4d61ae9c",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "name": null,
@@ -19286,7 +19286,7 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "67712762-378e-11ef-9263-0242ac150006",
+                    "domainnode_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
                     "edgeid": "a184def9-f7ef-427b-bedc-46b27a62546a",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "name": null,
@@ -21960,7 +21960,7 @@
                     "issearchable": true,
                     "istopnode": false,
                     "name": "Land Use Site",
-                    "nodegroup_id": "67712762-378e-11ef-9263-0242ac150006",
+                    "nodegroup_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
                     "nodeid": "5782bd48-6aa6-11ef-b2e2-0242ac120006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E15_Identifier_Assignment",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
@@ -29055,7 +29055,7 @@
                     "issearchable": true,
                     "istopnode": false,
                     "name": "Recommended designation, identification and protection",
-                    "nodegroup_id": "67712762-378e-11ef-9263-0242ac150006",
+                    "nodegroup_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
                     "nodeid": "60032b9a-3790-11ef-a167-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -4039,7 +4039,7 @@
                         "en": "Grade"
                     },
                     "node_id": "319d5b7e-d766-4a99-9cb6-dabc17e36060",
-                    "sortorder": 7,
+                    "sortorder": 5,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
@@ -21994,7 +21994,7 @@
                     "nodeid": "f4c393ac-6aa6-11ef-b1e8-a1a88c0bb289",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 4,
+                    "sortorder": 2,
                     "sourcebranchpublication_id": null
                 },
                 {
@@ -22017,7 +22017,7 @@
                     "nodeid": "5782bd48-6aa6-11ef-b2e2-0242ac120006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E15_Identifier_Assignment",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
-                    "sortorder": 9,
+                    "sortorder": 3,
                     "sourcebranchpublication_id": null
                 },
                 {
@@ -22040,7 +22040,7 @@
                     "nodeid": "f4c393ac-6aa6-11ef-b1e8-0242ac120006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
-                    "sortorder": 0,
+                    "sortorder": 4,
                     "sourcebranchpublication_id": null
                 },
                 {
@@ -25703,7 +25703,7 @@
                     "nodeid": "319d5b7e-d766-4a99-9cb6-dabc17e36060",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P141_assigned",
-                    "sortorder": 0,
+                    "sortorder": 1,
                     "sourcebranchpublication_id": null
                 },
                 {

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -2304,6 +2304,35 @@
             ],
             "cards_x_nodes_x_widgets": [
                 {
+                    "card_id": "0e47da02-80e7-4763-b036-5e5ea193fa45",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Land Folio Number",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%%"
+                    },
+                    "id": "0c69ba9c-56ea-4bf4-8e67-8d64d60c3183",
+                    "label": {
+                        "en": "Land Folio Number"
+                    },
+                    "node_id": "f4c393ac-6aa6-11ef-b1e8-0242ac120006",
+                    "sortorder": 21,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
                     "card_id": "280b2f9d-e879-4e5f-984e-157ae4f8ffbd",
                     "config": {
                         "defaultResourceInstance": [],
@@ -2830,19 +2859,19 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Recommended Designation Type",
+                        "label": "Recommended designation, identification and protection",
                         "placeholder": {
                             "en": "Select an option"
                         }
                     },
                     "id": "0aa2ef18-a035-481c-aa55-75a6c1fc0958",
                     "label": {
-                        "en": "Recommended Designation Type"
+                        "en": "Recommended designation, identification and protection"
                     },
                     "node_id": "60032b9a-3790-11ef-a167-0242ac150006",
                     "sortorder": 2,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000015"
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
                 },
                 {
                     "card_id": "458dcc3f-5b44-4a08-852b-2dacb074f26d",
@@ -3431,7 +3460,7 @@
                     "node_id": "5c865d99-b9c2-43c8-813e-e77948afa21d",
                     "sortorder": 24,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "0e47da02-80e7-4763-b036-5e5ea193fa45",
@@ -15065,6 +15094,24 @@
             "edges": [
                 {
                     "description": null,
+                    "domainnode_id": "67712762-378e-11ef-9263-0242ac150006",
+                    "edgeid": "5ffa0842-97b9-4f1a-ad91-3a8d4d61ae9c",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
+                    "rangenode_id": "5782bd48-6aa6-11ef-b2e2-0242ac120006"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
+                    "edgeid": "a1feffa7-411e-4102-86f2-c499b972bd52",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "rangenode_id": "f4c393ac-6aa6-11ef-b1e8-0242ac120006"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "a9eeba97-34d4-424e-99cc-586f6b3c626f",
                     "edgeid": "8fdcbc91-5e5e-4792-ac91-d42d9f37fc29",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
@@ -15098,15 +15145,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "rangenode_id": "42c2c4fc-4dc3-11ef-8b61-0242ac120006"
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "72f3eda8-0bc4-4e41-ba5c-3b3e7a1b7688",
-                    "edgeid": "b7526642-57ff-478b-a8ad-007f051dc816",
-                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
-                    "rangenode_id": "5c865d99-b9c2-43c8-11ba-e77948afa21d"
                 },
                 {
                     "description": null,
@@ -18381,7 +18419,7 @@
                     "edgeid": "7c8add74-7d0c-4959-88b0-4aa07f8f2f4e",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "5c865d99-b9c2-43c8-813e-e77948afa21d"
                 },
                 {
@@ -21891,6 +21929,52 @@
             ],
             "nodes": [
                 {
+                    "alias": "land_use_site",
+                    "config": {
+                        "rdmCollection": "dcab7c77-02ab-4c21-9afd-ca5a5fcc1bad"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Land Use Site",
+                    "nodegroup_id": "67712762-378e-11ef-9263-0242ac150006",
+                    "nodeid": "5782bd48-6aa6-11ef-b2e2-0242ac120006",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E15_Identifier_Assignment",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
+                    "sortorder": 3,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "land_folio_number",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Land Folio Number",
+                    "nodegroup_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
+                    "nodeid": "f4c393ac-6aa6-11ef-b1e8-0242ac120006",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "smc_documentation_file_s_",
                     "config": {
                         "graphs": [
@@ -21989,29 +22073,7 @@
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },
-                {
-                    "alias": "county_selected",
-                    "config": {
-                        "rdmCollection": "02458080-9b7a-4a02-b298-f7ea61f60dbb"
-                    },
-                    "datatype": "concept",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "County Selected",
-                    "nodegroup_id": "38dad285-9014-4c7b-ad81-b0562038ebf2",
-                    "nodeid": "5c865d99-b9c2-43c8-11ba-e77948afa21d",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
+
                 {
                     "alias": "generated_historic_parks_and_garden",
                     "config": {
@@ -28795,11 +28857,13 @@
                 },
                 {
                     "alias": "county_value",
-                    "config": {},
-                    "datatype": "string",
+                    "config": {
+                        "rdmCollection": "02458080-9b7a-4a02-b298-f7ea61f60dbb"
+                    },
+                    "datatype": "concept",
                     "description": null,
-                    "exportable": true,
-                    "fieldname": "County",
+                    "exportable": false,
+                    "fieldname": null,
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "hascustomalias": false,
                     "is_collector": false,
@@ -28809,8 +28873,8 @@
                     "name": "County Value",
                     "nodegroup_id": "38dad285-9014-4c7b-ad81-b0562038ebf2",
                     "nodeid": "5c865d99-b9c2-43c8-813e-e77948afa21d",
-                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },
@@ -28962,55 +29026,9 @@
                 {
                     "alias": "recommended_designation_type",
                     "config": {
-                        "i18n_config": {
-                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
-                        },
-                        "options": [
-                            {
-                                "id": "119d4ad2-5c68-49bf-ab57-9011f6c280f6",
-                                "selected": false,
-                                "text": {
-                                    "en": "Scheduled"
-                                }
-                            },
-                            {
-                                "id": "67b692ea-7c97-4562-95cd-e6444a8a7495",
-                                "selected": false,
-                                "text": {
-                                    "en": "A"
-                                }
-                            },
-                            {
-                                "id": "0e6f2cfa-3ba7-4dfd-abdd-901923327d7e",
-                                "selected": false,
-                                "text": {
-                                    "en": "B1"
-                                }
-                            },
-                            {
-                                "id": "a7568640-f5a7-4643-9889-9a5e9ce0d53a",
-                                "selected": false,
-                                "text": {
-                                    "en": "B2"
-                                }
-                            },
-                            {
-                                "id": "92cdabd1-7ae3-4086-a3bd-86dbd24018e7",
-                                "selected": false,
-                                "text": {
-                                    "en": "Record Only"
-                                }
-                            },
-                            {
-                                "id": "13d95f40-e699-4ae1-86f0-38dae6269816",
-                                "selected": false,
-                                "text": {
-                                    "en": "Delist"
-                                }
-                            }
-                        ]
+                        "rdmCollection": "08224567-338c-406b-91ae-6ce4b4ee3608"
                     },
-                    "datatype": "domain-value",
+                    "datatype": "concept-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -29020,7 +29038,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Recommended Designation Type",
+                    "name": "Recommended designation, identification and protection",
                     "nodegroup_id": "67712762-378e-11ef-9263-0242ac150006",
                     "nodeid": "60032b9a-3790-11ef-a167-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -2333,6 +2333,27 @@
                 {
                     "card_id": "6af2a0cd-efc5-11eb-bfc2-a87eeabdefba",
                     "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Listing Criteria",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "6af2a0cd-efc5-11eb-bfc2-a1a88c0bb289",
+                    "label": {
+                        "en": "Listing Criteria"
+                    },
+                    "node_id": "74ef37e0-37b5-11ef-9263-a1a88c0bb289",
+                    "sortorder": 4,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                },
+                {
+                    "card_id": "6af2a0cd-efc5-11eb-bfc2-a87eeabdefba",
+                    "config": {
                         "defaultValue": {
                             "en": {
                                 "direction": "ltr",
@@ -15284,6 +15305,15 @@
                 {
                     "description": null,
                     "domainnode_id": "6af2b6a1-efc5-11eb-bd62-a87eeabdefba",
+                    "edgeid": "448093b0-9df6-4e18-9c3d-3a8d4d61ae9c",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "74ef37e0-37b5-11ef-9263-a1a88c0bb289"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "6af2b6a1-efc5-11eb-bd62-a87eeabdefba",
                     "edgeid": "076f9381-97b9-4f1a-ad91-3a8d4d61ae9c",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "name": null,
@@ -22205,6 +22235,29 @@
                 }
             ],
             "nodes": [
+                {
+                    "alias": "listing_criteria",
+                    "config": {
+                        "rdmCollection": "ddb92162-2508-4900-a8d5-92c0ec7769af"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Listing Criteria",
+                    "nodegroup_id": "6af2b6a1-efc5-11eb-bd62-a87eeabdefba",
+                    "nodeid": "74ef37e0-37b5-11ef-9263-a1a88c0bb289",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 4,
+                    "sourcebranchpublication_id": null
+                },
                 {
                     "alias": "land_use_site",
                     "config": {

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -2360,7 +2360,7 @@
                     "widget_id": "10000000-0000-0000-0000-000000000001"
                 },
                 {
-                    "card_id": "bba34a38-37b4-11ef-9263-0242ac150006",
+                    "card_id": "6af2a0cd-efc5-11eb-bfc2-a87eeabdefba",
                     "config": {
                         "defaultValue": "",
                         "i18n_properties": [
@@ -15283,7 +15283,7 @@
             "edges": [
                 {
                     "description": null,
-                    "domainnode_id": "bba34790-37b4-11ef-9263-0242ac150006",
+                    "domainnode_id": "6af2b6a1-efc5-11eb-bd62-a87eeabdefba",
                     "edgeid": "076f9381-97b9-4f1a-ad91-3a8d4d61ae9c",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "name": null,
@@ -16146,7 +16146,7 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "bba34790-37b4-11ef-9263-0242ac150006",
+                    "domainnode_id": "6af2b6a1-efc5-11eb-bd62-a87eeabdefba",
                     "edgeid": "448093b0-9df6-4e18-9c3d-add5e8c6e9dc",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "name": null,
@@ -22221,7 +22221,7 @@
                     "issearchable": true,
                     "istopnode": false,
                     "name": "Land Use Site",
-                    "nodegroup_id": "bba34790-37b4-11ef-9263-0242ac150006",
+                    "nodegroup_id": "6af2b6a1-efc5-11eb-bd62-a87eeabdefba",
                     "nodeid": "5782bd48-6aa6-11ef-b483-5e5ea193fa45",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E15_Identifier_Assignment",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
@@ -28640,7 +28640,7 @@
                     "issearchable": true,
                     "istopnode": false,
                     "name": "Recommended designation, identification and protection",
-                    "nodegroup_id": "bba34790-37b4-11ef-9263-0242ac150006",
+                    "nodegroup_id": "6af2b6a1-efc5-11eb-bd62-a87eeabdefba",
                     "nodeid": "74ef37e0-37b5-11ef-9263-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -2331,6 +2331,57 @@
             ],
             "cards_x_nodes_x_widgets": [
                 {
+                    "card_id": "6af2a0cd-efc5-11eb-bfc2-a87eeabdefba",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Land Folio Number",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%%"
+                    },
+                    "id": "f4c393ac-efc5-11eb-bfc2-a87eeabdefba",
+                    "label": {
+                        "en": "Land Folio Number"
+                    },
+                    "node_id": "f4c393ac-6aa6-11ef-b483-5e5ea193fa45",
+                    "sortorder": 21,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
+                    "card_id": "bba34a38-37b4-11ef-9263-0242ac150006",
+                    "config": {
+                        "defaultValue": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Land Use Site",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "2cedf759-e47f-48a8-b1e8-5ba91477d22d",
+                    "label": {
+                        "en": "Land Use Site"
+                    },
+                    "node_id": "5782bd48-6aa6-11ef-b483-5e5ea193fa45",
+                    "sortorder": 6,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
+                },
+                {
                     "card_id": "36560f39-fd37-4561-b483-05a6ae912642",
                     "config": {
                         "defaultResourceInstance": [],
@@ -2423,28 +2474,6 @@
                     "sortorder": 2,
                     "visible": true,
                     "widget_id": "10000000-0000-0000-0000-000000000001"
-                },
-                {
-                    "card_id": "87d39b27-f44f-11eb-a02c-a87eeabdefba",
-                    "config": {
-                        "defaultValue": "",
-                        "i18n_properties": [
-                            "placeholder"
-                        ],
-                        "label": "County",
-                        "options": [],
-                        "placeholder": {
-                            "en": "Select an option"
-                        }
-                    },
-                    "id": "955107a5-e3a0-4077-8776-e7aa07fa068f",
-                    "label": {
-                        "en": "County"
-                    },
-                    "node_id": "8bfe714e-3ec2-11ef-9023-0242ac140007",
-                    "sortorder": 27,
-                    "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "10f14bcc-4307-422d-afdf-417f6b9eac38",
@@ -2585,25 +2614,25 @@
                     "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
-                    "card_id": "bba34a38-37b4-11ef-9263-0242ac150006",
+                    "card_id": "6af2a0cd-efc5-11eb-bfc2-a87eeabdefba",
                     "config": {
                         "defaultValue": "",
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Recommended Designation Type",
+                        "label": "Recommended designation, identification and protection",
                         "placeholder": {
                             "en": "Select an option"
                         }
                     },
-                    "id": "05b8416c-d103-4503-a656-31e6c6c1dea2",
+                    "id": "6af2a0cd-efc5-11eb-bfc2-0242ac150006",
                     "label": {
-                        "en": "Recommended Designation Type"
+                        "en": "Recommended designation, identification and protection"
                     },
                     "node_id": "74ef37e0-37b5-11ef-9263-0242ac150006",
                     "sortorder": 3,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000015"
+                    "widget_id": "10000000-0000-0000-0000-000000000012"
                 },
                 {
                     "card_id": "7e303e62-7bd0-4d89-84c0-cb4782a228cc",
@@ -8959,8 +8988,8 @@
                     },
                     "node_id": "87d3ff32-f44f-11eb-aa82-a87eeabdefba",
                     "sortorder": 27,
-                    "visible": false,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "87d39b27-f44f-11eb-a02c-a87eeabdefba",
@@ -15260,6 +15289,24 @@
             "edges": [
                 {
                     "description": null,
+                    "domainnode_id": "bba34790-37b4-11ef-9263-0242ac150006",
+                    "edgeid": "076f9381-97b9-4f1a-ad91-3a8d4d61ae9c",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
+                    "rangenode_id": "5782bd48-6aa6-11ef-b483-5e5ea193fa45"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "6af2a0cb-efc5-11eb-8436-a87eeabdefba",
+                    "edgeid": "076f9381-411e-4102-86f2-c499b972bd52",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "rangenode_id": "f4c393ac-6aa6-11ef-b483-5e5ea193fa45"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "076f9380-7b00-11e9-88c8-80000b44d1d9",
                     "edgeid": "8f132774-85eb-427c-aa16-74123b677f86",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
@@ -15287,15 +15334,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "87d3ff2a-f44f-11eb-9951-a87eeabdefba",
-                    "edgeid": "b7526642-57ff-478b-a8ad-007f051dc816",
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
-                    "rangenode_id": "8bfe714e-3ec2-11ef-9023-0242ac140007"
-                },
-                {
-                    "description": null,
                     "domainnode_id": "de6b6af0-44e3-11ef-9114-0242ac120006",
                     "edgeid": "ba1fe25d-8a2f-439e-a853-7fb903255f96",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
@@ -15311,15 +15349,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "de6b6af0-44e3-11ef-9114-0242ac120006"
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "87d3ff2a-f44f-11eb-9951-a87eeabdefba",
-                    "edgeid": "b7526642-57ff-478b-a8ad-007f051dc816",
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
-                    "rangenode_id": "8bfe714e-3ec2-11ef-9023-0242ac140007"
                 },
                 {
                     "description": null,
@@ -19115,7 +19144,7 @@
                     "edgeid": "87dc7391-f44f-11eb-8d12-a87eeabdefba",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "rangenode_id": "87d3ff32-f44f-11eb-aa82-a87eeabdefba"
                 },
                 {
@@ -22183,6 +22212,52 @@
             ],
             "nodes": [
                 {
+                    "alias": "land_use_site",
+                    "config": {
+                        "rdmCollection": "dcab7c77-02ab-4c21-9afd-ca5a5fcc1bad"
+                    },
+                    "datatype": "concept-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Land Use Site",
+                    "nodegroup_id": "bba34790-37b4-11ef-9263-0242ac150006",
+                    "nodeid": "5782bd48-6aa6-11ef-b483-5e5ea193fa45",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E15_Identifier_Assignment",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P15i_influenced",
+                    "sortorder": 9,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "land_folio_number",
+                    "config": {
+                        "en": ""
+                    },
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Land Folio Number",
+                    "nodegroup_id": "6af2a0cb-efc5-11eb-8436-a87eeabdefba",
+                    "nodeid": "f4c393ac-6aa6-11ef-b483-5e5ea193fa45",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E42_Identifier",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "smc_documentation_file_s_",
                     "config": {
                         "graphs": [
@@ -22278,29 +22353,6 @@
                     "nodeid": "fe7d67f8-44e3-11ef-9114-0242ac120006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "county_selected",
-                    "config": {
-                        "rdmCollection": "763ba635-3800-324a-8d54-c1427bcaa5aa"
-                    },
-                    "datatype": "concept",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "County Selected",
-                    "nodegroup_id": "87d39b25-f44f-11eb-95e5-a87eeabdefba",
-                    "nodeid": "8bfe714e-3ec2-11ef-9023-0242ac140007",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },
@@ -28581,55 +28633,9 @@
                 {
                     "alias": "recommended_designation_type",
                     "config": {
-                        "i18n_config": {
-                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
-                        },
-                        "options": [
-                            {
-                                "id": "13d95f40-e699-4ae1-86f0-38dae6269816",
-                                "selected": false,
-                                "text": {
-                                    "en": "Delist"
-                                }
-                            },
-                            {
-                                "id": "92cdabd1-7ae3-4086-a3bd-86dbd24018e7",
-                                "selected": false,
-                                "text": {
-                                    "en": "Record Only"
-                                }
-                            },
-                            {
-                                "id": "a7568640-f5a7-4643-9889-9a5e9ce0d53a",
-                                "selected": false,
-                                "text": {
-                                    "en": "B2"
-                                }
-                            },
-                            {
-                                "id": "0e6f2cfa-3ba7-4dfd-abdd-901923327d7e",
-                                "selected": false,
-                                "text": {
-                                    "en": "B1"
-                                }
-                            },
-                            {
-                                "id": "67b692ea-7c97-4562-95cd-e6444a8a7495",
-                                "selected": false,
-                                "text": {
-                                    "en": "A"
-                                }
-                            },
-                            {
-                                "id": "119d4ad2-5c68-49bf-ab57-9011f6c280f6",
-                                "selected": false,
-                                "text": {
-                                    "en": "Scheduled"
-                                }
-                            }
-                        ]
+                        "rdmCollection": "08224567-338c-406b-91ae-6ce4b4ee3608"
                     },
-                    "datatype": "domain-value",
+                    "datatype": "concept-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -28639,7 +28645,7 @@
                     "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
-                    "name": "Recommended Designation Type",
+                    "name": "Recommended designation, identification and protection",
                     "nodegroup_id": "bba34790-37b4-11ef-9263-0242ac150006",
                     "nodeid": "74ef37e0-37b5-11ef-9263-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
@@ -33897,8 +33903,10 @@
                 },
                 {
                     "alias": "county_value",
-                    "config": {},
-                    "datatype": "string",
+                    "config": {
+                        "rdmCollection": "763ba635-3800-324a-8d54-c1427bcaa5aa"
+                    },
+                    "datatype": "concept",
                     "description": null,
                     "exportable": true,
                     "fieldname": "County",
@@ -33911,8 +33919,8 @@
                     "name": "County Value",
                     "nodegroup_id": "87d39b25-f44f-11eb-95e5-a87eeabdefba",
                     "nodeid": "87d3ff32-f44f-11eb-aa82-a87eeabdefba",
-                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E44_Place_Appellation",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P1_is_identified_by",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -8965,26 +8965,20 @@
                 {
                     "card_id": "87d39b27-f44f-11eb-a02c-a87eeabdefba",
                     "config": {
-                        "defaultValue": {
-                            "en": {
-                                "direction": "ltr",
-                                "value": ""
-                            }
-                        },
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "County ",
+                        "label": "County",
                         "maxLength": null,
                         "placeholder": {
-                            "en": "Enter text"
+                            "en": "Select an option"
                         },
                         "uneditable": false,
                         "width": "100%"
                     },
                     "id": "87d3ff49-f44f-11eb-b010-a87eeabdefba",
                     "label": {
-                        "en": "County "
+                        "en": "County"
                     },
                     "node_id": "87d3ff32-f44f-11eb-aa82-a87eeabdefba",
                     "sortorder": 27,

--- a/coral/pkg/reference_data/collections/collections.xml
+++ b/coral/pkg/reference_data/collections/collections.xml
@@ -52289,4 +52289,28 @@
   <skos:Concept rdf:about="http://arches:8000/92f40033-ef66-3e72-a24f-91153a8d520f"/>
   <skos:Concept rdf:about="http://arches:8000/eddc1678-27b0-32db-b7c3-b0effa5270ad"/>
   <skos:Concept rdf:about="http://arches:8000/fa02defb-adce-3d14-9754-61a308141b92"/>
+  <skos:Collection rdf:about="http://arches:8000/ddb92162-2508-4900-a8d5-92c0ec7769af">
+    <skos:prefLabel xml:lang="en">{"id": "6ec92fc8-f210-4ffe-b189-4a26cf04bae3", "value": "Listing Criteria"}</skos:prefLabel>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-e10ddcc4c5ae" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-bf0ee8126e94" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-de8a99b26647" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-7a49732a45ec" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-8ef6cec4a1b7" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-3223af0c0615" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-78c8da89b1b5" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a32ac3c36" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7ae8126e94" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a99b26647" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a732a45ec" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7acec4a1b7" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7aaf0c0615" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7ada89b1b5" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615da89b1b6" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-061599b26647" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615732a45ec" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-2645bea49be2" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615af0c0615" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615da89b1b5" /></skos:member>
+    <skos:member><skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-061532ab735f" /></skos:member>
+  </skos:Collection>
 </rdf:RDF>

--- a/coral/pkg/reference_data/concepts/Listing_Criteria_20240918.xml
+++ b/coral/pkg/reference_data/concepts/Listing_Criteria_20240918.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+  xmlns:dcterms="http://purl.org/dc/terms/"
+>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-e10ddcc4c5ae">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-34b97dcdba5a", "value": "A. Style"}</skos:prefLabel>
+    <skos:inScheme>
+      <skos:ConceptScheme rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f">
+        <dcterms:title xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-c023f1566c09", "value": "Listing Criteria"}</dcterms:title>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-7a49732a45ec"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-bf0ee8126e94"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a32ac3c36"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-de8a99b26647"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-3223af0c0615"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-8ef6cec4a1b7"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-78c8da89b1b5"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-e10ddcc4c5ae"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7ae8126e94"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a99b26647"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a732a45ec"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7acec4a1b7"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7aaf0c0615"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7ada89b1b5"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-061532ab735f"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-061599b26647"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-0615732a45ec"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-2645bea49be2"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-0615af0c0615"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-0615da89b1b5"/>
+        <skos:hasTopConcept rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-0615da89b1b6"/>
+      </skos:ConceptScheme>
+    </skos:inScheme>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-bf0ee8126e94">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-3b483b301e7a", "value": "B. Proportion"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-de8a99b26647">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-f7284105212f", "value": "C. Ornamentation"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-7a49732a45ec">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-87c893b603f7", "value": "D. Plan Form"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-8ef6cec4a1b7">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-ca5bb0a117e6", "value": "E. Spatial Organisation"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-3223af0c0615">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-7466d83e9ca7", "value": "F. Structural System"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-78c8da89b1b5">
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-e07627136d50", "value": "G. Innovatory Qualities"}</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a32ac3c36">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-4b5fc844dcf6", "value": "H+. Alterations enhancing the building"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+    <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7ae8126e94">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-3b483b302c1e", "value": "H-. Alterations detracting from building"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a99b26647">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-1e7a4105212f", "value": "I. Quality and survival of Interior"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7a732a45ec">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-1e7a93b603f7", "value": "J. Setting"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7acec4a1b7">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-1e7ab0a117e6", "value": "K. Group value"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7aaf0c0615">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-1e7ad83e9ca7", "value": "R. Age"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-1e7ada89b1b5">
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-1e7a27136d50", "value": "S. Authenticity"}</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615da89b1b6">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-0615c844dcf6", "value": "T. Historic Importance"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+ <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-061599b26647">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-06154105212f", "value": "U. Historic Associations"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615732a45ec">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-061593b603f7", "value": "V. Authorship"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-2645bea49be2">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-0615b0a117e6", "value": "W. Northern Ireland / International interest"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615af0c0615">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-0615d83e9ca7", "value": "X. Local Interest"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-0615da89b1b5">
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-061527136d50", "value": "Y. Social, cultural or economic importance"}</skos:prefLabel>
+  </skos:Concept>
+  <skos:Concept rdf:about="http://localhost:8000/ddb92162-2508-4900-a8d5-061532ab735f">
+    <skos:prefLabel xml:lang="en">{"id": "ddb92162-2508-4900-a8d5-061532ab735e", "value": "Z. Rarity"}</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://localhost:8000/ddb92162-2508-4900-a8d5-886837eb735f"/>
+  </skos:Concept>
+
+</rdf:RDF>

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -196,6 +196,7 @@
                   "nodegroupid": "2af35abc-9dee-4438-a127-c0fb69e63124",
                   "semanticName": "Designation and Protection Assignment",
                   "hiddenNodes": [
+                    "ba848524-c2ab-4d13-add0-2f1680391127",
                     "6f588050-8ead-4131-9ea5-495bf62f2443",
                     "d11ecd97-0a37-4e2b-90d3-35ec5bfcc8dc",
                     "2f1563f3-92a6-4985-8eb1-53b88e34f538",

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -212,6 +212,18 @@
                 "tilesManaged": "one",
                 "componentName": "default-card-util",
                 "uniqueInstanceName": "designation-protection-type"
+              },
+              {
+                "parameters": {
+                  "graphid": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                  "resourceid": "['start-step']['d4cffd08-58c6-46f2-8ef7-08a7af8ae7f5'][0]['resourceid']['resourceInstanceId']",
+                  "nodegroupid": "3d415e98-d23b-11ee-9373-0242ac180006",
+                  "labels": [["CM Reference", "Records NI"]],
+                  "semanticName": "Record NI"
+                },
+                "tilesManaged": "one",
+                "componentName": "default-card-util",
+                "uniqueInstanceName": "4ae2af75-3829-4633-9b69-0242ac180006"
               }
             ]
           }

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -217,7 +217,7 @@
                 "parameters": {
                   "graphid": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                   "resourceid": "['start-step']['d4cffd08-58c6-46f2-8ef7-08a7af8ae7f5'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "3d415e98-d23b-11ee-9373-0242ac180006",
+                  "nodegroupid": "94c6fd66-19fa-4261-8728-35a67a88b96b",
                   "labels": [["CM Reference", "Records NI"]],
                   "semanticName": "Record NI"
                 },

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -210,7 +210,7 @@
                   ]
                 },
                 "tilesManaged": "one",
-                "componentName": "default-card",
+                "componentName": "default-card-util",
                 "uniqueInstanceName": "designation-protection-type"
               }
             ]

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=9, patch=38)
+APP_VERSION = semantic_version.Version(major=5, minor=10, patch=38)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
This PR prepares the designation workflow for the list changes which will be made when [Taiga #1910](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/1910) is completed

## Test
In order to test this you must delete Heritage Asset Revision, then Heritage Asset model  
There are changes to datatypes so `make manage CMD="es reindex_database"`
Changes have been made to the designation workflow so also do a `make webpack`
There are also changes in the json for heritage designation workflow so `make manage CMD="coral reload"` 
then import  
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Monument.json'`
`make manage CMD='packages -o import_graphs -s coral/pkg/graphs/resource_models/Monument\ Revision.json'`
Rest of the test script is available at [Taiga #1758](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/1758)