### PR TITLE
Fix/#2214/node options for max date

### DIFF
--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -285,6 +285,25 @@ define([
             }
         };
 
+
+        this.getNodeOptions = (nodeId, widgetConfig = {}) => {
+            const options = params.nodeOptions?.[nodeId] || {};
+            if (options?.config) {
+                options.config = {
+                ...widgetConfig,
+                ...options.config
+                };
+            }
+            Object.keys(options).forEach((key) => {
+                // Should this be used a JS workflow maintain the users
+                // provided reactivity.
+                if (!ko.isObservable(options[key])) {
+                options[key] = ko.observable(options[key]);
+                }
+            });
+            return options;
+        };
+
         this.initialize();
     };
 });

--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -1,0 +1,290 @@
+define([
+    'knockout',
+    'underscore',
+    'arches',
+    'viewmodels/alert',
+    'bindings/scrollTo'
+], function(ko, _, arches, AlertViewModel) {
+    return function(params) {
+        var self = this;
+
+        if (!params.card && ko.unwrap(params.form.card)) {
+            params.card = ko.unwrap(params.form.card);
+        }
+
+        this.inResourceEditor = location.pathname.includes(arches.urls.resource_editor);
+        this.configKeys = params.configKeys || [];
+        this.showIds = params.showIds || false;
+        this.state = params.state || 'form';
+        this.preview = params.preview;
+        this.loading = params.loading || ko.observable(false);
+        this.card = params.card;
+        this.showGrid = params?.form?.showGrid;
+        this.toggleGrid = params?.form?.toggleGrid;
+        this.card.hideEmptyNodes = params.hideEmptyNodes;
+        this.card.showIds = this.showIds;
+        this.tile = params.tile;
+        this.reportExpanded = ko.observable(true);
+        this.form = params.form;
+        this.provisionalTileViewModel = params.provisionalTileViewModel;
+        this.reviewer = params.reviewer;
+        this.expanded = ko.observable(true);
+        this.showHeaderLine = params.showHeaderLine;
+
+        this.config = this.card.model ? this.card.model.get('config') : {};
+        _.each(this.configKeys, function(key) {
+            self[key] = self.config[key];
+        });
+
+        this.showChildCards = ko.computed(function() {
+            return this.card.widgets().length === 0;
+        }, this);
+
+        this.componentCssClasses = function(widget) {
+            return ["card_component",
+                ko.unwrap(widget.node?.graph?.attributes?.slug),
+                ko.unwrap(widget.node?.alias),
+                widget?.widgetLookup[ko.unwrap(widget?.widget_id)].name].join(" ");
+        };
+
+
+        this.initialize = function() {
+            self.card.showForm(true);
+
+            self.tiles = ko.computed(function() {
+                var tiles = [];
+                if (self.tile) {
+                    return self.getTiles(self.tile);
+                } else {
+                    self.card.tiles().forEach(function(tile) {
+                        self.getTiles(tile, tiles);
+                    });
+                }
+                return tiles;
+            }, self);
+            if (ko.isObservable(params.tiles)) {
+                params.tiles(self.tiles());
+
+                self.tiles.subscribe(function(tiles) {
+                    params.tiles(tiles);
+                });
+            }
+
+            self.dirty = ko.computed(function() {
+                if (!ko.unwrap(self.tiles)) {
+                    return true;
+                }
+                else {
+                    return ko.unwrap(self.tiles).reduce(function(acc, tile) {
+                        if (tile.dirty()) {
+                            acc = true;
+                        }
+                        return acc;
+                    }, false);
+                }
+            });
+            if (ko.isObservable(params.dirty)) {
+                self.dirty.subscribe(function(dirty) {
+                    params.dirty(dirty);
+                });
+            }
+
+
+            if (self.preview) {
+                if (!self.card.newTile) {
+                    self.card.newTile = self.card.getNewTile();
+                }
+                self.tile = self.card.newTile;
+            }
+
+            if (self.card.tiles().length > 0) {
+                self.card.showForm(false);
+            }
+
+            if (self.card.preSaveCallback) {
+                self.card.preSaveCallback(self.saveTile);
+            }
+        };
+
+        this.revealForm = function(card){
+            if (!card.selected()) {card.selected(true);}
+            setTimeout(function(){
+                card.showForm(true);
+            }, 50);
+        };
+
+        this.getTiles = function(tile, tiles) {
+            tiles = tiles || [tile];
+            tile.cards.forEach(function(card) {
+                card.tiles().forEach(function(tile) {
+                    tiles.push(tile);
+                    self.getTiles(tile, tiles);
+                });
+            });
+            return tiles;
+        };
+
+        this.beforeMove = function(e) {
+            e.cancelDrop = (e.sourceParent!==e.targetParent);
+        };
+
+        this.startDrag = function(e, ui) {
+            ko.utils.domData.get(ui.item[0], 'ko_sortItem').selected(true);
+        };
+
+        this.getValuesByDatatype = function(type) {
+            var values = {};
+            if (self.tile && self.form) {
+                var data = self.tile.getAttributes().data;
+                _.each(data, function(value, key) {
+                    var node = self.form.nodeLookup[key];
+                    if (node && ko.unwrap(node.datatype) === type){
+                        values[ko.unwrap(node.id)] = {
+                            name: ko.unwrap(node.name),
+                            value: value
+                        };
+                    }
+                });
+            }
+            return values;
+        };
+
+        this.selectWorkflowTile = function(tile) {  // used for cardinality 'n' cards in workflows
+            tile.selected(true);
+            self.tile = tile;
+            params.dirty(true);
+        };
+
+        // ctrl+S to save any edited/dirty tiles in resource view 
+        var keyListener = function(e) {
+            if (e.ctrlKey && e.key === "s") {
+                e.preventDefault();
+                if (self?.tile?.dirty() == true && 
+                    self?.tile?.parent?.isWritable === true) {
+                        self.saveTile();
+                }
+            }
+        };
+        document.addEventListener("keydown", keyListener)
+        // dispose of eventlistener
+        this.dispose = function(){
+            document.removeEventListener("keydown", keyListener);
+        };
+
+        this.saveTile = function(callback) {
+            self.loading(true);
+            self.tile.transactionId = params.form?.workflowId || undefined;
+
+            if (params.resourceid) {
+                self.tile.resourceinstance_id = params.resourceid;
+            }
+            else if (ko.unwrap(params.form?.resourceId)){
+                self.tile.resourceinstance_id = ko.unwrap(params.form.resourceId);
+            }
+            self.tile.save(function(response) {
+                self.loading(false);
+                if(params?.form?.error){
+                    params.form.error(response.responseJSON.message);
+                }
+                params.pageVm.alert(
+                    new AlertViewModel(
+                        'ep-alert-red',
+                        response.responseJSON.title,
+                        response.responseJSON.message,
+                        null,
+                        function(){}
+                    )
+                );
+                if (params.form.onSaveError) {
+                    params.form.onSaveError(self.tile);
+                }
+            }, function() {
+                self.loading(false);
+                if (typeof self.onSaveSuccess === 'function') self.onSaveSuccess();
+                if (params.form.onSaveSuccess) {
+                    params.form.onSaveSuccess(self.tile);
+                }
+                if (typeof callback === 'function') callback();
+            });
+        };
+
+        var saveTileInWorkflow = function() {
+            self.saveTile(function() {
+                params.form.complete(true);
+            });
+        };
+        if (params.save) {
+            params.save = saveTileInWorkflow;
+        }
+        if (params.form && params.form.save) {
+            params.form.save = saveTileInWorkflow;
+        }
+
+        /*
+            TODO: Reverse this logic to be in-line with card UX in resource_editor using this logic:
+                    params.card && params.card.cardinality === 'n'
+                    && params.form.componentData.cardinalityOverride !== '1'
+        */
+        if (params.renderContext === 'workflow') {
+            if (params.form.componentData.cardinalityOverride === 'n') {
+                self.card.selected(true);  // cardinality 'n' cards will display appropriately
+                self.inResourceEditor = true;
+            }
+        }
+
+        this.saveTileAddNew = function() {
+            self.saveTile(function() {
+                window.setTimeout(function() {
+                    self.card.selected(true);
+                }, 1);
+            });
+        };
+
+        this.deleteTile = function() {
+            params.pageVm.alert(            
+                new AlertViewModel(
+                    'ep-alert-red',
+                    'Item Deletion.',
+                    'Are you sure you would like to delete this item?',
+                    function(){}, //does nothing when canceled
+                    function() {
+                        self.loading(true);
+                        self.tile.deleteTile(function(response) {
+                            self.loading(false);
+                            params.pageVm.alert(
+                                new AlertViewModel(
+                                    'ep-alert-red',
+                                    response.responseJSON.title,
+                                    response.responseJSON.message,
+                                    null,
+                                    function(){}
+                                )
+                            );
+                            if (params.form.onDeleteError) {
+                                params.form.onDeleteError(self.tile);
+                            }
+                        }, function() {
+                            self.loading(false);
+                            if (typeof self.onDeleteSuccess === 'function') self.onDeleteSuccess();
+                            if (params.form.onDeleteSuccess) {
+                                params.form.onDeleteSuccess(self.tile);
+                            }
+                        });
+                    })
+                );
+        };
+
+        this.createParentAndChild = async(parenttile, childcard) => {
+            try{
+                const newSave = await self.card.saveParentTile(parenttile);
+                if(newSave){
+                    childcard.selected(true);
+                }
+            } catch (err){
+                console.log(err);
+            }
+        };
+
+        this.initialize();
+    };
+});

