### PR TITLE
fix(#2484): enforcements not showing correctly

### DIFF
--- a/coral/media/js/views/components/plugins/view-enforcements.js
+++ b/coral/media/js/views/components/plugins/view-enforcements.js
@@ -347,17 +347,15 @@ define([
       const descriptionTile = consultation.tiles.find((tile) => {
         return tile.nodegroup === '89bf628e-b552-11ee-805b-0242ac120006';
       });
+      return descriptionTile?.data['89bf6c48-b552-11ee-805b-0242ac120006'][arches.activeLanguage]['value']
+    };
+
+    this.getStatus = (consultation) => {
       const statusTile = consultation.tiles.find((tile) => {
         return tile.nodegroup === 'ac823b90-b555-11ee-805b-0242ac120006';
       });
-      return {
-        status: statusTile?.data['c9711ef6-b555-11ee-baf6-0242ac120006'],
-        description:
-          descriptionTile?.data['89bf6c48-b552-11ee-805b-0242ac120006'][arches.activeLanguage][
-            'value'
-          ]
-      };
-    };
+      return statusTile?.data['c9711ef6-b555-11ee-baf6-0242ac120006']
+    }
 
     this.getStatusText = (nodeValueId) => {
       switch (nodeValueId) {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=0, patch=0)
+APP_VERSION = semantic_version.Version(major=6, minor=0, patch=1)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/plugins/view-enforcements.htm
+++ b/coral/templates/views/components/plugins/view-enforcements.htm
@@ -13,12 +13,12 @@
       </div>
       <div
         class="panel-body library-card-body"
-        data-bind="html: getDescription(consultation).description"
+        data-bind="html: getDescription(consultation)"
       ></div>
       <div class="panel-footer" style="height: 53px; display: flex; align-items: center; justify-content: space-between">
         <div>
           <span>
-            Status: <span data-bind="text: getStatusText(getDescription(consultation).status)"></span>
+            Status: <span data-bind="text: getStatusText(getStatus(consultation))"></span>
           </span>
         </div>
         <div>


### PR DESCRIPTION
### Descriptions
The enforcements were erroring on some resources as description data was not available and the error was not being handled. 

### Tests
- Restart containers
- Rebuild webpack
- Create multiple enforcements, some with name and descriptions, some with no description and some saved with no data
- Navigate to the enforcements dashboard
- Should see all the enforcements
- Should see status were applicable, description and a title name
- No errors should be present in the console