### PR TITLE
Feat(#2565) - Upload Name

### DIFF
--- a/coral/media/js/views/components/workflows/related-document-upload.js
+++ b/coral/media/js/views/components/workflows/related-document-upload.js
@@ -23,7 +23,6 @@ define([
     this.nodeSuffixId = params.nodeSuffixId ?? null
     this.resourceParentTile = params.resourceParentTile;
 
-    console.log("node prefix", this.additionalNodePrefixId)
     /**
      * The group id refers to the Digital Object name group.
      * The name node refers to the child node of the group that configures the name.
@@ -116,6 +115,9 @@ define([
       const fetchNodeData = async (resourceId, nodeId) => {
         const tile = await fetchTileData(resourceId, nodeId);
         const latestTile = tile[tile.length - 1]
+        if(!latestTile) {
+          return console.error("No tile data available for suffix")
+        }
         suffixString = latestTile.data[this.nodeSuffixId].en?.value
         return suffixString;
       }
@@ -135,6 +137,7 @@ define([
             value: self.fileObjectNamePrefix + resourceData.displayname + suffixString
           }
         };
+
         /**
          * Check if the tile has already been saved and has a tile id assigned.
          */

--- a/coral/media/js/views/components/workflows/related-document-upload.js
+++ b/coral/media/js/views/components/workflows/related-document-upload.js
@@ -10,7 +10,7 @@ define([
 ], function ($, _, ko, koMapping, uuid, arches, uploadDocumentStepTemplate) {
   function viewModel(params) {
     var self = this;
-
+    
     /**
      * Both of these values should come from the first card you initialized in
      * the workflow.
@@ -22,7 +22,6 @@ define([
     this.fileObjectNamePrefix = params?.fileObjectNamePrefix || 'Files for ';
     this.nodeSuffixId = params.nodeSuffixId ?? null
     this.resourceParentTile = params.resourceParentTile;
-
     /**
      * The group id refers to the Digital Object name group.
      * The name node refers to the child node of the group that configures the name.
@@ -113,12 +112,18 @@ define([
       };
 
       const fetchNodeData = async (resourceId, nodeId) => {
-        const tile = await fetchTileData(resourceId, nodeId);
-        const latestTile = tile[tile.length - 1]
-        if(!latestTile) {
+        const tiles = await fetchTileData(resourceId, nodeId);
+        let matchingTile = null
+        for(const tile of tiles) {
+          if(tile.parenttile === this.resourceParentTile) {
+            matchingTile = tile;
+            break;
+          }
+        }
+        if(!matchingTile) {
           return console.error("No tile data available for suffix")
         }
-        suffixString = latestTile.data[this.nodeSuffixId].en?.value
+        suffixString = matchingTile.data[this.nodeSuffixId].en?.value
         return suffixString;
       }
 

--- a/coral/plugins/incident-report-workflow.json
+++ b/coral/plugins/incident-report-workflow.json
@@ -315,6 +315,7 @@
                   "nodegroupid": "7db68c6c-8490-11ea-a543-f875a44e0e11",
                   "resourceModelId": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['resourceInstanceId']",
                   "fileObjectNamePrefix": "Documentation for ",
+                  "nodeSuffixId": "2001a33a-d711-11ee-9dd0-0242ac120006",
                   "resourceModelDigitalObjectNodeGroupId": "58f177c8-d640-11ee-8b04-0242ac180006",
                   "resourceParentTile": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['incidentReport']"
                 },

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=17, patch=57)
+APP_VERSION = semantic_version.Version(major=5, minor=18, patch=57)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
### Description
The incident report name was not reflected in the uploaded documents making them difficult to find. 
Added a config to allow a string node to be added to the end of the uploaded documents resource name. This is then used to add the incident report reference number.

### Test
- Reload containers
- Webpack rebuild
- Coral Reload
- Follow tests here [#2565](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2565)