--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -1,0 +1,309 @@
+define([
+    'knockout',
+    'underscore',
+    'arches',
+    'viewmodels/alert',
+    'bindings/scrollTo'
+], function(ko, _, arches, AlertViewModel) {
+    return function(params) {
+        var self = this;
+
+        if (!params.card && ko.unwrap(params.form.card)) {
+            params.card = ko.unwrap(params.form.card);
+        }
+
+        this.inResourceEditor = location.pathname.includes(arches.urls.resource_editor);
+        this.configKeys = params.configKeys || [];
+        this.showIds = params.showIds || false;
+        this.state = params.state || 'form';
+        this.preview = params.preview;
+        this.loading = params.loading || ko.observable(false);
+        this.card = params.card;
+        this.showGrid = params?.form?.showGrid;
+        this.toggleGrid = params?.form?.toggleGrid;
+        this.card.hideEmptyNodes = params.hideEmptyNodes;
+        this.card.showIds = this.showIds;
+        this.tile = params.tile;
+        this.reportExpanded = ko.observable(true);
+        this.form = params.form;
+        this.provisionalTileViewModel = params.provisionalTileViewModel;
+        this.reviewer = params.reviewer;
+        this.expanded = ko.observable(true);
+        this.showHeaderLine = params.showHeaderLine;
+
+        this.config = this.card.model ? this.card.model.get('config') : {};
+        _.each(this.configKeys, function(key) {
+            self[key] = self.config[key];
+        });
+
+        this.showChildCards = ko.computed(function() {
+            return this.card.widgets().length === 0;
+        }, this);
+
+        this.componentCssClasses = function(widget) {
+            return ["card_component",
+                ko.unwrap(widget.node?.graph?.attributes?.slug),
+                ko.unwrap(widget.node?.alias),
+                widget?.widgetLookup[ko.unwrap(widget?.widget_id)].name].join(" ");
+        };
+
+
+        this.initialize = function() {
+            self.card.showForm(true);
+
+            self.tiles = ko.computed(function() {
+                var tiles = [];
+                if (self.tile) {
+                    return self.getTiles(self.tile);
+                } else {
+                    self.card.tiles().forEach(function(tile) {
+                        self.getTiles(tile, tiles);
+                    });
+                }
+                return tiles;
+            }, self);
+            if (ko.isObservable(params.tiles)) {
+                params.tiles(self.tiles());
+
+                self.tiles.subscribe(function(tiles) {
+                    params.tiles(tiles);
+                });
+            }
+
+            self.dirty = ko.computed(function() {
+                if (!ko.unwrap(self.tiles)) {
+                    return true;
+                }
+                else {
+                    return ko.unwrap(self.tiles).reduce(function(acc, tile) {
+                        if (tile.dirty()) {
+                            acc = true;
+                        }
+                        return acc;
+                    }, false);
+                }
+            });
+            if (ko.isObservable(params.dirty)) {
+                self.dirty.subscribe(function(dirty) {
+                    params.dirty(dirty);
+                });
+            }
+
+
+            if (self.preview) {
+                if (!self.card.newTile) {
+                    self.card.newTile = self.card.getNewTile();
+                }
+                self.tile = self.card.newTile;
+            }
+
+            if (self.card.tiles().length > 0) {
+                self.card.showForm(false);
+            }
+
+            if (self.card.preSaveCallback) {
+                self.card.preSaveCallback(self.saveTile);
+            }
+        };
+
+        this.revealForm = function(card){
+            if (!card.selected()) {card.selected(true);}
+            setTimeout(function(){
+                card.showForm(true);
+            }, 50);
+        };
+
+        this.getTiles = function(tile, tiles) {
+            tiles = tiles || [tile];
+            tile.cards.forEach(function(card) {
+                card.tiles().forEach(function(tile) {
+                    tiles.push(tile);
+                    self.getTiles(tile, tiles);
+                });
+            });
+            return tiles;
+        };
+
+        this.beforeMove = function(e) {
+            e.cancelDrop = (e.sourceParent!==e.targetParent);
+        };
+
+        this.startDrag = function(e, ui) {
+            ko.utils.domData.get(ui.item[0], 'ko_sortItem').selected(true);
+        };
+
+        this.getValuesByDatatype = function(type) {
+            var values = {};
+            if (self.tile && self.form) {
+                var data = self.tile.getAttributes().data;
+                _.each(data, function(value, key) {
+                    var node = self.form.nodeLookup[key];
+                    if (node && ko.unwrap(node.datatype) === type){
+                        values[ko.unwrap(node.id)] = {
+                            name: ko.unwrap(node.name),
+                            value: value
+                        };
+                    }
+                });
+            }
+            return values;
+        };
+
+        this.selectWorkflowTile = function(tile) {  // used for cardinality 'n' cards in workflows
+            tile.selected(true);
+            self.tile = tile;
+            params.dirty(true);
+        };
+
+        // ctrl+S to save any edited/dirty tiles in resource view 
+        var keyListener = function(e) {
+            if (e.ctrlKey && e.key === "s") {
+                e.preventDefault();
+                if (self?.tile?.dirty() == true && 
+                    self?.tile?.parent?.isWritable === true) {
+                        self.saveTile();
+                }
+            }
+        };
+        document.addEventListener("keydown", keyListener)
+        // dispose of eventlistener
+        this.dispose = function(){
+            document.removeEventListener("keydown", keyListener);
+        };
+
+        this.saveTile = function(callback) {
+            self.loading(true);
+            self.tile.transactionId = params.form?.workflowId || undefined;
+
+            if (params.resourceid) {
+                self.tile.resourceinstance_id = params.resourceid;
+            }
+            else if (ko.unwrap(params.form?.resourceId)){
+                self.tile.resourceinstance_id = ko.unwrap(params.form.resourceId);
+            }
+            self.tile.save(function(response) {
+                self.loading(false);
+                if(params?.form?.error){
+                    params.form.error(response.responseJSON.message);
+                }
+                params.pageVm.alert(
+                    new AlertViewModel(
+                        'ep-alert-red',
+                        response.responseJSON.title,
+                        response.responseJSON.message,
+                        null,
+                        function(){}
+                    )
+                );
+                if (params.form.onSaveError) {
+                    params.form.onSaveError(self.tile);
+                }
+            }, function() {
+                self.loading(false);
+                if (typeof self.onSaveSuccess === 'function') self.onSaveSuccess();
+                if (params.form.onSaveSuccess) {
+                    params.form.onSaveSuccess(self.tile);
+                }
+                if (typeof callback === 'function') callback();
+            });
+        };
+
+        var saveTileInWorkflow = function() {
+            self.saveTile(function() {
+                params.form.complete(true);
+            });
+        };
+        if (params.save) {
+            params.save = saveTileInWorkflow;
+        }
+        if (params.form && params.form.save) {
+            params.form.save = saveTileInWorkflow;
+        }
+
+        /*
+            TODO: Reverse this logic to be in-line with card UX in resource_editor using this logic:
+                    params.card && params.card.cardinality === 'n'
+                    && params.form.componentData.cardinalityOverride !== '1'
+        */
+        if (params.renderContext === 'workflow') {
+            if (params.form.componentData.cardinalityOverride === 'n') {
+                self.card.selected(true);  // cardinality 'n' cards will display appropriately
+                self.inResourceEditor = true;
+            }
+        }
+
+        this.saveTileAddNew = function() {
+            self.saveTile(function() {
+                window.setTimeout(function() {
+                    self.card.selected(true);
+                }, 1);
+            });
+        };
+
+        this.deleteTile = function() {
+            params.pageVm.alert(            
+                new AlertViewModel(
+                    'ep-alert-red',
+                    'Item Deletion.',
+                    'Are you sure you would like to delete this item?',
+                    function(){}, //does nothing when canceled
+                    function() {
+                        self.loading(true);
+                        self.tile.deleteTile(function(response) {
+                            self.loading(false);
+                            params.pageVm.alert(
+                                new AlertViewModel(
+                                    'ep-alert-red',
+                                    response.responseJSON.title,
+                                    response.responseJSON.message,
+                                    null,
+                                    function(){}
+                                )
+                            );
+                            if (params.form.onDeleteError) {
+                                params.form.onDeleteError(self.tile);
+                            }
+                        }, function() {
+                            self.loading(false);
+                            if (typeof self.onDeleteSuccess === 'function') self.onDeleteSuccess();
+                            if (params.form.onDeleteSuccess) {
+                                params.form.onDeleteSuccess(self.tile);
+                            }
+                        });
+                    })
+                );
+        };
+
+        this.createParentAndChild = async(parenttile, childcard) => {
+            try{
+                const newSave = await self.card.saveParentTile(parenttile);
+                if(newSave){
+                    childcard.selected(true);
+                }
+            } catch (err){
+                console.log(err);
+            }
+        };
+
+
+        this.getNodeOptions = (nodeId, widgetConfig = {}) => {
+            const options = params.nodeOptions?.[nodeId] || {};
+            if (options?.config) {
+                options.config = {
+                ...widgetConfig,
+                ...options.config
+                };
+            }
+            Object.keys(options).forEach((key) => {
+                // Should this be used a JS workflow maintain the users
+                // provided reactivity.
+                if (!ko.isObservable(options[key])) {
+                options[key] = ko.observable(options[key]);
+                }
+            });
+            return options;
+        };
+
+        this.initialize();
+    };
+});

