### PR TITLE
Fix #2623: Dashboard fix

### DIFF
--- a/coral/functions/notify_planning.py
+++ b/coral/functions/notify_planning.py
@@ -52,10 +52,9 @@ class NotifyPlanning(BaseFunction):
 
     def post_save(self, tile, request, context):
         from arches_orm.models import Person
-
+    
         resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
         nodegroup_id = str(tile.nodegroup_id)
-
         existing_notification = models.Notification.objects.filter(
             context__resource_instance_id=resource_instance_id
         ).first()
@@ -100,8 +99,8 @@ class NotifyPlanning(BaseFunction):
             elif response_group_uuid == RESPONSE_HB:
                 response_group = "HB"
             notification.message = f"{name} response has been completed by {response_group}"
-            notification.context['response_slug'] = 'assign-consultation-workflow'
-            self.notify_group(PLANNING_ADMIN, notification)
+            response_slug = 'assign-consultation-workflow'
+            self.notify_group(PLANNING_ADMIN, notification, response_slug)
             return
 
         # fetch re-assigned to data from a seperate nodegroup
@@ -179,7 +178,6 @@ class NotifyPlanning(BaseFunction):
         notified_users_list = notification.context.get("last_notified", []) if isinstance(notification.context.get("last_notified"), list) else []
 
         for user in assigned_users_list:
-            print(user)
             selected_user = Person.find(user['user']['resourceId'])
 
             if not selected_user.user_account:

--- a/coral/functions/notify_planning.py
+++ b/coral/functions/notify_planning.py
@@ -70,6 +70,7 @@ class NotifyPlanning(BaseFunction):
                     "resource_instance_id": resource_instance_id,
                     "consultation_id": name,
                     "last_notified": None,
+                    "response_slug": 'assign-consultation-workflow'
                 },
             )
         
@@ -99,6 +100,7 @@ class NotifyPlanning(BaseFunction):
             elif response_group_uuid == RESPONSE_HB:
                 response_group = "HB"
             notification.message = f"{name} response has been completed by {response_group}"
+            notification.context['response_slug'] = 'assign-consultation-workflow'
             self.notify_group(PLANNING_ADMIN, notification)
             return
 
@@ -124,31 +126,36 @@ class NotifyPlanning(BaseFunction):
             if data[ACTION_TYPE] is None and data[ACTION_STATUS] in action_type_conditions and not is_assigned_to_a_user:
                 if existing_notification and existing_notification.context["last_notified"] == PLANNING_ADMIN:
                     return
-                self.notify_group(PLANNING_ADMIN, notification)
+                self.notify_group(PLANNING_ADMIN, notification, 'assign-consultation-workflow')
 
             elif data[ACTION_TYPE] in [ASSIGN_HM, ASSIGN_BOTH] and data[ACTION_STATUS] in action_type_conditions and not is_assigned_to_a_user:
                 if existing_notification and existing_notification.context["last_notified"] == HM_MANAGERS:
                     return
-                self.notify_group(HM_MANAGERS, notification)
+                self.notify_group(HM_MANAGERS, notification, 'hm-planning-consultation-response-workflow')
 
             elif data[ACTION_TYPE] in [ASSIGN_HB, ASSIGN_BOTH] and data[ACTION_STATUS] in action_type_conditions and not is_assigned_to_a_user:
                 if existing_notification and existing_notification.context["last_notified"] == HB_MANAGERS:
                     return
                 
-                self.notify_group(HB_MANAGERS, notification)
+                self.notify_group(HB_MANAGERS, notification, 'hb-planning-consultation-response-workflow')
 
             elif data[ACTION_STATUS] in action_type_conditions and is_assigned_to_a_user:
                 with admin():
                     assigned_users_list = []
+                    
                     if re_assignment_node:
                         return
                     else:
                         for user in tile.data[ASSIGNED_TO]:
-                            assigned_users_list.append(user)
+                            team = self.find_user_team(user)
+                            assigned_users_list.append({
+                                'user': user,
+                                'team': team
+                            })
 
                     self.notify_users(assigned_users_list, notification)
 
-    def notify_group(self, group_id, notification):
+    def notify_group(self, group_id, notification, response_slug):
         from arches_orm.models import Group, Person
         
         with admin():
@@ -156,6 +163,7 @@ class NotifyPlanning(BaseFunction):
             persons = [Person.find(member.id) for member in group.members if isinstance(member, Person)]
 
             notification.context["last_notified"] = group_id
+            notification.context["response_slug"] = response_slug
             notification.save()
             for person in persons:
                 user = person.user_account
