### PR TITLE
Hotfix/#2769 mandatory add

### DIFF
--- a/coral/media/js/views/components/cards/default.js
+++ b/coral/media/js/views/components/cards/default.js
@@ -50,17 +50,18 @@ define([
             this.mandatoryNodes = ko.observableArray([])
             this.currentValues = ko.observable({})
 
+            // this has been removed as it was causing issues with hidden nodes
             // do a node lookup to check for isrequired on the model config
-            if(params.form.nodeLookup){
-                for(const [key, node] of Object.entries(params.form.nodeLookup)){
-                    if(node?.isrequired() === true){
-                        if(!this.tile.data[key]){
-                            continue
-                        }
-                        this.mandatoryNodes.push(key)
-                    }
-                }   
-            }
+            // if(params.form.nodeLookup){
+            //     for(const [key, node] of Object.entries(params.form.nodeLookup)){
+            //         if(node?.isrequired() === true){
+            //             if(!this.tile.data[key]){
+            //                 continue
+            //             }
+            //             this.mandatoryNodes.push(key)
+            //         }
+            //     }   
+            // }
 
             // check workflow config for isrequired attributes also
             if(params.nodeOptions){

--- a/coral/plugins/state-care-condition-survey-workflow.json
+++ b/coral/plugins/state-care-condition-survey-workflow.json
@@ -83,8 +83,29 @@
                   "graphid": "c0098070-d052-4449-982b-952507306c03",
                   "nodegroupid": "c43324d0-5329-11ef-9337-0242ac120006",
                   "semanticName": "Assessments",
-                  "resourceid": "['initial-step-step']['e769c1dc-f1ca-4982-bf7e-f7e2ee344dea'][0]['resourceid']['resourceInstanceId']"
-
+                  "resourceid": "['initial-step-step']['e769c1dc-f1ca-4982-bf7e-f7e2ee344dea'][0]['resourceid']['resourceInstanceId']",
+                  "nodeOptions":{
+                    "e5c8e976-532a-11ef-9d2a-0242ac120006": {
+                      "node":{
+                        "isrequired": true
+                      }
+                    },
+                    "918ac3e8-532a-11ef-9337-0242ac120006": {
+                      "node":{
+                        "isrequired": true
+                      }
+                    },
+                    "8ef1921e-532b-11ef-9d2a-0242ac120006": {
+                      "node":{
+                        "isrequired": true
+                      }
+                    },
+                    "e5d079bc-5329-11ef-9d2a-0242ac120006": {
+                      "node":{
+                        "isrequired": true
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "many",
                 "componentName": "default-card",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=3, patch=4)
+APP_VERSION = semantic_version.Version(major=6, minor=3, patch=5)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
The disable add was causing some many selects to be permanently disabled due to hidden nodes that were set as required on the model.
This PR removes the check for the isrequired against the model and only looks for ones set in the workflow config.
State care condition had previously been set on the model so this has been updated to use the workflow config

## Test
- coral reload
- rebuild webpack
- Open the licence workflow
- Navigate to the communications step
- Fill in the many select fields
- Add should be enabled
- Navigate to the location details step
- The area name and area type should need both fields before add is enabled
- Open state care condition
- Navigate to Overall Score Assessment
- The top 4 mandatory fields should be filled before disable add is enabled 