--- a/coral/media/js/views/components/cards/default.js
+++ b/coral/media/js/views/components/cards/default.js
@@ -45,10 +45,23 @@ define([
             return (parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i]);
         };
 
-        this.getNodeOptions = (nodeId) => {
-            return params.nodeOptions?.[nodeId]
-        }
-    
+        this.getNodeOptions = (nodeId, widgetConfig = {}) => {
+          const options = params.nodeOptions?.[nodeId] || {};
+          if (options?.config) {
+            options.config = {
+              ...widgetConfig,
+              ...options.config
+            };
+          }
+          Object.keys(options).forEach((key) => {
+            // Should this be used a JS workflow maintain the users
+            // provided reactivity.
+            if (!ko.isObservable(options[key])) {
+              options[key] = ko.observable(options[key]);
+            }
+          });
+          return options;
+        };
     }
 
     return ko.components.register('default-card', {

--- a/coral/media/js/views/components/cards/default.js
+++ b/coral/media/js/views/components/cards/default.js
@@ -45,16 +45,23 @@ define([
             return (parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + sizes[i]);
         };
 
-        this.getNodeOptions = (nodeId) => {
-            const options = params.nodeOptions?.[nodeId] || {};
-            if (options?.config) {
-                options?.config = {
-                    ...this.widget.configJSON,
-                    ...options?.config
-                }
+        this.getNodeOptions = (nodeId, widgetConfig = {}) => {
+          const options = params.nodeOptions?.[nodeId] || {};
+          if (options?.config) {
+            options.config = {
+              ...widgetConfig,
+              ...options.config
+            };
+          }
+          Object.keys(options).forEach((key) => {
+            // Should this be used a JS workflow maintain the users
+            // provided reactivity.
+            if (!ko.isObservable(options[key])) {
+              options[key] = ko.observable(options[key]);
             }
-            return options
-        }
+          });
+          return options;
+        };
     }
 
     return ko.components.register('default-card', {

--- a/coral/media/js/views/components/cards/default.js
+++ b/coral/media/js/views/components/cards/default.js
@@ -46,9 +46,15 @@ define([
         };
 
         this.getNodeOptions = (nodeId) => {
-            return params.nodeOptions?.[nodeId]
+            const options = params.nodeOptions?.[nodeId] || {};
+            if (options?.config) {
+                options?.config = {
+                    ...this.widget.configJSON,
+                    ...options?.config
+                }
+            }
+            return options
         }
-    
     }
 
     return ko.components.register('default-card', {

--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -105,7 +105,69 @@ define([
                   parameters: {
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '05f6b846-5d49-11ee-911e-0242ac130003',
-                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
+                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
+                    nodeOptions: {
+                    "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1add78d0-c450-11ee-8be7-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "239c373a-c451-11ee-8be7-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1add78d0-c450-11ee-8be7-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                   }
                 },
                 {
@@ -301,7 +363,69 @@ define([
                       '684121d8-48ce-11ee-8e4e-0242ac140007',
                       '68412778-48ce-11ee-8e4e-0242ac140007'
                     ],
-                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
+                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
+                    nodeOptions: {
+                      "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "239c373a-c451-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 }
               ]
@@ -324,7 +448,69 @@ define([
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '69f2eb3c-c430-11ee-94bf-0242ac180006',
                     resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
-                    parenttileid: "['init-step']['app-id'][0]['resourceid']['decisionTileId']"
+                    parenttileid: "['init-step']['app-id'][0]['resourceid']['decisionTileId']",
+                    nodeOptions: {
+                      "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "239c373a-c451-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 },
                 {
@@ -335,7 +521,69 @@ define([
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: 'c9f504b4-c42d-11ee-94bf-0242ac180006',
                     resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
-                    parenttileid: "['init-step']['app-id'][0]['resourceid']['decisionTileId']"
+                    parenttileid: "['init-step']['app-id'][0]['resourceid']['decisionTileId']",
+                    nodeOptions: {
+                      "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "239c373a-c451-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 },
                 {
@@ -346,7 +594,69 @@ define([
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '1887f678-c42d-11ee-bc4b-0242ac180006',
                     resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
-                    parenttileid: "['init-step']['app-id'][0]['resourceid']['decisionTileId']"
+                    parenttileid: "['init-step']['app-id'][0]['resourceid']['decisionTileId']",
+                    nodeOptions: {
+                      "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "239c373a-c451-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 },
                 {
@@ -444,7 +754,69 @@ define([
                     title: 'Transfer of Licence',
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '6397b05c-c443-11ee-94bf-0242ac180006',
-                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
+                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
+                    nodeOptions: {
+                      "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "239c373a-c451-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 },
                 {
@@ -455,7 +827,69 @@ define([
                     title: 'Extension of Licence',
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '69b2738e-c4d2-11ee-b171-0242ac180006',
-                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
+                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
+                    nodeOptions: {
+                      "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "239c373a-c451-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 }
               ]
@@ -484,7 +918,69 @@ define([
                   parameters: {
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: 'f060583a-6120-11ee-9fd1-0242ac120003',
-                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
+                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
+                    nodeOptions: {
+                      "ed16bb80-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1887faf6-c42d-11ee-bc4b-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "239c373a-c451-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "97f6c776-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "684110e4-48ce-11ee-8e4e-0242ac140007": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "1add78d0-c450-11ee-8be7-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "58880bd6-5d4a-11ee-9b75-0242ac130003": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "59b77af6-dc6f-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "0a089af2-dc7a-11ee-8def-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 },
                 {

--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -815,6 +815,11 @@ define([
                         "config":{
                           "maxDate":"today"
                         }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
                       }
                     }
                   }
@@ -888,7 +893,13 @@ define([
                         "config":{
                           "maxDate":"today"
                         }
+                      },
+                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
                       }
+
                     }
                   }
                 }

--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -815,11 +815,6 @@ define([
                         "config":{
                           "maxDate":"today"
                         }
-                      },
-                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
-                        "config":{
-                          "maxDate":"today"
-                        }
                       }
                     }
                   }
@@ -893,13 +888,7 @@ define([
                         "config":{
                           "maxDate":"today"
                         }
-                      },
-                      "c6f09242-c4d2-11ee-b171-0242ac180006": {
-                        "config":{
-                          "maxDate":"today"
-                        }
                       }
-
                     }
                   }
                 }

--- a/coral/media/js/views/components/plugins/merge-workflow.js
+++ b/coral/media/js/views/components/plugins/merge-workflow.js
@@ -198,8 +198,14 @@ define([
                   parameters: {
                     graphid: 'd9318eb6-f28d-427c-b061-6fe3021ce8aa',
                     nodegroupid: '726951a8-cce0-11ee-af2a-0242ac180006',
-                    resourceid:
-                      "['information-step']['notes'][0]['resourceid']['resourceInstanceId']"
+                    resourceid: "['information-step']['notes'][0]['resourceid']['resourceInstanceId']",
+                    nodeOptions: {
+                      "726956bc-cce0-11ee-af2a-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                   }
                 }
               ]

--- a/coral/media/js/views/components/plugins/relate-two-monuments-workflow.js
+++ b/coral/media/js/views/components/plugins/relate-two-monuments-workflow.js
@@ -75,7 +75,134 @@ define([
                     graphid: '076f9381-7b00-11e9-8d6b-80000b44d1d9',
                     nodegroupid: '35d8256a-d7d6-11ee-9916-0242ac120006',
                     resourceid: "['target-step']['target-record'][0]['selectedResourceId']",
-                    parenttileid: "['relating-step']['relating-record'][0]['tileId']"
+                    parenttileid: "['relating-step']['relating-record'][0]['tileId']",
+                    nodeOptions: {
+                    "6694d802-37c0-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "126c0042-dbc3-11ee-8835-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98c42ca8-37be-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9368892-1902-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96656e9c-d646-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "82731030-37bf-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "85396d94-37bc-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                   }
                 },
                 {
@@ -86,7 +213,134 @@ define([
                     graphid: '076f9381-7b00-11e9-8d6b-80000b44d1d9',
                     nodegroupid: '76fc577c-d7d7-11ee-ade0-0242ac120006',
                     resourceid: "['target-step']['target-record'][0]['selectedResourceId']",
-                    parenttileid: "['relating-step']['relating-record'][0]['tileId']"
+                    parenttileid: "['relating-step']['relating-record'][0]['tileId']",
+                    nodeOptions: {
+                      "6694d802-37c0-11ef-a167-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "126c0042-dbc3-11ee-8835-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "98c42ca8-37be-11ef-a167-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "d9368892-1902-11ef-aa9c-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "96656e9c-d646-11ee-8b04-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "82731030-37bf-11ef-a167-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      },
+                      "85396d94-37bc-11ef-9263-0242ac150006": {
+                        "config":{
+                          "maxDate":"today"
+                        }
+                      }
+                    }
                   }
                 }
               ]

--- a/coral/media/js/views/components/workflows/default-card-util.js
+++ b/coral/media/js/views/components/workflows/default-card-util.js
@@ -25,7 +25,6 @@ define([
         });
       });
     }
-    console.log("util", this.graphid, this.title)
 
     this.form
       .card()

--- a/coral/media/js/views/components/workflows/default-card-util.js
+++ b/coral/media/js/views/components/workflows/default-card-util.js
@@ -25,6 +25,7 @@ define([
         });
       });
     }
+    console.log("util", this.graphid, this.title)
 
     this.form
       .card()

--- a/coral/media/js/views/components/workflows/default-card-util.js
+++ b/coral/media/js/views/components/workflows/default-card-util.js
@@ -25,6 +25,7 @@ define([
         });
       });
     }
+    console.log("util", this.graphid, this.title)
 
     this.form
       .card()
@@ -132,6 +133,24 @@ define([
           saveSubscription.dispose(); /* this-disposing subscription only runs once */
         }
       });
+    };
+
+    this.getNodeOptions = (nodeId, widgetConfig = {}) => {
+      const options = params.nodeOptions?.[nodeId] || {};
+      if (options?.config) {
+          options.config = {
+          ...widgetConfig,
+          ...options.config
+          };
+      }
+      Object.keys(options).forEach((key) => {
+          // Should this be used a JS workflow maintain the users
+          // provided reactivity.
+          if (!ko.isObservable(options[key])) {
+          options[key] = ko.observable(options[key]);
+          }
+      });
+      return options;
     };
   }
 

--- a/coral/media/js/views/components/workflows/default-card-util.js
+++ b/coral/media/js/views/components/workflows/default-card-util.js
@@ -25,7 +25,6 @@ define([
         });
       });
     }
-    console.log("util", this.graphid, this.title)
 
     this.form
       .card()
@@ -133,24 +132,6 @@ define([
           saveSubscription.dispose(); /* this-disposing subscription only runs once */
         }
       });
-    };
-
-    this.getNodeOptions = (nodeId, widgetConfig = {}) => {
-      const options = params.nodeOptions?.[nodeId] || {};
-      if (options?.config) {
-          options.config = {
-          ...widgetConfig,
-          ...options.config
-          };
-      }
-      Object.keys(options).forEach((key) => {
-          // Should this be used a JS workflow maintain the users
-          // provided reactivity.
-          if (!ko.isObservable(options[key])) {
-          options[key] = ko.observable(options[key]);
-          }
-      });
-      return options;
     };
   }
 

--- a/coral/plugins/add-building-workflow.json
+++ b/coral/plugins/add-building-workflow.json
@@ -335,7 +335,134 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['51d184d9-269c-4562-a29b-3ef9a7aa3d3a'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "3897b87a-1902-11ef-aa9f-0242ac150006"
+                  "nodegroupid": "3897b87a-1902-11ef-aa9f-0242ac150006",
+                  "nodeOptions": {
+                    "6694d802-37c0-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "126c0042-dbc3-11ee-8835-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98c42ca8-37be-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9368892-1902-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96656e9c-d646-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "82731030-37bf-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "85396d94-37bc-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -325,7 +325,134 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['12645f4a-6638-4f80-b020-c7dd7f886163'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "3897b87a-1902-11ef-aa9f-0242ac150006",
-                  "semanticName": "Garden Sign Off"
+                  "semanticName": "Garden Sign Off",
+                  "nodeOptions": {
+                    "6694d802-37c0-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "126c0042-dbc3-11ee-8835-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98c42ca8-37be-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9368892-1902-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96656e9c-d646-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "82731030-37bf-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "85396d94-37bc-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/add-ihr-workflow.json
+++ b/coral/plugins/add-ihr-workflow.json
@@ -328,7 +328,134 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['f100407e-3c79-459d-bf91-21b4358c17f6'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "3897b87a-1902-11ef-aa9f-0242ac150006",
-                  "semanticName": "Garden Sign Off"
+                  "semanticName": "Garden Sign Off",
+                  "nodeOptions": {
+                    "6694d802-37c0-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "126c0042-dbc3-11ee-8835-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98c42ca8-37be-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9368892-1902-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96656e9c-d646-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "82731030-37bf-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "85396d94-37bc-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -376,7 +376,134 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['768652bb-5228-438f-8b98-31ed24f0315c'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "3897b87a-1902-11ef-aa9f-0242ac150006"
+                  "nodegroupid": "3897b87a-1902-11ef-aa9f-0242ac150006",
+                  "nodeOptions": {
+                    "6694d802-37c0-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "126c0042-dbc3-11ee-8835-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98c42ca8-37be-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9368892-1902-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96656e9c-d646-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "82731030-37bf-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "85396d94-37bc-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/archive-catalogue-workflow.json
+++ b/coral/plugins/archive-catalogue-workflow.json
@@ -146,7 +146,29 @@
                   ],
                   "nodegroupid": "3001afdf-b46a-11ea-a528-f875a44e0e11",
                   "parenttileid": "['archive-reference-step']['d7782f56-fe24-458e-9452-a734fc73d17c'][0]['resourceid']['archiveHolding']",
-                  "semanticName": "Archive Source Creation"
+                  "semanticName": "Archive Source Creation",
+                  "nodeOptions": {
+                    "602c8b40-1aba-11ec-9afc-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98ac7e00-ba0a-11ee-987d-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a919d111-ee15-11eb-9308-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a919d102-ee15-11eb-941c-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",
@@ -194,7 +216,29 @@
                   "graphid": "b07cfa6f-894d-11ea-82aa-f875a44e0e11",
                   "resourceid": "['archive-reference-step']['d7782f56-fe24-458e-9452-a734fc73d17c'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "98ac662c-ba0a-11ee-987d-0242ac180006",
-                  "semanticName": "Archive Loaning"
+                  "semanticName": "Archive Loaning",
+                  "nodeOptions": {
+                    "602c8b40-1aba-11ec-9afc-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98ac7e00-ba0a-11ee-987d-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a919d111-ee15-11eb-9308-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a919d102-ee15-11eb-941c-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "many",
                 "componentName": "default-card",

--- a/coral/plugins/assign-consultation-workflow.json
+++ b/coral/plugins/assign-consultation-workflow.json
@@ -409,52 +409,12 @@
                   "nodegroupid": "a5e15f5c-51a3-11eb-b240-f875a44e0e11",
                   "semanticName": "Action",
                   "nodeOptions": {
-                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
                     "config":{
                       "maxDate":"today"
                     }
                     },
-                    "083e9df0-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083eed32-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083ef872-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
                     "c4413ac8-69b6-11ee-908a-0242ac120002": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
                       "config":{
                         "maxDate":"today"
                       }
@@ -462,7 +422,7 @@
                   }
                 },
                 "tilesManaged": "one",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "action"
               }
             ]

--- a/coral/plugins/assign-consultation-workflow.json
+++ b/coral/plugins/assign-consultation-workflow.json
@@ -81,56 +81,11 @@
                     "config":{
                       "maxDate":"today"
                     }
-                    },
-                    "083e9df0-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083eed32-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083ef872-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
-                      "config":{
-                        "maxDate":"today"
-                      }
                     }
                   }
                 },
                 "tilesManaged": "one",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "dif-received-date"
               },
               {
@@ -188,7 +143,7 @@
                   "semanticName": "Contacts"
                 },
                 "tilesManaged": "one",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "contacts"
               },
               {
@@ -202,52 +157,7 @@
                   "nodegroupid": "40eff4c9-893a-11ea-ac3a-f875a44e0e11",
                   "semanticName": "Consultation Dates",
                   "nodeOptions": {
-                    "04494bbe-c769-11ee-82c4-0242ac180006": {
-                    "config":{
-                      "maxDate":"today"
-                    }
-                    },
-                    "083e9df0-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083eed32-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083ef872-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                    "40eff4cd-893a-11ea-b0cc-f875a44e0e11": {
                       "config":{
                         "maxDate":"today"
                       }
@@ -255,7 +165,7 @@
                   }
                 },
                 "tilesManaged": "one",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "consultation-dates"
               },
               {

--- a/coral/plugins/assign-consultation-workflow.json
+++ b/coral/plugins/assign-consultation-workflow.json
@@ -75,7 +75,59 @@
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "04492152-c769-11ee-82c4-0242ac180006",
-                  "semanticName": "DIF Received Date"
+                  "semanticName": "DIF Received Date",
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",
@@ -148,7 +200,59 @@
                     "40eff4ce-893a-11ea-ae2e-f875a44e0e11"
                   ],
                   "nodegroupid": "40eff4c9-893a-11ea-ac3a-f875a44e0e11",
-                  "semanticName": "Consultation Dates"
+                  "semanticName": "Consultation Dates",
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",
@@ -303,7 +407,59 @@
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "a5e15f5c-51a3-11eb-b240-f875a44e0e11",
-                  "semanticName": "Action"
+                  "semanticName": "Action",
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",

--- a/coral/plugins/curatorial-workflow.json
+++ b/coral/plugins/curatorial-workflow.json
@@ -213,7 +213,59 @@
                   "hiddenNodes": [
                     "998d6728-fb26-11ee-838d-0242ac190006",
                     "ff42f8f2-3e93-11ef-9023-0242ac140007"
-                  ]
+                  ],
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/evaluation-meeting-workflow.json
+++ b/coral/plugins/evaluation-meeting-workflow.json
@@ -250,54 +250,10 @@
                   "nodegroupid": "34959a52-03aa-11ef-948f-0242ac150003",
                   "semanticName": "Evaluation",
                   "nodeOptions": {
-                    "04494bbe-c769-11ee-82c4-0242ac180006": {
-                    "config":{
-                      "maxDate":"today"
-                    }
-                    },
-                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                    "5ffdc00e-03ad-11ef-948f-0242ac150003": {
                       "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083eed32-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "083ef872-ca61-11ee-afca-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
-                      "config":{
-                        "maxDate":"today"
+                        "maxDate":"today",
+                        "label": "Sign Off Date"
                       }
                     }
                   }