@@ -171,8 +179,8 @@ class NotifyPlanning(BaseFunction):
         notified_users_list = notification.context.get("last_notified", []) if isinstance(notification.context.get("last_notified"), list) else []
 
         for user in assigned_users_list:
-
-            selected_user = Person.find(user['resourceId'])
+            print(user)
+            selected_user = Person.find(user['user']['resourceId'])
 
             if not selected_user.user_account:
                 return
@@ -182,9 +190,34 @@ class NotifyPlanning(BaseFunction):
 
             notified_users_list.append(selected_user.id)
             notification.context["last_notified"] = notified_users_list
+            notification.context["response_slug"] = f"{user['team']}-planning-consultation-response-workflow"
             notification.save()
             
             user_x_notification = models.UserXNotification(
                 notif=notification, recipient=selected_user.user_account
             )
             user_x_notification.save()
+
+    def find_user_team(self, user):
+        from arches_orm.models import Group, Person
+        hm_teams = [HM_MANAGERS, HM_USER]
+        hb_teams = [HB_MANAGERS, HB_USER]
+
+        hb_groups = [Group.find(id) for id in hb_teams]
+        hm_groups = [Group.find(id) for id in hm_teams]
+
+        person = Person.find(user['resourceId'])
+
+        def find_users_in_teams(groups):
+            for group in groups:
+                for member in group.members:
+                    if member.id == person.id:
+                        return True
+            return False
+
+        if find_users_in_teams(hm_groups):
+            user_team = 'hm'
+        elif find_users_in_teams(hb_groups):
+            user_team = 'hb'
+
+        return user_team

