### PR TITLE
Fix/#2608 Excavation Report Status

### DIFF
--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -47,7 +47,7 @@ define([
                 widget?.widgetLookup[ko.unwrap(widget?.widget_id)].name].join(" ");
         };
 
-
+    
         this.initialize = function() {
             self.card.showForm(true);
 
@@ -292,6 +292,12 @@ define([
                 ...widgetConfig,
                 ...options.config
               });
+            }
+            if (options?.node) {
+                options.node = {
+                  ...params.form.nodeLookup[nodeId],
+                  ...options.node
+                };
             }
             const nodeOptions = {...options}
             if(options?.asObservable) {

--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -492,7 +492,14 @@ define([
                   parameters: {
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: 'f060583a-6120-11ee-9fd1-0242ac120003',
-                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']"
+                    resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
+                    nodeOptions: {
+                      "ea6ea7a8-dc70-11ee-b70c-0242ac120006": {
+                        node: { 
+                          isrequired: true
+                        }
+                      }
+                    }
                   }
                 },
                 {

--- a/coral/media/js/views/components/workflows/excavation-licence-workflow/excavation-report-step.js
+++ b/coral/media/js/views/components/workflows/excavation-licence-workflow/excavation-report-step.js
@@ -9,19 +9,30 @@ define([
 ], function (_, ko, koMapping, uuid, arches, DefaultCardUtilViewModel, componentTemplate) {
   function viewModel(params) {
 
-  DefaultCardUtilViewModel.apply(this, [params]);
+    DefaultCardUtilViewModel.apply(this, [params]);
 
-  this.DOCUMENT_REFERENCE_NODE = "d8f74d42-dc6e-11ee-8def-0242ac120006"
+    this.DOCUMENT_REFERENCE_NODE = "d8f74d42-dc6e-11ee-8def-0242ac120006"
+    this.CLASSIFICATION_DATE_NODE = "ea6ea7a8-dc70-11ee-b70c-0242ac120006"
 
-      params.disableAdd(true)
+    params.disableAdd(true)
 
-      this.tile.data[this.DOCUMENT_REFERENCE_NODE].subscribe((newValue) => {
-          if (newValue.en.value != ""){
+    
 
-              params.disableAdd(false)
-          }
-      })
+    const checkBothNodes = (classificationDate, docReference) => {
+      if (classificationDate !== null && ko.unwrap(docReference) !== ''){
+        params.disableAdd(false)
+      }
+    }
 
+    this.tile.data[this.CLASSIFICATION_DATE_NODE].subscribe((newValue) => {
+      const documentReferenceValue = this.tile.data[this.DOCUMENT_REFERENCE_NODE]().en.value;
+      checkBothNodes(newValue, documentReferenceValue);
+    });
+
+    this.tile.data[this.DOCUMENT_REFERENCE_NODE].subscribe((newValue) => {
+      const classificationDateValue = this.tile.data[this.CLASSIFICATION_DATE_NODE]();
+      checkBothNodes(classificationDateValue, newValue.en.value);
+    });
 
   }
 

--- a/coral/media/js/views/components/workflows/excavation-licence-workflow/excavation-report-step.js
+++ b/coral/media/js/views/components/workflows/excavation-licence-workflow/excavation-report-step.js
@@ -19,6 +19,7 @@ define([
     
 
     const checkBothNodes = (classificationDate, docReference) => {
+      params.disableAdd(true)
       if (classificationDate !== null && ko.unwrap(docReference) !== ''){
         params.disableAdd(false)
       }

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -175,15 +175,22 @@ class PlanningTaskStrategy(TaskStrategy):
                 action_status = utilities.node_check(lambda: consultation.action[0].action_status )
                 action_type = utilities.node_check(lambda: consultation.action[0].action_type) 
                 assigned_to_list = utilities.node_check(lambda: consultation.action[0].assigned_to_n1, [])
-                reassigned_to_list = utilities.node_check(lambda: consultation.assignment[0].re_assignee.re_assigned_to, [])
+                reassigned_to_tiles = utilities.node_check(lambda: consultation.assignment, [])
 
-                user_assigned = any(assigned_to_list) or any(reassigned_to_list)
+                user_assigned = any(assigned_to_list)
+
+                if not user_assigned:
+                    for tile in reassigned_to_tiles:
+                        if any(tile.re_assignee.re_assigned_to):
+                            user_assigned = True
+                            break 
 
                 is_assigned_to_user = False
 
                 # first checks reassigned to as this overwrites the assigned to field if true
-                if reassigned_to_list:
-                    is_assigned_to_user = any(user.id == userResourceId for user in reassigned_to_list)
+                if reassigned_to_tiles:
+                    for tile in reassigned_to_tiles:
+                        is_assigned_to_user = any(user.id == userResourceId for user in tile.re_assignee.re_assigned_to)
                 elif assigned_to_list:
                     is_assigned_to_user = any(user.id == userResourceId for user in assigned_to_list)
                 

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -295,12 +295,22 @@ class ExcavationTaskStrategy(TaskStrategy):
         valid_until_date = utilities.node_check(lambda:licence.decision[0].licence_valid_timespan.valid_until_date)
         employing_body = utilities.node_check(lambda:licence.contacts.companies.employing_body)
         nominated_directors = utilities.node_check(lambda:licence.contacts.licensees.licensee)
-        report_status = utilities.node_check(lambda:licence.report[-1].classification_type) #takes the last report, assumes the newest
+        report_tiles = utilities.node_check(lambda:licence.report) #takes the last report, assumes the newest
         licence_number = utilities.node_check(lambda:licence.licence_number.licence_number_value)
 
         nominated_directors_name_list = [utilities.node_check(lambda:director.name[0].full_name) for director in nominated_directors]
         
         employing_body_name_list = [utilities.node_check(lambda:body.names[0].organization_name) for body in employing_body]
+
+        report_status = None
+        if report_tiles:
+            sorted_report_tiles = sorted(
+                report_tiles,
+                key=lambda x: datetime.strptime(x.classification_date.classification_date_value, "%Y-%m-%dT%H:%M:%S.%f%z") if x.classification_date.classification_date_value else datetime.min
+            )
+            latest_report_tile = sorted_report_tiles[-1]
+            report_status = latest_report_tile.classification_type
+
 
         name = display_name[0]
         if name.startswith("Excavation Licence"):


### PR DESCRIPTION
## Description
This changes how the report status data is pulled for the excavation dashboard. We now get the classification date, sort the tiles and get the most recent.
The classification date has then been made mandatory, this is done through the nodeOptions which have been updated to allow for configurations of the node.
The disable add has also been updated on the custom component to only show add once both classification date and document reference have been entered

## Tests
- Restart containers
- coral reload
- rebuild webpack
- follow tests - [#2608](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2608)