--- a/coral/plugins/evaluation-meeting-workflow.json
+++ b/coral/plugins/evaluation-meeting-workflow.json
@@ -248,7 +248,59 @@
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['start-meeting-step']['5869a138-b293-49bb-9e96-fa2e309ce891'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "34959a52-03aa-11ef-948f-0242ac150003",
-                  "semanticName": "Evaluation"
+                  "semanticName": "Evaluation",
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/excavation-site-visit-workflow.json
+++ b/coral/plugins/excavation-site-visit-workflow.json
@@ -66,7 +66,49 @@
                     "4f5eeb28-993e-11ea-b5c1-f875a44e0e11",
                     "4f5eeb29-993e-11ea-8078-f875a44e0e11"
                   ],
-                  "nodegroupid": "4f5ec415-993e-11ea-bab0-f875a44e0e11"
+                  "nodegroupid": "4f5ec415-993e-11ea-bab0-f875a44e0e11",
+                  "nodeOptions": {
+                    "a64c82ae-3de4-11ef-8288-0242ac140007": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "2a5bc0a5-fe48-11ea-8aeb-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6c218875-ee13-11eb-a51c-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6c218866-ee13-11eb-9911-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a5416b51-f121-11eb-bdde-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a541921e-f121-11eb-b00f-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a5419225-f121-11eb-8224-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a541921f-f121-11eb-be85-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",
@@ -127,7 +169,49 @@
                 "parameters": {
                   "graphid": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "1d4ef3f4-02f4-11ef-927a-0242ac150006"
+                  "nodegroupid": "1d4ef3f4-02f4-11ef-927a-0242ac150006",
+                  "nodeOptions": {
+                    "a64c82ae-3de4-11ef-8288-0242ac140007": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "2a5bc0a5-fe48-11ea-8aeb-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6c218875-ee13-11eb-a51c-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6c218866-ee13-11eb-9911-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a5416b51-f121-11eb-bdde-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a541921e-f121-11eb-b00f-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a5419225-f121-11eb-8224-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a541921f-f121-11eb-be85-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/flag-for-enforcement-workflow.json
+++ b/coral/plugins/flag-for-enforcement-workflow.json
@@ -76,7 +76,14 @@
                   "graphid": "8c3a4ae7-2704-4f47-aa68-4da7f9fc6d84",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "229501c2-b552-11ee-805b-0242ac120006",
-                  "semanticName": "Flagged Date"
+                  "semanticName": "Flagged Date",
+                  "nodeOptions": {
+                    "2295085c-b552-11ee-805b-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",

--- a/coral/plugins/fmw-inspection-workflow.json
+++ b/coral/plugins/fmw-inspection-workflow.json
@@ -75,7 +75,59 @@
                     "083e9df0-ca61-11ee-afca-0242ac180006"
                   ],
                   "nodegroupid": "083df90e-ca61-11ee-afca-0242ac180006",
-                  "parenttileid": "['start-step']['system-reference'][0]['resourceid']['locationData']"
+                  "parenttileid": "['start-step']['system-reference'][0]['resourceid']['locationData']",
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",
@@ -90,7 +142,59 @@
                     "40eff4ce-893a-11ea-ae2e-f875a44e0e11",
                     "7224417b-893a-11ea-b383-f875a44e0e11"
                   ],
-                  "nodegroupid": "40eff4c9-893a-11ea-ac3a-f875a44e0e11"
+                  "nodegroupid": "40eff4c9-893a-11ea-ac3a-f875a44e0e11",
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",
@@ -255,7 +359,59 @@
                 "parameters": {
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['start-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "93199292-fb24-11ee-838d-0242ac190006"
+                  "nodegroupid": "93199292-fb24-11ee-838d-0242ac190006",
+                  "nodeOptions": {
+                    "04494bbe-c769-11ee-82c4-0242ac180006": {
+                    "config":{
+                      "maxDate":"today"
+                    }
+                    },
+                    "083e9df0-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083eed32-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "083ef872-ca61-11ee-afca-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1cf746f6-1853-11eb-a9df-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463959-3ee4-11eb-9488-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "62463948-3ee4-11eb-9c38-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c4413ac8-69b6-11ee-908a-0242ac120002": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac905d54-ca65-11ee-b83c-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "caf5bff5-a3d7-11e9-8c7e-00224800b26d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -207,7 +207,129 @@
                     "b850af26-7f33-4b26-a7e2-daa15308c56c",
                     "482d0935-2330-491a-aa41-d0cc3293b568",
                     "15b164d5-9509-4d4c-a0b7-e4b430ba5d31"
-                  ]
+                  ],
+                  "nodeOptions": {
+                    "2cbc7bf7-ccbb-4ac2-bb29-bc3bc597c753": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "0ccb08ee-dbc4-11ee-b0db-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "8623e2d5-5407-4b57-b769-89c934941ac5": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e1d85f71-85d2-4357-951f-9318f1df36b5": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1f1d69ee-99c8-4808-b2b2-2b33b1364dda": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a54ab030-d2c9-4e1f-bde9-7e234f3f3e58": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "0cd0998c-dbd6-11ee-b0db-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "229d12d0-1908-11ef-aa9f-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "257efb18-2d61-11ef-8722-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "7f932826-1908-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a20d4124-3795-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "cffa2fc8-3797-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "603015fe-3afe-4475-87e7-771a9d625503": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1752059c-1e67-4876-94a1-605dbbb4a03d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "379e65bc-555b-4dd9-bd6d-cf7b6de20527": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "7e1a19c8-676d-4382-a039-0cd28a9a1c28": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "f98b388c-db09-4519-bbd2-0d7bc339c805": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6b901bcd-724a-48b8-9ff7-8ec917dbfec7": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "577bd652-c9dc-4954-9765-7546ba0cabac": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c2736493-9ba2-4d59-a358-45eef0086a16": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "af5fd406-dbd1-11ee-b0db-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "59935456-379a-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "17d822a9-4ef7-4ecd-8100-05c6ea9b41b2": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d70da550-3798-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -207,132 +207,10 @@
                     "b850af26-7f33-4b26-a7e2-daa15308c56c",
                     "482d0935-2330-491a-aa41-d0cc3293b568",
                     "15b164d5-9509-4d4c-a0b7-e4b430ba5d31"
-                  ],
-                  "nodeOptions": {
-                    "2cbc7bf7-ccbb-4ac2-bb29-bc3bc597c753": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "0ccb08ee-dbc4-11ee-b0db-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "8623e2d5-5407-4b57-b769-89c934941ac5": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "e1d85f71-85d2-4357-951f-9318f1df36b5": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1f1d69ee-99c8-4808-b2b2-2b33b1364dda": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "a54ab030-d2c9-4e1f-bde9-7e234f3f3e58": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "0cd0998c-dbd6-11ee-b0db-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "229d12d0-1908-11ef-aa9f-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "257efb18-2d61-11ef-8722-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "7f932826-1908-11ef-aa9c-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "a20d4124-3795-11ef-9263-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "cffa2fc8-3797-11ef-a167-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "603015fe-3afe-4475-87e7-771a9d625503": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1752059c-1e67-4876-94a1-605dbbb4a03d": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "379e65bc-555b-4dd9-bd6d-cf7b6de20527": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "7e1a19c8-676d-4382-a039-0cd28a9a1c28": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "f98b388c-db09-4519-bbd2-0d7bc339c805": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "6b901bcd-724a-48b8-9ff7-8ec917dbfec7": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "577bd652-c9dc-4954-9765-7546ba0cabac": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "c2736493-9ba2-4d59-a358-45eef0086a16": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "af5fd406-dbd1-11ee-b0db-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "59935456-379a-11ef-9263-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "17d822a9-4ef7-4ecd-8100-05c6ea9b41b2": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "d70da550-3798-11ef-a167-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    }
-                  }
+                  ]
                 },
                 "tilesManaged": "one",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "designation-protection-type"
               },
               {
@@ -417,7 +295,131 @@
                   "nodegroupid": "3c51740c-dbd0-11ee-8835-0242ac120006",
                   "resourceid": "['start-step']['d4cffd08-58c6-46f2-8ef7-08a7af8ae7f5'][0]['resourceid']['resourceInstanceId']",
                   "hiddenNodes": ["99605e36-3924-11ef-82af-0242ac150006"],
-                  "semanticName": "Approvals"
+                  "semanticName": "Approvals",
+                  "nodeOptions": {
+                    "2cbc7bf7-ccbb-4ac2-bb29-bc3bc597c753": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "0ccb08ee-dbc4-11ee-b0db-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "8623e2d5-5407-4b57-b769-89c934941ac5": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e1d85f71-85d2-4357-951f-9318f1df36b5": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1f1d69ee-99c8-4808-b2b2-2b33b1364dda": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a54ab030-d2c9-4e1f-bde9-7e234f3f3e58": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "0cd0998c-dbd6-11ee-b0db-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "229d12d0-1908-11ef-aa9f-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "257efb18-2d61-11ef-8722-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "7f932826-1908-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "a20d4124-3795-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today",
+                        "label": "Owner Notified Date"
+                      }
+                    },
+                    "cffa2fc8-3797-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "603015fe-3afe-4475-87e7-771a9d625503": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "1752059c-1e67-4876-94a1-605dbbb4a03d": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "379e65bc-555b-4dd9-bd6d-cf7b6de20527": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "7e1a19c8-676d-4382-a039-0cd28a9a1c28": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "f98b388c-db09-4519-bbd2-0d7bc339c805": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6b901bcd-724a-48b8-9ff7-8ec917dbfec7": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "577bd652-c9dc-4954-9765-7546ba0cabac": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "c2736493-9ba2-4d59-a358-45eef0086a16": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "af5fd406-dbd1-11ee-b0db-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "59935456-379a-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today",
+                        "label": "Director Sign Off Date"
+                      }
+                    },
+                    "17d822a9-4ef7-4ecd-8100-05c6ea9b41b2": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d70da550-3798-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/scheduled-monument-consent-workflow.json
+++ b/coral/plugins/scheduled-monument-consent-workflow.json
@@ -124,7 +124,134 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['heritage-asset-step']['438ed643-4d7d-446b-91a8-e1d966d2504d'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "eeec9986-d23c-11ee-9373-0242ac180006",
-                  "semanticName": "Received Date"
+                  "semanticName": "Received Date",
+                  "nodeOptions": {
+                    "6694d802-37c0-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "126c0042-dbc3-11ee-8835-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98c42ca8-37be-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9368892-1902-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96656e9c-d646-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "82731030-37bf-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "85396d94-37bc-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card-util",
@@ -207,7 +334,134 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['heritage-asset-step']['438ed643-4d7d-446b-91a8-e1d966d2504d'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "82c9eef6-2d5a-11ef-8722-0242ac120006"
+                  "nodegroupid": "82c9eef6-2d5a-11ef-8722-0242ac120006",
+                  "nodeOptions": {
+                    "6694d802-37c0-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "126c0042-dbc3-11ee-8835-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "35d84fea-d7d6-11ee-9916-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ca07b860-2d5b-11ef-bbfd-0242ac120006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "ac25af94-1903-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "98c42ca8-37be-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6522916e-efc8-11eb-8a9b-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "65227d22-efc8-11eb-b78e-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2a0cf-efc5-11eb-806d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b69b-efc5-11eb-8d5a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "6af2b6a0-efc5-11eb-985a-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9368892-1902-11ef-aa9c-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3c2a4-f44f-11eb-a170-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b6-f44f-11eb-a60d-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7bc-f44f-11eb-b884-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "87d3d7b7-f44f-11eb-acd2-a87eeabdefba": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96656e9c-d646-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "96826227-0262-11eb-a1c0-f875a44e0e11": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e2815e0c-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "d9bd0b80-d643-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "e8d511cc-d64c-11ee-8b04-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "eeec9e68-d23c-11ee-9373-0242ac180006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "82731030-37bf-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "5253a3a8-37bd-11ef-a167-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
+                    "85396d94-37bc-11ef-9263-0242ac150006": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/plugins/scheduled-monument-consent-workflow.json
+++ b/coral/plugins/scheduled-monument-consent-workflow.json
@@ -254,7 +254,7 @@
                   }
                 },
                 "tilesManaged": "one",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "9a98ac24-a286-463f-a0b1-113fc4b756f9"
               },
               {

--- a/coral/templates/views/components/cards/default.htm
+++ b/coral/templates/views/components/cards/default.htm
@@ -330,7 +330,7 @@
                             graph: self.form.graph,
                             type: "resource-editor",
                             disabled: !self.card.isWritable && !self.preview,
-                            ...self.getNodeOptions?.(widget.node_id())
+                            ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
                 }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}