--- a/coral/media/js/views/components/plugins/dashboard.js
+++ b/coral/media/js/views/components/plugins/dashboard.js
@@ -117,14 +117,18 @@ define([
 
       //reduces the number of items per page based on the window width
       const updateItemsPerPage = () => {
+        console.log('width', window.innerWidth)
         if (window.innerWidth < 1000){
             this.itemsPerPage(2);
         }
-        else if (window.innerWidth < 1600){
+        else if (window.innerWidth < 1360){
             this.itemsPerPage(4);
         }
-        else if (window.innerWidth < 2200){
+        else if (window.innerWidth < 1760){
             this.itemsPerPage(6);
+        }
+        else{
+            this.itemsPerPage(8)
         }
       }
 

--- a/coral/templates/views/components/cards/dashboard-card.htm
+++ b/coral/templates/views/components/cards/dashboard-card.htm
@@ -1,5 +1,5 @@
 <!-- ko if: state === 'Planning'-->
-<div class="card-grid-item" style="margin: 2rem; width:375px">
+<div class="card-grid-item" style="margin: 1rem; width:375px">
   <div class="panel mar-no dashboard-card-panel">
     <div class="panel-heading" style="height: 38px">
       <h3 id="f1-name" class="panel-title library-card-panel-title" style="font-weight: bold; font-size: 1.4rem">

--- a/coral/templates/views/components/notification.htm
+++ b/coral/templates/views/components/notification.htm
@@ -50,7 +50,7 @@
         <!-- ko if: state.fields_cache.notif.context.consultation_id -->
         <div class='entry'>
             <a data-bind="click: () => {
-                openFlagged(state.fields_cache.notif.context.resource_instance_id, 'assign-consultation-workflow')
+                openFlagged(state.fields_cache.notif.context.resource_instance_id, state.fields_cache.notif.context.response_slug)
               } " 
               target="_blank" style="color: steelblue"
             >

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -195,7 +195,9 @@ class PlanningTaskStrategy(TaskStrategy):
                 # first checks reassigned to as this overwrites the assigned to field if true
                 if reassigned_to_tiles:
                     for tile in reassigned_to_tiles:
-                        is_assigned_to_user = any(user.id == userResourceId for user in tile.re_assignee.re_assigned_to)
+                        if any(user.id == userResourceId for user in tile.re_assignee.re_assigned_to):
+                            is_assigned_to_user = True
+                            break
                 elif assigned_to_list:
                     is_assigned_to_user = any(user.id == userResourceId for user in assigned_to_list)
                 

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -64,6 +64,7 @@ class Dashboard(View):
                 task_resources = data['task_resources']
                 counters = data['counters']
                 sort_options = data['sort_options']
+                filter_options = data['filter_options']
                 utilities = Utilities()
                 task_resources = utilities.sort_resources(task_resources, sort_by, sort_order)
 

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -56,6 +56,7 @@ class Dashboard(View):
             sort_order = request.GET.get('sortOrder', None)
             filter = request.GET.get('filterBy', None)
             sort_options = []
+            filter_options = []
 
             if not update and cache.get(cache_key):
                 cache_data = cache.get(cache_key)

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -156,76 +156,78 @@ class TaskStrategy:
 class PlanningTaskStrategy(TaskStrategy):
     def get_tasks(self, groupId, userResourceId, sort_by='deadline', sort_order='asc', filter='All'):
         from arches_orm.models import Consultation
-    
-        TYPE_ASSIGN_HM = '94817212-3888-4b5c-90ad-a35ebd2445d5'
-        TYPE_ASSIGN_HB = '12041c21-6f30-4772-b3dc-9a9a745a7a3f'
-        TYPE_ASSIGN_BOTH = '7d2b266f-f76d-4d25-87f5-b67ff1e1350f'
-        
-        is_hm_manager = groupId in [HM_MANAGER] 
-        is_hb_manager = groupId in [HB_MANAGER] 
-        is_hm_user = groupId in [HM_GROUP] 
-        is_hb_user = groupId in [HB_GROUP] 
-        is_admin = groupId in [PLANNING_GROUP]
+        with admin():
+            TYPE_ASSIGN_HM = '94817212-3888-4b5c-90ad-a35ebd2445d5'
+            TYPE_ASSIGN_HB = '12041c21-6f30-4772-b3dc-9a9a745a7a3f'
+            TYPE_ASSIGN_BOTH = '7d2b266f-f76d-4d25-87f5-b67ff1e1350f'
+            
+            is_hm_manager = groupId in [HM_MANAGER] 
+            is_hb_manager = groupId in [HB_MANAGER] 
+            is_hm_user = groupId in [HM_GROUP] 
+            is_hb_user = groupId in [HB_GROUP] 
+            is_admin = groupId in [PLANNING_GROUP]
 
-        resources = [] 
+            resources = [] 
 
-        utilities = Utilities()
+            utilities = Utilities()
 
-        consultations = Consultation.all()
+            consultations = Consultation.all()
 
-        #filter out consultations that are not planning consultations
-        planning_consultations=[c for c in consultations if (resourceid := c.system_reference_numbers.uuid.resourceid) and resourceid.startswith('CON/')]
+            #filter out consultations that are not planning consultations
+            planning_consultations=[c for c in consultations if (resourceid := c.system_reference_numbers.uuid.resourceid) and resourceid.startswith('CON/')]
 
-        #checks against type & status and assigns to user if in correct group
-        for consultation in planning_consultations:
-                action_status = utilities.node_check(lambda: consultation.action[0].action_status )
-                action_type = utilities.node_check(lambda: consultation.action[0].action_type) 
-                assigned_to_list = utilities.node_check(lambda: consultation.action[0].assigned_to_n1, [])
-                reassigned_to_tiles = utilities.node_check(lambda: consultation.assignment, [])
+            #checks against type & status and assigns to user if in correct group
+            for consultation in planning_consultations:
+                    action_status = utilities.node_check(lambda: consultation.action[0].action_status )
+                    action_type = utilities.node_check(lambda: consultation.action[0].action_type) 
+                    assigned_to_list = utilities.node_check(lambda: consultation.action[0].assigned_to_n1, [])
+                    reassigned_to_tiles = utilities.node_check(lambda: consultation.assignment, [])
 
-                user_assigned = any(assigned_to_list)
+                    user_assigned = any(assigned_to_list)
 
-                if not user_assigned:
-                    for tile in reassigned_to_tiles:
-                        if any(tile.re_assignee.re_assigned_to):
-                            user_assigned = True
-                            break 
+                    if not user_assigned:
+                        for tile in reassigned_to_tiles:
+                            if any(tile.re_assignee.re_assigned_to):
+                                user_assigned = True
+                                break 
 
-                is_assigned_to_user = False
+                    is_assigned_to_user = False
 
-                # first checks reassigned to as this overwrites the assigned to field if true
-                if reassigned_to_tiles:
-                    for tile in reassigned_to_tiles:
-                        if any(user.id == userResourceId for user in tile.re_assignee.re_assigned_to):
-                            is_assigned_to_user = True
-                            break
-                elif assigned_to_list:
-                    is_assigned_to_user = any(user.id == userResourceId for user in assigned_to_list)
-                
-                hm_status_conditions = [STATUS_OPEN, STATUS_HB_DONE, STATUS_EXTENSION_REQUESTED]
-                hb_status_conditions = [STATUS_OPEN, STATUS_HM_DONE, STATUS_EXTENSION_REQUESTED]
+                    # first checks reassigned to as this overwrites the assigned to field if true
+                    if reassigned_to_tiles:
+                        for tile in reassigned_to_tiles:
+                            if any(user.id == userResourceId for user in tile.re_assignee.re_assigned_to):
+                                is_assigned_to_user = True
+                                break
+                    elif assigned_to_list:
+                        for user in assigned_to_list:
+                            print("USER ID", user.id, userResourceId)
+                        is_assigned_to_user = any(user.id == userResourceId for user in assigned_to_list)
+                    
+                    hm_status_conditions = [STATUS_OPEN, STATUS_HB_DONE, STATUS_EXTENSION_REQUESTED]
+                    hb_status_conditions = [STATUS_OPEN, STATUS_HM_DONE, STATUS_EXTENSION_REQUESTED]
 
-                conditions_for_task = (
-                    (is_hm_manager and action_status in hm_status_conditions and action_type in [TYPE_ASSIGN_HM, TYPE_ASSIGN_BOTH] and (not user_assigned or is_assigned_to_user)) or
-                    (is_hb_manager and action_status in hb_status_conditions and action_type in [TYPE_ASSIGN_HB, TYPE_ASSIGN_BOTH] and (not user_assigned or is_assigned_to_user)) or
-                    (is_hm_user and is_assigned_to_user and action_status in hm_status_conditions and action_type in [TYPE_ASSIGN_HM, TYPE_ASSIGN_BOTH]) or
-                    (is_hb_user and is_assigned_to_user and action_status in hb_status_conditions and action_type in [TYPE_ASSIGN_HB, TYPE_ASSIGN_BOTH]) or
-                    (is_admin)
-                )
-                if conditions_for_task:                 
-                    task = self.build_data(consultation, groupId)
-                    if task:
-                        resources.append(task)
+                    conditions_for_task = (
+                        (is_hm_manager and action_status in hm_status_conditions and action_type in [TYPE_ASSIGN_HM, TYPE_ASSIGN_BOTH] and (not user_assigned or is_assigned_to_user)) or
+                        (is_hb_manager and action_status in hb_status_conditions and action_type in [TYPE_ASSIGN_HB, TYPE_ASSIGN_BOTH] and (not user_assigned or is_assigned_to_user)) or
+                        (is_hm_user and is_assigned_to_user and action_status in hm_status_conditions and action_type in [TYPE_ASSIGN_HM, TYPE_ASSIGN_BOTH]) or
+                        (is_hb_user and is_assigned_to_user and action_status in hb_status_conditions and action_type in [TYPE_ASSIGN_HB, TYPE_ASSIGN_BOTH]) or
+                        (is_admin)
+                    )
+                    if conditions_for_task:                 
+                        task = self.build_data(consultation, groupId)
+                        if task:
+                            resources.append(task)
 
 
-        # Convert the 'deadline', 'date' field to a date and sort
-        sorted_resources = utilities.sort_resources(resources, sort_by, sort_order)
+            # Convert the 'deadline', 'date' field to a date and sort
+            sorted_resources = utilities.sort_resources(resources, sort_by, sort_order)
 
-        counters = utilities.get_count_groups(resources, ['status', 'hierarchy_type'])
-        sort_options = [{'id': 'deadline', 'name': 'Deadline'}, {'id': 'date', 'name': 'Date'}]
-        filter_options = []
+            counters = utilities.get_count_groups(resources, ['status', 'hierarchy_type'])
+            sort_options = [{'id': 'deadline', 'name': 'Deadline'}, {'id': 'date', 'name': 'Date'}]
+            filter_options = []
 
-        return sorted_resources, counters, sort_options, filter_options
+            return sorted_resources, counters, sort_options, filter_options
     
     def build_data(self, consultation, groupId):
         utilities = Utilities()


### PR DESCRIPTION
## Description
Fixes some issues that appeared on the dashboards:
- The open link in the notification only directed to assign consultation. It will now redirect to the correct team response depending on the user
- An error sometimes occurred that filter options was used before being initialised. Initialised an empty array to stop this.
- A bug that could reset the assigned user when looping through several tiles. Now breaks when truthy is found
- No notification was sent when a response had been completed. Should notify the planning admin of a completed response of the team

## Tests
- Reload the Notify Planning function
- Either reload the consultation or add the function back onto the model
- Restart containers
- rebuild webpack
- Create or use a user for both the HM and HB groups
- Create a planning admin and add them to the planning admin group
- As admin create a new consultation and assign to both and assign the users, set status to open
- Log in as the HM user
- Check the notification, should say it has been assigned to the user
- Click the open workflow button - should take you to the hm response
- Open the dashboard for the user
- Should see the task
- Repeat the steps for HB user
- Complete the response for one of the teams and save
- Log in as a planning admin
- Should see a notification saying that a resource has been completed by the appropriate team
- Create multiple resources 8 min
- The screen should resize and display the correct amount of tasks to fit the screen without overlapping the paignator
- Resize the screen
- The tasks should change the amount shown per page dependent upon the screen size