### PR TITLE
Fix/#2482/evaluation meeting start step required

### DIFF
--- a/coral/plugins/evaluation-meeting-workflow.json
+++ b/coral/plugins/evaluation-meeting-workflow.json
@@ -11,7 +11,7 @@
       {
         "name": "start-meeting-step",
         "title": "Start Meeting",
-        "required": false,
+        "required": true,
         "hiddenWorkflowButtons": ["undo"],
         "layoutSections": [
           {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=16, patch=45)
+APP_VERSION = semantic_version.Version(major=5, minor=16, patch=46)
 
 GROUPINGS = {
     "groups": {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=12, patch=44)
+APP_VERSION = semantic_version.Version(major=5, minor=12, patch=45)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION

Just needs a webpack rebuild and a a coral reload.

Check if the evaluation meeting can change steps before saving id.