--- a/coral/templates/views/components/workflows/default-card-util.htm
+++ b/coral/templates/views/components/workflows/default-card-util.htm
@@ -50,7 +50,7 @@
                                 value: $data.data[card.widgets()[0].node_id()],
                                 type: 'resource-editor',
                                 state: 'display_value',
-                                disabled: !self.card.isWritable && !self.preview
+                                disabled: !self.card.isWritable && !self.preview,
                                 ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
                             }
                         }"></div>
@@ -337,7 +337,7 @@
                             expanded: self.expanded,
                             graph: self.form.graph,
                             type: "resource-editor",
-                            disabled: !self.card.isWritable && !self.preview
+                            disabled: !self.card.isWritable && !self.preview,
                             ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview

--- a/coral/templates/views/components/workflows/default-card-util.htm
+++ b/coral/templates/views/components/workflows/default-card-util.htm
@@ -50,7 +50,8 @@
                                 value: $data.data[card.widgets()[0].node_id()],
                                 type: 'resource-editor',
                                 state: 'display_value',
-                                disabled: !self.card.isWritable && !self.preview
+                                disabled: !self.card.isWritable && !self.preview,
+                                ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
                             }
                         }"></div>
                         <!-- /ko -->
@@ -336,7 +337,8 @@
                             expanded: self.expanded,
                             graph: self.form.graph,
                             type: "resource-editor",
