### PR TITLE
Fix #2557 #2558 | Monument | Monument Revision - rename input field labels

### DIFF
--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -5545,14 +5545,14 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Field Worker",
+                        "label": "Field Worker(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "44a87f76-e3fc-4f65-8862-e7cc07a8ee1b",
                     "label": {
-                        "en": "Field Worker"
+                        "en": "Field Worker(s)"
                     },
                     "node_id": "5fccac10-07ba-11ef-859d-0242ac140006",
                     "sortorder": 14,
@@ -8744,14 +8744,14 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Owner",
+                        "label": "Owner(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "8c335782-34b7-4cc0-b72a-2104be4b5302",
                     "label": {
-                        "en": "Owner"
+                        "en": "Owner(s)"
                     },
                     "node_id": "7cee2524-c5e3-4a08-ac0a-a9032ad81c63",
                     "sortorder": 6,

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -3237,19 +3237,19 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Area Archaeologist",
+                        "label": "Area Archaeologist(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "101b4709-d4e9-437d-9d71-6ac770e00a48",
                     "label": {
-                        "en": "Area Archaeologist"
+                        "en": "Area Archaeologist(s)"
                     },
                     "node_id": "d0b45457-d9a3-43fc-910b-0dc29c14315b",
                     "sortorder": 3,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "ae8b24f7-ed3f-49c1-8ace-03e52111d45e",
@@ -4446,19 +4446,19 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Occupier",
+                        "label": "Occupier(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "2a578f7a-112b-4ad2-9a3b-6c72522a39c2",
                     "label": {
-                        "en": "Occupier"
+                        "en": "Occupier(s)"
                     },
                     "node_id": "56c385ad-24be-42bf-bbbe-42104488dcfe",
                     "sortorder": 0,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "bd9292aa-4b19-4d57-ba07-8bb144bd507e",
@@ -5645,7 +5645,7 @@
                     "node_id": "995e311e-2f93-480d-9f1e-107bdf781bf3",
                     "sortorder": 0,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "90caa8ad-741d-420c-9cb4-7d20fbd00b61",
@@ -5736,19 +5736,19 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "CWT Area Supervisor",
+                        "label": "CWT Area Supervisor(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "4b630fa1-00ed-44b5-9d5a-fb08a2d1c5dd",
                     "label": {
-                        "en": "CWT Area Supervisor"
+                        "en": "CWT Area Supervisor(s)"
                     },
                     "node_id": "9dadc62b-ca39-4ca5-8255-444dac6dc89e",
                     "sortorder": 6,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "458dcc3f-5b44-4a08-852b-2dacb074f26d",
@@ -32386,7 +32386,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -32663,7 +32663,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -36248,7 +36248,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -13170,14 +13170,14 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Owner",
+                        "label": "Owner(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "aa62c7d4-d23e-11ee-9ae7-0242ac180006",
                     "label": {
-                        "en": "Owner"
+                        "en": "Owner(s)"
                     },
                     "node_id": "aa62ada8-d23e-11ee-9ae7-0242ac180006",
                     "sortorder": 6,
@@ -13300,14 +13300,14 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Field Worker",
+                        "label": "Field Worker(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "b1f68f4d-8a89-4776-add1-7d7b3e434758",
                     "label": {
-                        "en": "Field Worker"
+                        "en": "Field Worker(s)"
                     },
                     "node_id": "650bb092-07b8-11ef-a15f-0242ac140006",
                     "sortorder": null,

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -4989,19 +4989,19 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Area Archaeologist",
+                        "label": "Area Archaeologist(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "5a2cef3f-755b-4d2f-b230-45d3b9bbb885",
                     "label": {
-                        "en": "Area Archaeologist"
+                        "en": "Area Archaeologist(s)"
                     },
                     "node_id": "a53af708-d631-11ee-a5a3-0242ac180006",
                     "sortorder": 3,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "51ec4343-762a-4079-bbad-c065be7a7ee3",
@@ -12375,7 +12375,7 @@
                     "node_id": "6d65ffb8-d630-11ee-9454-0242ac180006",
                     "sortorder": 0,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "9eceaff9-795b-497c-982b-cfb41e8f8ec0",
@@ -13040,19 +13040,19 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "Occupier",
+                        "label": "Occupier(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "aa62c158-d23e-11ee-9ae7-0242ac180006",
                     "label": {
-                        "en": "Occupier"
+                        "en": "Occupier(s)"
                     },
                     "node_id": "aa62b10e-d23e-11ee-9ae7-0242ac180006",
                     "sortorder": 0,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "aa629b2e-d23e-11ee-9ae7-0242ac180006",
@@ -14637,19 +14637,19 @@
                         "i18n_properties": [
                             "placeholder"
                         ],
-                        "label": "CWT Area Supervisor",
+                        "label": "CWT Area Supervisor(s)",
                         "placeholder": {
                             "en": ""
                         }
                     },
                     "id": "e6553564-7cd8-45c6-a477-5c7b6a68c34a",
                     "label": {
-                        "en": "CWT Area Supervisor"
+                        "en": "CWT Area Supervisor(s)"
                     },
                     "node_id": "506dd6ae-d632-11ee-9454-0242ac180006",
                     "sortorder": 6,
                     "visible": true,
-                    "widget_id": "31f3728c-7613-11e7-a139-784f435179ea"
+                    "widget_id": "ff3c400a-76ec-11e7-a793-784f435179ea"
                 },
                 {
                     "card_id": "a1f10404-d648-11ee-9a11-0242ac180006",
@@ -25683,7 +25683,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -28590,7 +28590,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -35931,7 +35931,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,
@@ -36326,7 +36326,7 @@
                         "searchDsl": "",
                         "searchString": ""
                     },
-                    "datatype": "resource-instance",
+                    "datatype": "resource-instance-list",
                     "description": null,
                     "exportable": true,
                     "fieldname": "Plan_Offic",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=17, patch=52)
+APP_VERSION = semantic_version.Version(major=5, minor=17, patch=53)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/plugins/open-incident-report-workflow.htm
+++ b/coral/templates/views/components/plugins/open-incident-report-workflow.htm
@@ -36,7 +36,7 @@
           graphids: graphIds(),
           config: {
             label: 'Select Licence',
-            placeholder: 'Please select a Monument',
+            placeholder: 'Please select a Heritage Asset',
           },
           renderContext: 'workflow',
           value: selectedResource


### PR DESCRIPTION
### Description
Change the Field Worker and Owner labels to plurals
Change the placeholder text for the initial monument selection to say Heritage Asset
Updated the following from a resource instance to a resource instance list:
- Issue Identified by
- Area Archaeologist
- CWT Area Supervisor
- Occupier
Also updated the labels to add plurals

### Test
- Remove the monument model
- Reload the monument
- Restart containers
- Run webpack
- Follow tests here [#2557](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2557)