### PR TITLE
Feat #2563 Organisation Contact Info Report

### DIFF
--- a/coral/media/js/views/components/reports/organization.js
+++ b/coral/media/js/views/components/reports/organization.js
@@ -17,6 +17,7 @@ define([
             this.configForm = params.configForm || false;
             this.configType = params.configType || 'header';
             this.report = params.report;
+            this.summary = params.summary
 
             Object.assign(self, reportUtils);
             self.sections = [
@@ -39,9 +40,13 @@ define([
             self.fullReportConfig = {
                 id: 'organization',
                 label: 'Organization',
+                summaryNodeGroups: [
+                    "e8431c5d-8098-11ea-8348-f875a44e0e11",
+                    "af3b0116-29a9-11eb-8333-f875a44e0e11",
+                    "1b6f9cb4-51ae-11eb-a1fe-f875a44e0e11"
+                ],
                 ignoreNodes: []
             }
-
 
             self.nameDataConfig = {
                 name: 'names',

--- a/coral/media/js/views/components/reports/scenes/all.js
+++ b/coral/media/js/views/components/reports/scenes/all.js
@@ -22,10 +22,19 @@ define([
         "preload_resource_data": true,
         "templateid": "50000000-0000-0000-0000-000000000001"
       }
+      this.nodeGroups = params.nodeGroups ?? null
+      this.showRelated = params.showRelated ?? true
 
       params.report.hideEmptyNodes = true;
 
-      ReportViewModel.apply(this, [params])
+      // nodeGroups controls what groups to show. If it is null it will render everything
+      if (this.nodeGroups?.length > 0) {
+        params.report.cards = params.report.cards.filter(card => {
+            return this.nodeGroups.includes(card.nodegroupid);
+        });
+    }
+
+      ReportViewModel.apply(this, [params])      
 
       // this.report = ko.observable(params.report);
       // this.configForm = params.configForm;

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=5, minor=19, patch=57)
+APP_VERSION = semantic_version.Version(major=5, minor=20, patch=57)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/reports/organization.htm
+++ b/coral/templates/views/components/reports/organization.htm
@@ -137,12 +137,13 @@
 {% endblock report %}
 
 {% block summary %}
-<div class="aher-summary-report-header">
+<div class="aher-summary-report-header" style="top:80px">
     <h1 class="aher-summary-report-title"><span data-bind="text: displayname" class="aher-report-instance-name"></span><span class="aher-report-name pad-lft-sm">{% trans "(Place)" %}</span></h1>
 </div>
 <div class="model-summary-report">
     <div class="aher-report-page">
-        <!-- Names -->
+        <!--
+        <!- - Names - ->
         <div data-bind="component: {
             name: 'views/components/reports/scenes/name',
             params: {
@@ -151,13 +152,24 @@
                 dataConfig: nameDataConfig
             }
         }"></div>
-        <!-- Description -->
+        <!- - Description - ->
         <div data-bind="component: {
             name: 'views/components/reports/scenes/description',
             params: {
                 data: resource,
                 cards: descriptionCards,
                 dataConfig: descriptionDataConfig
+            }
+        }"></div>
+        -->
+        <!-- All -->
+        <div data-bind="component: {
+            name: 'views/components/reports/scenes/all',
+            params: {
+                 report: $data.report,
+                 nodeGroups: $data.fullReportConfig.summaryNodeGroups,
+                 summary: $data.summary,
+                 showRelated: false
             }
         }"></div>
     </div>

--- a/coral/templates/views/components/reports/scenes/all.htm
+++ b/coral/templates/views/components/reports/scenes/all.htm
@@ -30,6 +30,7 @@
     </div>
 </div>
 
+<!-- ko if: showRelated -->
 <div class="rp-report-section relative report-related-resources">
   <div class="rp-report-section-title">
       <div class="h4 rp-section-title"><span data-bind="text: $root.translations.relatedResources"></span></div>
@@ -76,6 +77,7 @@
   <!-- /ko -->
   <!-- /ko -->    
 </div>  
+<!-- /ko -->
 
 
 


### PR DESCRIPTION
## Description
Updated the info button for an organisation when used in a resource instance list.
Used the all report template created for the full report and added in functionality to control the node groups that are listed as well as disabling the related resources.

## Test
- Restart containers
- Webpack rebuild
-  Run the update_reports.sh from the coral-arches folder(in the taiga link below)
- Follow tests here [#2563](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2563)