-                            disabled: !self.card.isWritable && !self.preview
+                            disabled: !self.card.isWritable && !self.preview,
+                            ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
                 }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}

--- a/coral/templates/views/components/workflows/default-card-util.htm
+++ b/coral/templates/views/components/workflows/default-card-util.htm
@@ -51,6 +51,7 @@
                                 type: 'resource-editor',
                                 state: 'display_value',
                                 disabled: !self.card.isWritable && !self.preview
+                                ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
                             }
                         }"></div>
                         <!-- /ko -->
@@ -337,6 +338,7 @@
                             graph: self.form.graph,
                             type: "resource-editor",
                             disabled: !self.card.isWritable && !self.preview
+                            ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
                 }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}

--- a/coral/templates/views/components/workflows/default-card-util.htm
+++ b/coral/templates/views/components/workflows/default-card-util.htm
@@ -50,8 +50,7 @@
                                 value: $data.data[card.widgets()[0].node_id()],
                                 type: 'resource-editor',
                                 state: 'display_value',
-                                disabled: !self.card.isWritable && !self.preview,
-                                ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
+                                disabled: !self.card.isWritable && !self.preview
                             }
                         }"></div>
                         <!-- /ko -->
@@ -337,8 +336,7 @@
                             expanded: self.expanded,
                             graph: self.form.graph,
                             type: "resource-editor",
