### PR TITLE
Feat(#2560):  Disable map edit

### DIFF
--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -285,24 +285,22 @@ define([
             }
         };
 
-
         this.getNodeOptions = (nodeId, widgetConfig = {}) => {
             const options = params.nodeOptions?.[nodeId] || {};
             if (options?.config) {
-                options.config = {
+              options.config = ko.observable({
                 ...widgetConfig,
                 ...options.config
-                };
+              });
             }
-            Object.keys(options).forEach((key) => {
-                // Should this be used a JS workflow maintain the users
-                // provided reactivity.
-                if (!ko.isObservable(options[key])) {
-                options[key] = ko.observable(options[key]);
-                }
-            });
-            return options;
-        };
+            const nodeOptions = {...options}
+            if(options?.asObservable) {
+              Object.entries(options.asObservable).forEach((key, value) => {
+                  nodeOptions[key] = ko.observable(value);
+                });
+            } 
+            return nodeOptions;
+        }
 
         this.initialize();
     };

--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -1,0 +1,309 @@
+define([
+    'knockout',
+    'underscore',
+    'arches',
+    'viewmodels/alert',
+    'bindings/scrollTo'
+], function(ko, _, arches, AlertViewModel) {
+    return function(params) {
+        var self = this;
+
+        if (!params.card && ko.unwrap(params.form.card)) {
+            params.card = ko.unwrap(params.form.card);
+        }
+
+        this.inResourceEditor = location.pathname.includes(arches.urls.resource_editor);
+        this.configKeys = params.configKeys || [];
+        this.showIds = params.showIds || false;
+        this.state = params.state || 'form';
+        this.preview = params.preview;
+        this.loading = params.loading || ko.observable(false);
+        this.card = params.card;
+        this.showGrid = params?.form?.showGrid;
+        this.toggleGrid = params?.form?.toggleGrid;
+        this.card.hideEmptyNodes = params.hideEmptyNodes;
+        this.card.showIds = this.showIds;
+        this.tile = params.tile;
+        this.reportExpanded = ko.observable(true);
+        this.form = params.form;
+        this.provisionalTileViewModel = params.provisionalTileViewModel;
+        this.reviewer = params.reviewer;
+        this.expanded = ko.observable(true);
+        this.showHeaderLine = params.showHeaderLine;
+
+        this.config = this.card.model ? this.card.model.get('config') : {};
+        _.each(this.configKeys, function(key) {
+            self[key] = self.config[key];
+        });
+
+        this.showChildCards = ko.computed(function() {
+            return this.card.widgets().length === 0;
+        }, this);
+
+        this.componentCssClasses = function(widget) {
+            return ["card_component",
+                ko.unwrap(widget.node?.graph?.attributes?.slug),
+                ko.unwrap(widget.node?.alias),
+                widget?.widgetLookup[ko.unwrap(widget?.widget_id)].name].join(" ");
+        };
+
+
+        this.initialize = function() {
+            self.card.showForm(true);
+
+            self.tiles = ko.computed(function() {
+                var tiles = [];
+                if (self.tile) {
+                    return self.getTiles(self.tile);
+                } else {
+                    self.card.tiles().forEach(function(tile) {
+                        self.getTiles(tile, tiles);
+                    });
+                }
+                return tiles;
+            }, self);
+            if (ko.isObservable(params.tiles)) {
+                params.tiles(self.tiles());
+
+                self.tiles.subscribe(function(tiles) {
+                    params.tiles(tiles);
+                });
+            }
+
+            self.dirty = ko.computed(function() {
+                if (!ko.unwrap(self.tiles)) {
+                    return true;
+                }
+                else {
+                    return ko.unwrap(self.tiles).reduce(function(acc, tile) {
+                        if (tile.dirty()) {
+                            acc = true;
+                        }
+                        return acc;
+                    }, false);
+                }
+            });
+            if (ko.isObservable(params.dirty)) {
+                self.dirty.subscribe(function(dirty) {
+                    params.dirty(dirty);
+                });
+            }
+
+
+            if (self.preview) {
+                if (!self.card.newTile) {
+                    self.card.newTile = self.card.getNewTile();
+                }
+                self.tile = self.card.newTile;
+            }
+
+            if (self.card.tiles().length > 0) {
+                self.card.showForm(false);
+            }
+
+            if (self.card.preSaveCallback) {
+                self.card.preSaveCallback(self.saveTile);
+            }
+        };
+
+        this.revealForm = function(card){
+            if (!card.selected()) {card.selected(true);}
+            setTimeout(function(){
+                card.showForm(true);
+            }, 50);
+        };
+
+        this.getTiles = function(tile, tiles) {
+            tiles = tiles || [tile];
+            tile.cards.forEach(function(card) {
+                card.tiles().forEach(function(tile) {
+                    tiles.push(tile);
+                    self.getTiles(tile, tiles);
+                });
+            });
+            return tiles;
+        };
+
+        this.beforeMove = function(e) {
+            e.cancelDrop = (e.sourceParent!==e.targetParent);
+        };
+
+        this.startDrag = function(e, ui) {
+            ko.utils.domData.get(ui.item[0], 'ko_sortItem').selected(true);
+        };
+
+        this.getValuesByDatatype = function(type) {
+            var values = {};
+            if (self.tile && self.form) {
+                var data = self.tile.getAttributes().data;
+                _.each(data, function(value, key) {
+                    var node = self.form.nodeLookup[key];
+                    if (node && ko.unwrap(node.datatype) === type){
+                        values[ko.unwrap(node.id)] = {
+                            name: ko.unwrap(node.name),
+                            value: value
+                        };
+                    }
+                });
+            }
+            return values;
+        };
+
+        this.selectWorkflowTile = function(tile) {  // used for cardinality 'n' cards in workflows
+            tile.selected(true);
+            self.tile = tile;
+            params.dirty(true);
+        };
+
+        // ctrl+S to save any edited/dirty tiles in resource view 
+        var keyListener = function(e) {
+            if (e.ctrlKey && e.key === "s") {
+                e.preventDefault();
+                if (self?.tile?.dirty() == true && 
+                    self?.tile?.parent?.isWritable === true) {
+                        self.saveTile();
+                }
+            }
+        };
+        document.addEventListener("keydown", keyListener)
+        // dispose of eventlistener
+        this.dispose = function(){
+            document.removeEventListener("keydown", keyListener);
+        };
+
+        this.saveTile = function(callback) {
+            self.loading(true);
+            self.tile.transactionId = params.form?.workflowId || undefined;
+
+            if (params.resourceid) {
+                self.tile.resourceinstance_id = params.resourceid;
+            }
+            else if (ko.unwrap(params.form?.resourceId)){
+                self.tile.resourceinstance_id = ko.unwrap(params.form.resourceId);
+            }
+            self.tile.save(function(response) {
+                self.loading(false);
+                if(params?.form?.error){
+                    params.form.error(response.responseJSON.message);
+                }
+                params.pageVm.alert(
+                    new AlertViewModel(
+                        'ep-alert-red',
+                        response.responseJSON.title,
+                        response.responseJSON.message,
+                        null,
+                        function(){}
+                    )
+                );
+                if (params.form.onSaveError) {
+                    params.form.onSaveError(self.tile);
+                }
+            }, function() {
+                self.loading(false);
+                if (typeof self.onSaveSuccess === 'function') self.onSaveSuccess();
+                if (params.form.onSaveSuccess) {
+                    params.form.onSaveSuccess(self.tile);
+                }
+                if (typeof callback === 'function') callback();
+            });
+        };
+
+        var saveTileInWorkflow = function() {
+            self.saveTile(function() {
+                params.form.complete(true);
+            });
+        };
+        if (params.save) {
+            params.save = saveTileInWorkflow;
+        }
+        if (params.form && params.form.save) {
+            params.form.save = saveTileInWorkflow;
+        }
+
+        /*
+            TODO: Reverse this logic to be in-line with card UX in resource_editor using this logic:
+                    params.card && params.card.cardinality === 'n'
+                    && params.form.componentData.cardinalityOverride !== '1'
+        */
+        if (params.renderContext === 'workflow') {
+            if (params.form.componentData.cardinalityOverride === 'n') {
+                self.card.selected(true);  // cardinality 'n' cards will display appropriately
+                self.inResourceEditor = true;
+            }
+        }
+
+        this.saveTileAddNew = function() {
+            self.saveTile(function() {
+                window.setTimeout(function() {
+                    self.card.selected(true);
+                }, 1);
+            });
+        };
+
+        this.deleteTile = function() {
+            params.pageVm.alert(            
+                new AlertViewModel(
+                    'ep-alert-red',
+                    'Item Deletion.',
+                    'Are you sure you would like to delete this item?',
+                    function(){}, //does nothing when canceled
+                    function() {
+                        self.loading(true);
+                        self.tile.deleteTile(function(response) {
+                            self.loading(false);
+                            params.pageVm.alert(
+                                new AlertViewModel(
+                                    'ep-alert-red',
+                                    response.responseJSON.title,
+                                    response.responseJSON.message,
+                                    null,
+                                    function(){}
+                                )
+                            );
+                            if (params.form.onDeleteError) {
+                                params.form.onDeleteError(self.tile);
+                            }
+                        }, function() {
+                            self.loading(false);
+                            if (typeof self.onDeleteSuccess === 'function') self.onDeleteSuccess();
+                            if (params.form.onDeleteSuccess) {
+                                params.form.onDeleteSuccess(self.tile);
+                            }
+                        });
+                    })
+                );
+        };
+
+        this.createParentAndChild = async(parenttile, childcard) => {
+            try{
+                const newSave = await self.card.saveParentTile(parenttile);
+                if(newSave){
+                    childcard.selected(true);
+                }
+            } catch (err){
+                console.log(err);
+            }
+        };
+
+
+        this.getNodeOptions = (nodeId, widgetConfig = {}) => {
+            const options = params.nodeOptions?.[nodeId] || {};
+            if (options?.config) {
+                options.config = {
+                ...widgetConfig,
+                ...options.config
+                };
+            }
+            Object.keys(options).forEach((key) => {
+                // Should this be used a JS workflow maintain the users
+                // provided reactivity.
+                if (!ko.isObservable(options[key])) {
+                options[key] = ko.observable(options[key]);
+                }
+            });
+            return options;
+        };
+
+        this.initialize();
+    };
+});

