### PR TITLE
Fix/#2560 - Non Mandatory Contact Details, nodeOptions Fix

### DIFF
--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -301,10 +301,11 @@ define([
             }
             const nodeOptions = {...options}
             if(options?.asObservable) {
-              Object.entries(options.asObservable).forEach((key, value) => {
+              Object.entries(options.asObservable).forEach(([key, value]) => {
                   nodeOptions[key] = ko.observable(value);
                 });
             } 
+            delete nodeOptions.asObservable
             return nodeOptions;
         }
 

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -25749,7 +25749,7 @@
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "hascustomalias": false,
                     "is_collector": false,
-                    "isrequired": true,
+                    "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
                     "name": "Contact Details Value",

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -24010,7 +24010,7 @@
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "hascustomalias": false,
                     "is_collector": false,
-                    "isrequired": true,
+                    "isrequired": false,
                     "issearchable": true,
                     "istopnode": false,
                     "name": "Contact Details Value",


### PR DESCRIPTION
### Description
Contact Details on the Incident Report was still mandatory and causing a save error on the step as it is now hidden.
Updated the nodeOptions for the asObservable, the object was not de-structured correctly

### Tests
- Reload the monument model
- restart containers
- make webpack
- coral reload
- Navigate to the incident report
- Go to the location check
- The location description should be disabled
- Go to Work Proposed step
- Add a work carried out by resource
- Click save
- Should save and move to the next step