-                            disabled: !self.card.isWritable && !self.preview,
-                            ...self.getNodeOptions?.(widget.node_id(), widget.configJSON())
+                            disabled: !self.card.isWritable && !self.preview
                         }
                     }, css:{ "active": widget.selected, "hover": widget.hovered, "widget-preview": self.preview
                 }, click: function(data, e) { if (!widget.selected() && self.preview) {widget.selected(true);}


### PR DESCRIPTION
Requires parts of [PR 489](https://github.com/flaxandteal/coral-arches/pull/489)

If you're testing before that is merged you can 
`git checkout fix/#2564-incident-report-future-dates coral/templates/views/components/cards/default.htm coral/media/js/viewmodels/card-component.js`

This PR adds nodeOptions to the default-card-util since it is needed for several custom components (in this pr excavation-report-step)

The uses nodeOptions to set the max date for every date widget where this should be applied.
The tests I followed and passed can be found on [taiga](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2214)

requires containers to be killed and rebuild
`make webpack`
`make manage CMD="coral reload"`

At the time of writing there are unnecessary nodes in the nodeOptions in many places, this is because I grepped the models for nodeid's where I'd changed the maxDate while completing [pr 480](https://github.com/flaxandteal/coral-arches/pull/480) and just pasted them in.

I'll trim this as I get time but since it's passing the tests I'll open the pr