--- a/coral/media/js/viewmodels/map-editor.js
+++ b/coral/media/js/viewmodels/map-editor.js
@@ -27,7 +27,6 @@ define([
         if (this.widgets === undefined) { // could be [], so checking specifically for undefined
             this.widgets = params.widgets || [];
         }
-        
         this.geojsonWidgets = this.widgets.filter(function(widget){ return widget.datatype.datatype === 'geojson-feature-collection'; });
         this.newNodeId = null;
         this.featureLookup = {};
@@ -43,8 +42,7 @@ define([
         this.bufferResult = ko.observable();
         this.bufferAddNew = ko.observable(false);
         this.allowAddNew = this.card && this.card.canAdd() && this.tile !== this.card.newTile;
-        this.disableEdit = ko.observable(params.disableEdit ?? true)
-        console.log("custom editor", this.disableEdit())
+        this.disableEdit = ko.observable(params.disableEdit ?? false)
         var selectSource = this.selectSource();
         var selectSourceLayer = this.selectSourceLayer();
         var selectFeatureLayers = selectFeatureLayersFactory(resourceId, selectSource, selectSourceLayer);
@@ -189,7 +187,7 @@ define([
             params.fitBoundsOptions = { padding: {top: padding, left: padding + 200, bottom: padding, right: padding + 200} };
         }
 
-        params.activeTab = 'editor';
+        params.activeTab = this.disableEdit() ? null : 'editor';
         params.sources = Object.assign({
             "geojson-editor-data": {
                 "type": "geojson",

--- a/coral/media/js/viewmodels/map-editor.js
+++ b/coral/media/js/viewmodels/map-editor.js
@@ -1,0 +1,1014 @@
+define([
+    'jquery',
+    'underscore',
+    'knockout',
+    'knockout-mapping',
+    'arches',
+    'uuid',
+    'geojson-extent',
+    'geojsonhint',
+    'togeojson',
+    'proj4',
+    'views/components/map',
+    'views/components/cards/select-feature-layers',
+    'views/components/datatypes/geojson-feature-collection',
+    'templates/views/components/map.htm',
+    'templates/views/components/map-editor.htm'
+
+], function($, _, ko, koMapping, arches, uuid, geojsonExtent, geojsonhint, toGeoJSON, proj4, MapComponentViewModel, selectFeatureLayersFactory) {
+    var viewModel = function(params) {
+         
+
+        var self = this;
+        var padding = 40;
+        var drawFeatures;
+        
+        var resourceId = params.tile ? params.tile.resourceinstance_id : '';
+        if (this.widgets === undefined) { // could be [], so checking specifically for undefined
+            this.widgets = params.widgets || [];
+        }
+        
+        this.geojsonWidgets = this.widgets.filter(function(widget){ return widget.datatype.datatype === 'geojson-feature-collection'; });
+        this.newNodeId = null;
+        this.featureLookup = {};
+        this.selectedFeatureIds = ko.observableArray();
+        this.geoJSONString = ko.observable();
+        this.draw = null;
+        this.selectSource = this.selectSource || ko.observable();
+        this.selectSourceLayer = this.selectSourceLayer || ko.observable();
+        this.drawAvailable = ko.observable(false);
+        this.bufferNodeId = ko.observable();
+        this.bufferDistance = ko.observable(0);
+        this.bufferUnits = ko.observable('m');
+        this.bufferResult = ko.observable();
+        this.bufferAddNew = ko.observable(false);
+        this.allowAddNew = this.card && this.card.canAdd() && this.tile !== this.card.newTile;
+        this.disableEdit = ko.observable(params.disableEdit ?? true)
+        console.log("custom editor", this.disableEdit())
+        var selectSource = this.selectSource();
+        var selectSourceLayer = this.selectSourceLayer();
+        var selectFeatureLayers = selectFeatureLayersFactory(resourceId, selectSource, selectSourceLayer);
+
+        this.setSelectLayersVisibility = function(visibility) {
+            var map = self.map();
+            if (map) {
+                selectFeatureLayers.forEach(function(layer) {
+                    map.setLayoutProperty(
+                        layer.id,
+                        'visibility',
+                        visibility ? 'visible' : 'none'
+                    );
+                });
+            }
+        };
+
+
+        var sources = [];
+        for (var sourceName in arches.mapSources) {
+            if (Object.prototype.hasOwnProperty.call(arches.mapSources, sourceName)) {
+                sources.push(sourceName);
+            }
+        }
+        var updateSelectLayers = function() {
+            var source = self.selectSource();
+            var sourceLayer = self.selectSourceLayer();
+            selectFeatureLayers = sources.indexOf(source) > 0 ?
+                selectFeatureLayersFactory(resourceId, source, sourceLayer) :
+                [];
+            self.additionalLayers(
+                extendedLayers.concat(
+                    selectFeatureLayers,
+                    geojsonLayers
+                )
+            );
+        };
+        this.selectSource.subscribe(updateSelectLayers);
+        this.selectSourceLayer.subscribe(updateSelectLayers);
+
+        this.setDrawTool = function(tool) {
+            var showSelectLayers = (tool === 'select_feature');
+            self.setSelectLayersVisibility(showSelectLayers);
+            if (showSelectLayers) {
+                self.draw.changeMode('simple_select');
+                self.selectedFeatureIds([]);
+            } else {
+                if (tool) {
+                    self.draw.changeMode(tool);
+                    self.map().draw_mode = tool;
+                }
+            }
+        };
+
+        self.geojsonWidgets.forEach(function(widget) {
+            var id = ko.unwrap(widget.node_id);
+            self.featureLookup[id] = {
+                features: ko.computed(function() {
+                    var value = koMapping.toJS(self.tile.data[id]);
+                    if (value) return value.features;
+                    else return [];
+                }),
+                selectedTool: ko.observable(),
+                dropErrors: ko.observableArray()
+            };
+            self.featureLookup[id].selectedTool.subscribe(function(tool) {
+                if (self.draw) {
+                    if (tool === '') {
+                        self.draw.trash();
+                        self.draw.changeMode('simple_select');
+                    } else if (tool) {
+                        _.each(self.featureLookup, function(value, key) {
+                            if (key !== id) {
+                                value.selectedTool(null);
+                            }
+                        });
+                        self.newNodeId = id;
+                    }
+                    self.setDrawTool(tool);
+                }
+            });
+        });
+
+        this.selectedTool = ko.pureComputed(function() {
+            var tool;
+            _.find(self.featureLookup, function(value) {
+                var selectedTool = value.selectedTool();
+                if (selectedTool) tool = selectedTool;
+            });
+            return tool;
+        });
+
+        this.updateTiles = function() {
+            var featureCollection = self.draw.getAll();
+            _.each(self.featureLookup, function(value) {
+                value.selectedTool(null);
+            });
+            self.geojsonWidgets.forEach(function(widget) {
+                var id = ko.unwrap(widget.node_id);
+                var features = [];
+                featureCollection.features.forEach(function(feature){
+                    if (feature.properties.nodeId === id) features.push(feature);
+                });
+                if (ko.isObservable(self.tile.data[id])) {
+                    self.tile.data[id]({
+                        type: 'FeatureCollection',
+                        features: features
+                    });
+                } else {
+                    if (self.tile.data[id]) {
+                        self.tile.data[id].features(features);
+                    }
+                }
+            });
+        };
+
+        var getDrawFeatures = function() {
+            var drawFeatures = [];
+            self.geojsonWidgets.forEach(function(widget) {
+                var id = ko.unwrap(widget.node_id);
+                var featureCollection = koMapping.toJS(self.tile.data[id]);
+                if (featureCollection) {
+                    featureCollection.features.forEach(function(feature) {
+                        if (!feature.id) {
+                            feature.id = uuid.generate();
+                        }
+                        feature.properties.nodeId = id;
+                    });
+                    drawFeatures = drawFeatures.concat(featureCollection.features);
+                }
+            });
+            return drawFeatures;
+        };
+        drawFeatures = getDrawFeatures();
+
+        if (drawFeatures.length > 0) {
+            params.usePosition = false;
+            params.bounds = geojsonExtent({
+                type: 'FeatureCollection',
+                features: drawFeatures
+            });
+            params.fitBoundsOptions = { padding: {top: padding, left: padding + 200, bottom: padding, right: padding + 200} };
+        }
+
+        params.activeTab = 'editor';
+        params.sources = Object.assign({
+            "geojson-editor-data": {
+                "type": "geojson",
+                "data": {
+                    "type": "FeatureCollection",
+                    "features": []
+                }
+            }
+        }, params.sources);
+        var extendedLayers = [];
+        if (params.layers) {
+            extendedLayers = ko.unwrap(params.layers);
+        }
+        var geojsonLayers = [{
+            "id": "geojson-editor-polygon-fill",
+            "type": "fill",
+            "filter": ["==", "$type", "Polygon"],
+            "paint": {
+                "fill-color": "#3bb2d0",
+                "fill-outline-color": "#3bb2d0",
+                "fill-opacity": 0.1
+            },
+            "source": "geojson-editor-data"
+        },  {
+            "id": "geojson-editor-polygon-stroke-base",
+            "type": "line",
+            "filter": ["==", "$type", "Polygon"],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#fff",
+                "line-width": 4
+            },
+            "source": "geojson-editor-data"
+        },  {
+            "id": "geojson-editor-polygon-stroke",
+            "type": "line",
+            "filter": ["==", "$type", "Polygon"],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#3bb2d0",
+                "line-width": 2
+            },
+            "source": "geojson-editor-data"
+        }, {
+            "id": "geojson-editor-line",
+            "type": "line",
+            "filter": ["==", "$type", "LineString"],
+            "layout": {
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "paint": {
+                "line-color": "#3bb2d0",
+                "line-width": 2
+            },
+            "source": "geojson-editor-data"
+        }, {
+            "id": "geojson-editor-point-point-stroke",
+            "type": "circle",
+            "filter": ["==", "$type", "Point"],
+            "paint": {
+                "circle-radius": 6,
+                "circle-opacity": 1,
+                "circle-color": "#fff"
+            },
+            "source": "geojson-editor-data"
+        }, {
+            "id": "geojson-editor-point",
+            "type": "circle",
+            "filter": ["==", "$type", "Point"],
+            "paint": {
+                "circle-radius": 5,
+                "circle-color": "#3bb2d0"
+            },
+            "source": "geojson-editor-data"
+        }];
+
+        params.layers = ko.observable(
+            extendedLayers.concat(
+                selectFeatureLayers,
+                geojsonLayers
+            )
+        );
+
+        MapComponentViewModel.apply(this, [params]);
+
+        this.deleteFeature = function(feature) {
+            if (self.draw) {
+                self.draw.delete(feature.id);
+                self.selectedFeatureIds(
+                    self.selectedFeatureIds().filter(function(id) {
+                        return id !== feature.id;
+                    })
+                );
+                self.updateTiles();
+            }
+        };
+
+        this.editFeature = function(feature) {
+            if (self.draw) {
+                self.draw.changeMode('simple_select', {
+                    featureIds: [feature.id]
+                });
+                self.selectedFeatureIds([feature.id]);
+                _.each(self.featureLookup, function(value) {
+                    value.selectedTool(null);
+                });
+            }
+        };
+
+        this.updateLayers = function(layers) {
+            var map = self.map();
+            var style = map.getStyle();
+            if (style) {
+                style.layers = self.draw ? layers.concat(self.draw.options.styles) : layers;
+                map.setStyle(style);
+            }
+        };
+
+        this.fitFeatures = function(features) {
+            var map = self.map();
+            var bounds = geojsonExtent({
+                type: 'FeatureCollection',
+                features: features
+            });
+            var camera = map.cameraForBounds(bounds, { padding: padding });
+            map.jumpTo(camera);
+        };
+
+        this.editGeoJSON = function(features, nodeId) {
+            var geoJSONString = JSON.stringify({
+                type: 'FeatureCollection',
+                features: features
+            }, null, '   ');
+            this.geoJSONString(geoJSONString);
+            self.newNodeId = nodeId;
+        };
+        this.geoJSONString.subscribe(function(geoJSONString) {
+            var map = self.map();
+            if (geoJSONString === undefined) {
+                setupDraw(map);
+            } else if (self.draw) {
+                map.removeControl(self.draw);
+                self.draw = undefined;
+                self.selectedFeatureIds([]);
+            }
+            self.setSelectLayersVisibility(false);
+        });
+        this.geoJSONErrors = ko.pureComputed(function() {
+            var geoJSONString = self.geoJSONString();
+            var hint = geojsonhint.hint(geoJSONString);
+            var errors = [];
+            hint.forEach(function(item) {
+                if (item.level !== 'message') {
+                    errors.push(item);
+                }
+            });
+            return errors;
+        }).extend({ rateLimit: 50 });
+        var geoJSONLayerData = ko.pureComputed(function() {
+            var geoJSONString = self.geoJSONString();
+            var geoJSONErrors = self.geoJSONErrors();
+            if (geoJSONErrors.length === 0) return JSON.parse(geoJSONString);
+            var fc = {
+                type: 'FeatureCollection',
+                features: []
+            };
+            if (self.bufferNodeId() && self.bufferResult()) {
+                fc.features.push(self.bufferResult());
+            }
+            return fc;
+        }).extend({ rateLimit: 100 });
+        geoJSONLayerData.subscribe(function(data) {
+            var map = self.map();
+            map.getSource('geojson-editor-data').setData(data);
+        });
+        this.updateGeoJSON = function() {
+            if (self.geoJSONErrors().length === 0) {
+                var geoJSON = JSON.parse(this.geoJSONString());
+                geoJSON.features.forEach(function(feature) {
+                    feature.id = uuid.generate();
+                    if (!feature.properties) feature.properties = {};
+                    feature.properties.nodeId = self.newNodeId;
+                });
+                if (ko.isObservable(self.tile.data[self.newNodeId])) {
+                    self.tile.data[self.newNodeId](geoJSON);
+                } else {
+                    self.tile.data[self.newNodeId].features(geoJSON.features);
+                }
+                self.geoJSONString(undefined);
+            }
+        };
+
+        var setupDraw = function(map) {
+            require(['mapbox-gl-draw'], (MapboxDraw) => {
+                var modes = MapboxDraw.modes;
+                modes.static = {
+                    onSetup: function() {
+                        this.setActionableState();
+                        return {};
+                    },
+                    toDisplayFeatures: function(state, geojson, display) {
+                        display(geojson);
+                    }
+                };
+                self.draw = new MapboxDraw({
+                    displayControlsDefault: false,
+                    modes: modes
+                });
+                map.addControl(self.draw);
+                self.draw.set({
+                    type: 'FeatureCollection',
+                    features: getDrawFeatures()
+                });
+                map.on('draw.create', function(e) {
+                    e.features.forEach(function(feature) {
+                        self.draw.setFeatureProperty(feature.id, 'nodeId', self.newNodeId);
+                    });
+                    self.updateTiles();
+                });
+                map.on('draw.update', function() {
+                    self.updateTiles();
+                    if (self.coordinateEditing()) {
+                        var editingFeature = self.draw.getSelected().features[0];
+                        if (editingFeature) updateCoordinatesFromFeature(editingFeature);
+                    }
+                    if (self.bufferNodeId()) self.updateBufferFeature();
+                });
+                map.on('draw.delete', self.updateTiles);
+                map.on('draw.modechange', function(e) {
+                    self.updateTiles();
+                    self.setSelectLayersVisibility(false);
+                    map.draw_mode = e.mode;
+                });
+                map.on('draw.selectionchange', function(e) {
+                    self.selectedFeatureIds(e.features.map(function(feature) {
+                        return feature.id;
+                    }));
+                    if (e.features.length > 0) {
+                        _.each(self.featureLookup, function(value) {
+                            value.selectedTool(null);
+                        });
+                    }
+                    self.setSelectLayersVisibility(false);
+                });
+
+                if (self.form) self.form.on('tile-reset', function() {
+                    var style = self.map().getStyle();
+                    if (style) {
+                        self.draw.set({
+                            type: 'FeatureCollection',
+                            features: getDrawFeatures()
+                        });
+                    }
+                    _.each(self.featureLookup, function(value) {
+                        if (value.selectedTool()) value.selectedTool('');
+                    });
+                });
+                if (self.draw) {
+                    self.drawAvailable(true);
+                }
+            });
+        };
+
+        if (this.provisionalTileViewModel) {
+            this.provisionalTileViewModel.resetAuthoritative();
+            this.provisionalTileViewModel.selectedProvisionalEdit.subscribe(function(val){
+                if (val) {
+                    var displayAll = function(){
+                        var featureCollection;
+                        for (var k in self.tile.data){
+                            if (self.featureLookup[k] && self.draw) {
+                                try {
+                                    featureCollection = self.draw.getAll();
+                                    featureCollection.features = ko.unwrap(self.featureLookup[k].features);
+                                    self.draw.set(featureCollection);
+                                } catch(e) {
+                                    //pass: TypeError in draw seems inconsequential.
+                                }
+                            }
+                        }
+                    };
+                    setTimeout(displayAll, 100);
+                }
+            });
+        }
+
+        this.map.subscribe(setupDraw);
+
+        self.map.subscribe(function(map) {
+            if (self.draw && !params.draw) {
+                params.draw = self.draw;
+            }
+            if (map && !params.map) {
+                params.map = map;
+            }
+        });
+
+        if (!params.additionalDrawOptions) {
+            params.additionalDrawOptions = [];
+        }
+
+        self.geojsonWidgets.forEach(function(widget) {
+            if (widget.config.geometryTypes) {
+                widget.drawTools = ko.pureComputed(function() {
+                    var options = [{
+                        value: '',
+                        text: ''
+                    }];
+                    options = options.concat(
+                        ko.unwrap(widget.config.geometryTypes).map(function(type) {
+                            var option = {};
+                            switch (ko.unwrap(type.id)) {
+                            case 'Point':
+                                option.value = 'draw_point';
+                                option.text = arches.translations.mapAddPoint;
+                                break;
+                            case 'Line':
+                                option.value = 'draw_line_string';
+                                option.text = arches.translations.mapAddLine;
+                                break;
+                            case 'Polygon':
+                                option.value = 'draw_polygon';
+                                option.text = arches.translations.mapAddPolygon;
+                                break;
+                            }
+                            return option;
+                        })
+                    );
+                    if (self.selectSource()) {
+                        options.push({
+                            value: "select_feature",
+                            text: self.selectText() || arches.translations.mapSelectDrawing
+                        });
+                    }
+                    options = options.concat(params.additionalDrawOptions);
+                    return options;
+                });
+            }
+        });
+
+        this.isFeatureClickable = function(feature) {
+            var tool = self.selectedTool();
+            if (tool && tool !== 'select_feature') return false;
+            return feature.properties.resourceinstanceid || self.isSelectable(feature);
+        };
+
+        self.isSelectable = function(feature) {
+            var selectLayerIds = selectFeatureLayers.map(function(layer) {
+                return layer.id;
+            });
+            return selectLayerIds.indexOf(feature.layer.id) >= 0;
+        };
+
+        var addSelectFeatures = function(features) {
+            var featureIds = [];
+            features.forEach(function(feature) {
+                feature.id = uuid.generate();
+                feature.properties = {
+                    nodeId: self.newNodeId
+                };
+                self.draw.add(feature);
+                featureIds.push(feature.id);
+            });
+            self.updateTiles();
+            if (self.popup) self.popup.remove();
+            self.draw.changeMode('simple_select', {
+                featureIds: featureIds
+            });
+            self.selectedFeatureIds(featureIds);
+            _.each(self.featureLookup, function(value) {
+                value.selectedTool(null);
+            });
+        };
+
+        self.selectFeature = function(feature) {
+            try {
+                var geometry = JSON.parse(feature.properties.geojson);
+                var newFeature = {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": geometry
+                };
+                addSelectFeatures([newFeature]);
+            } catch(e) {
+                $.getJSON(feature.properties.geojson, function(data) {
+                    addSelectFeatures(data.features);
+                });
+            }
+        };
+
+        var addFromGeoJSON = function(geoJSONString, nodeId) {
+            var hint = geojsonhint.hint(geoJSONString);
+            var errors = [];
+            hint.forEach(function(item) {
+                if (item.level !== 'message') {
+                    errors.push(item);
+                }
+            });
+            if (errors.length === 0) {
+                var geoJSON = JSON.parse(geoJSONString);
+                geoJSON.features = geoJSON.features.filter(function(feature) {
+                    return feature.geometry;
+                });
+                if (geoJSON.features.length > 0) {
+                    self.map().fitBounds(
+                        geojsonExtent(geoJSON),
+                        {
+                            padding: padding
+                        }
+                    );
+                    geoJSON.features.forEach(function(feature) {
+                        feature.id = uuid.generate();
+                        if (!feature.properties) feature.properties = {};
+                        feature.properties.nodeId = nodeId;
+                        self.draw.add(feature);
+                    });
+                    self.updateTiles();
+                }
+            }
+            return errors;
+        };
+
+        self.handleFiles = function(files, nodeId) {
+            var errors = [];
+            var promises = [];
+            for (var i = 0; i < files.length; i++) {
+                var extension = files[i].name.split('.').pop();
+                if (!['kml', 'json', 'geojson'].includes(extension)) {
+                    errors.push({
+                        message: 'File unsupported: "' + files[i].name + '"'
+                    });
+                } else {
+                    promises.push(new Promise(function(resolve) {
+                        var file = files[i];
+                        var extension = file.name.split('.').pop();
+                        var reader = new window.FileReader();
+                        reader.onload = function(e) {
+                            var geoJSON;
+                            if (['json', 'geojson'].includes(extension))
+                                geoJSON = JSON.parse(e.target.result);
+                            else
+                                geoJSON = toGeoJSON.kml(
+                                    new window.DOMParser()
+                                        .parseFromString(e.target.result, "text/xml")
+                                );
+                            resolve(geoJSON);
+                        };
+                        reader.readAsText(file);
+                    }));
+                }
+            }
+            Promise.all(promises).then(function(results) {
+                var geoJSON = {
+                    "type": "FeatureCollection",
+                    "features": results.reduce(function(features, geoJSON) {
+                        features = features.concat(geoJSON.features);
+                        return features;
+                    }, [])
+                };
+                errors = errors.concat(
+                    addFromGeoJSON(JSON.stringify(geoJSON), nodeId)
+                );
+                self.featureLookup[nodeId].dropErrors(errors);
+            });
+        };
+
+        self.dropZoneHandler = function(data, e) {
+            var nodeId = data.node.nodeid;
+            e.stopPropagation();
+            e.preventDefault();
+            var files = e.originalEvent.dataTransfer.files;
+            self.handleFiles(files, nodeId);
+            self.dropZoneLeaveHandler(data, e);
+        };
+
+        self.dropZoneOverHandler = function(data, e) {
+            e.stopPropagation();
+            e.preventDefault();
+            e.originalEvent.dataTransfer.dropEffect = 'copy';
+        };
+
+        self.dropZoneClickHandler = function(data, e) {
+            var fileInput = e.target.parentNode.parentNode.querySelector('.hidden-file-input input');
+            var event = window.document.createEvent("MouseEvents");
+            event.initEvent("click", true, false);
+            fileInput.dispatchEvent(event);
+        };
+
+        self.dropZoneEnterHandler = function(data, e) {
+            e.target.classList.add('drag-hover');
+        };
+
+        self.dropZoneLeaveHandler = function(data, e) {
+            e.target.classList.remove('drag-hover');
+        };
+
+        self.dropZoneFileSelected = function(data, e) {
+            self.handleFiles(e.target.files, data.node.nodeid);
+        };
+        self.coordinateReferences = arches.preferredCoordinateSystems;
+        self.selectedCoordinateReference = ko.observable(self.coordinateReferences[0].proj4);
+        self.coordinates = ko.observableArray();
+        var geographic = '+proj=longlat +datum=WGS84 +no_defs", "default';
+        self.rawCoordinates = ko.computed(function() {
+            return self.coordinates().map(function(coords) {
+                var sourceCRS = self.selectedCoordinateReference();
+                return proj4(sourceCRS, geographic, [Number(coords[0]()), Number(coords[1]())]);
+            });
+        }).extend({ throttle: 100 });
+        self.rawCoordinates.subscribe(function(rawCoordinates) {
+            var selectedFeatureId = self.selectedFeatureIds()[0];
+            if (self.coordinateEditing()) {
+                if (selectedFeatureId) {
+                    var drawFeatures = getDrawFeatures();
+                    drawFeatures.forEach(function(feature) {
+                        if (feature.id === selectedFeatureId) {
+                            if (feature.geometry.type === 'Polygon') {
+                                rawCoordinates.push(rawCoordinates[0]);
+                                feature.geometry.coordinates[0] = rawCoordinates;
+                            } else if (feature.geometry.type === 'Point')
+                                feature.geometry.coordinates = rawCoordinates[0];
+                            else
+                                feature.geometry.coordinates = rawCoordinates;
+                        }
+                    });
+                    self.draw.set({
+                        type: 'FeatureCollection',
+                        features: drawFeatures
+                    });
+                    self.updateTiles();
+                } else if (rawCoordinates.length >= self.minCoordinates()) {
+                    var coordinates = [];
+                    var geomType = self.coordinateGeomType();
+                    switch (geomType) {
+                    case 'Polygon':
+                        rawCoordinates.push(rawCoordinates[0]);
+                        coordinates = [rawCoordinates];
+                        break;
+                    case 'Point':
+                        coordinates = rawCoordinates[0];
+                        break;
+                    default:
+                        coordinates = rawCoordinates;
+                        break;
+                    }
+                    addSelectFeatures([{
+                        type: "Feature",
+                        geometry: {
+                            type: geomType,
+                            coordinates: coordinates
+                        }
+                    }]);
+                }
+            }
+        });
+        self.showCoordinateFeature = function() {
+            var selectedFeatureIds = self.selectedFeatureIds();
+            var featureId = selectedFeatureIds[0];
+            if (featureId) {
+                var feature = self.draw.get(featureId);
+                self.fitFeatures([feature]);
+            }
+        };
+
+        self.coordinateEditing = ko.observable(false);
+        self.newX = ko.observable();
+        self.newY = ko.observable();
+        var newCoordinatePair = ko.computed(function() {
+            var x = self.newX();
+            var y = self.newY();
+            return [x, y];
+        });
+        self.focusLatestY = ko.observable(true);
+        var getNewCoordinatePair = function(coords) {
+            var newCoords = [
+                ko.observable(coords[0]),
+                ko.observable(coords[1])
+            ];
+            newCoords.forEach(function(value) {
+                value.subscribe(function(newValue) {
+                    if ([undefined, null, ""].includes(newValue)) value(0);
+                });
+            });
+            return newCoords;
+        };
+        newCoordinatePair.subscribe(function(coords) {
+            if (coords[0] && coords[1]) {
+                self.coordinates.push(getNewCoordinatePair(coords));
+                self.newX(undefined);
+                self.newY(undefined);
+                self.focusLatestY(true);
+            }
+        });
+        var updateCoordinatesFromFeature = function(feature) {
+            var sourceCoordinates = [];
+            if (feature.geometry.type === 'Polygon') {
+                sourceCoordinates = [];
+                for (var i = 0; i < feature.geometry.coordinates[0].length - 1; i++) {
+                    sourceCoordinates.push(feature.geometry.coordinates[0][i]);
+                }
+            } else if (feature.geometry.type === 'Point')
+                sourceCoordinates = [feature.geometry.coordinates];
+            else sourceCoordinates = feature.geometry.coordinates;
+            self.coordinateGeomType(feature.geometry.type);
+            self.coordinates(sourceCoordinates.map(function(coords) {
+                var newCoords = getNewCoordinatePair(coords);
+                transformCoordinatePair(newCoords, geographic);
+                return newCoords;
+            }));
+        };
+        var transformCoordinatePair = function(coords, sourceCRS) {
+            var targetCRS = self.selectedCoordinateReference();
+            var transformedCoordinates = proj4(sourceCRS, targetCRS, [Number(coords[0]()), Number(coords[1]())]);
+            coords[0](transformedCoordinates[0]);
+            coords[1](transformedCoordinates[1]);
+        };
+        var previousCRS = self.selectedCoordinateReference();
+        var transformCoordinates = function() {
+            var targetCRS = self.selectedCoordinateReference();
+            self.coordinates().forEach(function(coords) {
+                transformCoordinatePair(coords, previousCRS);
+            });
+            previousCRS = targetCRS;
+        };
+        self.selectedCoordinateReference.subscribe(transformCoordinates);
+
+        self.coordinateGeomType = ko.observable();
+        self.coordinateEditing.subscribe(function(editing) {
+            self.coordinateGeomType(null);
+            var selectedTool = self.selectedTool();
+            switch (selectedTool) {
+            case 'draw_point':
+                self.coordinateGeomType('Point');
+                break;
+            case 'draw_line_string':
+                self.coordinateGeomType('LineString');
+                break;
+            case 'draw_polygon':
+                self.coordinateGeomType('Polygon');
+                break;
+            default:
+                break;
+            }
+            var selectedFeatureIds = self.selectedFeatureIds();
+            var featureId = selectedFeatureIds[0];
+            self.focusLatestY(false);
+            self.coordinates([]);
+            self.newX(undefined);
+            self.newY(undefined);
+            if (editing) {
+                var selectConfig;
+                if (selectedFeatureIds.length > 0) {
+                    selectConfig = {
+                        featureIds: [featureId]
+                    };
+                    self.selectedFeatureIds([featureId]);
+                    var feature = self.draw.get(featureId);
+                    updateCoordinatesFromFeature(feature);
+                }
+                if (selectedTool) {
+                    self.draw.trash();
+                }
+                self.draw.changeMode('simple_select', selectConfig);
+                _.each(self.featureLookup, function(value) {
+                    value.selectedTool(null);
+                });
+            }
+        });
+        self.hideNewCoordinates = ko.computed(function() {
+            var geomType = self.coordinateGeomType();
+            var coordCount = self.coordinates().length;
+            return geomType === 'Point' && coordCount > 0;
+        });
+
+        self.minCoordinates = ko.computed(function() {
+            var geomType = self.coordinateGeomType();
+            var minCoordinates;
+            switch (geomType) {
+            case 'Point':
+                minCoordinates = 1;
+                break;
+            case 'LineString':
+                minCoordinates = 2;
+                break;
+            case 'Polygon':
+                minCoordinates = 3;
+                break;
+            default:
+                break;
+            }
+            return minCoordinates;
+        });
+
+        self.allowDeleteCoordinates = ko.computed(function() {
+            return self.coordinates().length > self.minCoordinates();
+        });
+
+        self.editCoordinates = function() {
+            self.coordinateEditing(true);
+        };
+
+        self.canEditCoordinates = ko.computed(function() {
+            var featureId = self.selectedFeatureIds()[0];
+            if (featureId) {
+                var feature = self.draw.get(featureId);
+                return ['Point', 'LineString', 'Polygon'].includes(feature.geometry.type);
+            } else {
+                var selectedTool = self.selectedTool();
+                return ['draw_point', 'draw_line_string', 'draw_polygon'].includes(selectedTool);
+            }
+        });
+
+        self.selectedFeatureIds.subscribe(function(ids) {
+            if (ids.length === 0) self.coordinateEditing(false);
+            else if (self.canEditCoordinates()) {
+                var feature = self.draw.get(ids[0]);
+                updateCoordinatesFromFeature(feature);
+            }
+        });
+
+        self.bufferFeature = ko.computed(function() {
+            return self.selectedFeatureIds()[0];
+        });
+        var getBufferFeature = function() {
+            var featureId = self.bufferFeature();
+            if (featureId) {
+                return self.draw.get(featureId);
+            }
+        };
+        self.bufferParams = ko.computed(function() {
+            var bufferFeature = getBufferFeature();
+            if (bufferFeature && self.bufferNodeId()) return {
+                "geometry": bufferFeature.geometry,
+                "buffer": {
+                    "width": parseFloat(self.bufferDistance()),
+                    "unit": self.bufferUnits()
+                }
+            };
+        });
+
+        self.bufferFeature.subscribe(function(bufferFeature) {
+            if (!bufferFeature) self.bufferNodeId(false);
+        });
+        self.updateBufferFeature = function() {
+            var bufferParams = self.bufferParams();
+            var bufferFeature = getBufferFeature();
+            if (bufferParams && bufferFeature) {
+                bufferParams.geometry = bufferFeature.geometry;
+                window.fetch(
+                    arches.urls.buffer +
+                    '?filter=' +
+                    JSON.stringify(bufferParams)
+                ).then(function(response) {
+                    if (response.ok) {
+                        return response.json();
+                    }
+                }).then(function(json) {
+                    var bufferFeature = getBufferFeature();
+                    self.bufferResult({
+                        type: 'Feature',
+                        id: uuid.generate(),
+                        geometry: json,
+                        properties: {
+                            nodeId: bufferFeature.properties.nodeId
+                        }
+                    });
+                });
+            } else self.bufferResult(undefined);
+
+        };
+        self.bufferParams.subscribe(self.updateBufferFeature);
+
+
+        if (self.card) {
+            self.card.map = self.map;
+        }
+
+        self.addBufferResult = function() {
+            var bufferResult = self.bufferResult();
+            if (self.bufferAddNew()) {
+                var dirty = ko.unwrap(self.tile.dirty);
+                var nodeId = self.bufferNodeId();
+                var addBufferResultAsNew = function() {
+                    var updateNewTile = self.card.selected.subscribe(function() {
+                        var fc = {
+                            "type": "FeatureCollection",
+                            "features": [bufferResult]
+                        };
+                        self.card.getNewTile().data[nodeId](fc);
+                        self.card.map.subscribe(function(map) {
+                            map.fitBounds(
+                                geojsonExtent(fc),
+                                {
+                                    duration: 0,
+                                    padding: padding
+                                }
+                            );
+                        });
+                        updateNewTile.dispose();
+                    });
+                    self.card.selected(true);
+                };
+                if (dirty) self.saveTile(addBufferResultAsNew);
+                else addBufferResultAsNew();
+            } else {
+                self.draw.add(bufferResult);
+                self.bufferNodeId(false);
+                self.updateTiles();
+                self.editFeature(bufferResult);
+                self.fitFeatures([bufferResult]);
+            }
+        };
+    };
+    return viewModel;
+});

--- a/coral/media/js/views/components/cards/default.js
+++ b/coral/media/js/views/components/cards/default.js
@@ -43,12 +43,7 @@ define([
             var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
             var i = Math.floor(Math.log(bytes) / Math.log(k));
             return (parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i]);
-        };
-
-        this.getNodeOptions = (nodeId) => {
-            return params.nodeOptions?.[nodeId]
-        }
-    
+        };    
     }
 
     return ko.components.register('default-card', {

--- a/coral/plugins/incident-report-workflow.json
+++ b/coral/plugins/incident-report-workflow.json
@@ -267,7 +267,12 @@
                   "resourceid": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "87d3872b-f44f-11eb-bd0c-a87eeabdefba",
                   "parenttileid": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['locationData']",
-                  "semanticName": "Geometry"
+                  "semanticName": "Geometry",
+                  "nodeOptions": {
+                    "87d3d7dc-f44f-11eb-bee9-a87eeabdefba": {
+                      "disableEdit": true
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "fetch-latest-tile",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=18, patch=57)
+APP_VERSION = semantic_version.Version(major=5, minor=19, patch=57)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/map-widget-editor.htm
+++ b/coral/templates/views/components/map-widget-editor.htm
@@ -1,0 +1,207 @@
+{% extends "views/components/map.htm" %}
+{% load i18n %}
+
+{% block tabs %}
+<!-- ko if: !disableEdit() -->
+<div id="toggle-editor-panel-button" class="workbench-card-sidebar-tab" tabindex="0" role="button" aria-controls="side-panel"
+    data-bind="onEnterkeyClick, onSpaceClick, click: function() {
+        toggleTab('editor');
+        $root.handleEscKey(event.currentTarget, '#side-panel');
+    }, css: {
+        'active': activeTab() === 'editor'
+    }, attr: {
+        'aria-label': $root.translations.mapEditor,
+        'aria-expanded': (activeTab() === 'editor').toString() 
+    },
+">
+    <i class="fa fa-pencil"></i>
+    <span data-bind="text: $root.translations.edit"></span>
+</div>
+<!-- /ko -->
+{{ block.super }}
+{% endblock tabs %}
+
+{% block sidepanel %}
+<!-- ko foreach: { data: [$data], as: 'self' } -->
+<!--ko if: activeTab() === 'editor' -->
+<div style="height: 95%">
+    <div class="workbench-card-sidepanel-header-container">
+        <p class="workbench-card-sidepanel-header h4" tabindex="0" role="button" 
+            data-bind="onEnterkeyClick, onSpaceClick, text: label,
+                click: function(){hideSidePanel('#toggle-editor-panel-button')},  
+                attr: {'aria-label': $root.translations.hideEditor},
+        "></p>
+    </div>
+    <div class="workbench-card-sidepanel-border"></div>
+        <div class="new-provisional-edit-card-container" style="height: 100%">
+            <!-- ko if: geoJSONString() !== undefined -->
+            <div class="card">
+                <div class="geojson-editor" data-bind="codemirror: {
+                    value: geoJSONString,
+                    mode: { name: 'javascript', json: true },
+                    lineNumbers: true
+                }"></div>
+                <div>
+                    <button class="btn btn-shim btn-danger btn-labeled btn-lg fa fa-times" data-bind="click: function () {
+                        geoJSONString(undefined);
+                    }">
+                        <span data-bind="text: $root.translations.cancel"></span>
+                    </button>
+                    <button class="btn btn-shim btn-labeled btn-lg fa fa-plus btn-mint" data-bind="css: {
+                        disabled: geoJSONErrors().length !== 0
+                    }, click: updateGeoJSON">
+                        <span data-bind="text: $root.translations.updateFeatures"></span>
+                    </button>
+                </div>
+                <!-- ko if: geoJSONErrors().length !== 0 -->
+                <div class="geojson-error-list">
+                    <span data-bind="text: $root.translations.geojsonErrors"></span>
+                    <ul>
+                        <!-- ko foreach: geoJSONErrors() -->
+                        <li data-bind="text: message"></li>
+                        <!-- /ko-->
+                    </ul>
+                </div>
+                <!-- /ko-->
+            </div>
+            <!-- /ko-->
+
+            {% include 'views/components/coordinate-editor.htm' %}
+
+            {% include 'views/components/buffer-editor.htm' %}
+
+            <div class="card" data-bind="visible: geoJSONString() === undefined && !coordinateEditing() && !bufferNodeId()">
+                <div class="row widget-wrapper">
+                    <div class="form-group">
+                        <div class="col-xs-12">
+                            <div class="map-card-feature-list">
+                                <div class="add-new-feature">
+                                    <select 
+                                        data-bind="
+                                            placeholder: $root.translations.addANewFeature + '...',
+                                            value: self.featureLookup[widget.node_id()].selectedTool,
+                                            valueAllowUnset: true,
+                                            options: widget.drawTools,
+                                            optionsText: 'text',
+                                            optionsValue: 'value',
+                                            chosen: {
+                                                'width': '100%',
+                                                'disable_search_threshold': 10,
+                                                'allow_single_deselect': true
+                                            },
+                                            attr: {'aria-label': $root.translations.addANewFeature}
+                                        "
+                                    ></select>
+                                </div>
+                                <div>
+                                    <div class="map-data-drop-area" tabindex="0" role="button" 
+                                        data-bind="event: {
+                                            dragover: dropZoneOverHandler,
+                                            drop: dropZoneHandler,
+                                            click: dropZoneClickHandler,
+                                            dragenter: dropZoneEnterHandler,
+                                            dragleave: dropZoneLeaveHandler,
+                                            dragend: dropZoneLeaveHandler
+                                        }, attr: {'aria-label': $root.translations.dragGeoJsonKml},
+                                        onEnterkeyClick, onSpaceClick
+                                        ">
+                                        <span data-bind="text: $root.translations.dragGeoJsonKml"></span>
+                                    </div>
+                                    <div class="hidden-file-input">
+                                        <input type="file" accept=".json,.geojson,.kml" data-bind="event: {
+                                            change: self.dropZoneFileSelected
+                                        }"/>
+                                    </div>
+                                </div>
+                                <!-- ko if: self.featureLookup[widget.node_id()].dropErrors().length !== 0 -->
+                                <div class="geojson-error-list">
+                                    <a href="javascript: void(0);" data-bind="click:function () {
+                                        self.featureLookup[widget.node_id()].dropErrors([]);
+                                    }">
+                                        <i class="fa fa-close"></i>
+                                    </a>
+                                    <span data-bind="text: $root.translations.followingErrorsOccurred"></span>
+                                    <ul>
+                                        <!-- ko foreach: self.featureLookup[widget.node_id()].dropErrors() -->
+                                        <li data-bind="text: message"></li>
+                                        <!-- /ko-->
+                                    </ul>
+                                </div>
+                                <!-- /ko-->
+                                <table class="table">
+                                    <tbody>
+                                        <!-- ko foreach: {data: self.featureLookup[widget.node_id()].features, as: 'feature'} -->
+                                        <tr class="map-card-feature-item" data-bind="css: {'active': self.selectedFeatureIds().indexOf(feature.id) >= 0}, click: function() { self.fitFeatures([feature]) }">
+                                            <td>
+                                                <span class="map-card-feature-name" data-bind="text: feature.geometry.type"></span>
+                                            </td>
+                                            <td class="map-card-feature-tool">
+                                                <a href="javascript:void(0);" role="button" data-bind="click: function() { self.editFeature(feature) }, clickBubble: false,
+                                                    attr: {'aria-label': $root.translations.editFeature}
+                                                ">
+                                                    <i class="fa fa-pencil map-card-feature-edit"></i>
+                                                    <span data-bind="text: $root.translations.edit"></span>
+                                                </a>
+                                            </td>
+                                            <td class="map-card-feature-tool">
+                                                <a href="javascript:void(0);" role="button" data-bind="click: function() { self.deleteFeature(feature) }, clickBubble: false,
+                                                    attr: {'aria-label': $root.translations.deleteFeature}
+                                                ">
+                                                    <i class="fa fa-trash map-card-feature-delete"></i>
+                                                    <span data-bind="text: $root.translations.delete"></span>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        <!-- /ko -->
+                                    </tbody>
+                                </table>
+                                <div class="map-card-zoom-tool">
+                                    <button data-bind="click: function() {
+                                        self.editGeoJSON(self.featureLookup[widget.node_id()].features(), widget.node_id());
+                                    }">
+                                        <i class="fa fa-pencil map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.editGeoJson"></span>
+                                    </button>
+                                    |
+                                    <button data-bind="click: canEditCoordinates() ? function(){self.coordinateEditing(true)} : null, 
+                                        css: {
+                                            'inactive': !canEditCoordinates() 
+                                        }, attr: {
+                                            'aria-disabled': (!canEditCoordinates()).toString()
+                                        }
+                                    ">
+                                        <i class="fa fa-list map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.editCoordinates"></span>
+                                    </button>
+                                    |
+                                    <button data-bind="click: self.bufferFeature() ? function() {self.bufferNodeId(widget.node_id())} : null,
+                                        css: {
+                                            'inactive': !self.bufferFeature() 
+                                        }, attr: {
+                                            'aria-disabled': !self.bufferFeature() && (!self.bufferFeature()).toString()
+                                        }
+                                    ">
+                                        <i class="fa fa-list map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.addBuffer"></span>
+                                    </button>
+                                    <!-- ko if: self.featureLookup[widget.node_id()].features().length > 0 -->
+                                    |
+                                    <button data-bind="click: function() {
+                                        self.fitFeatures(self.featureLookup[widget.node_id()].features());
+                                    }">
+                                        <i class="fa fa-search map-card-feature-edit"></i>
+                                        <span data-bind="text: $root.translations.zoomToAll"></span>
+                                    </button>
+                                    <!-- /ko -->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+<!--/ko -->
+<!--/ko -->
+{{ block.super }}
+{% endblock sidepanel %}


### PR DESCRIPTION
# Description
Disables the map edit by removing the button from the map menu. This can be set in the config of the workflow

## Test
- Rebuild containers
- Webpack rebuild
- Coral reload
- Follow tests here [#2560](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2560)