### PR TITLE
fix(Monument | Monument Revision): update category type domain list

### DIFF
--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -26292,17 +26292,10 @@
                         },
                         "options": [
                             {
-                                "id": "52353731-b0ac-48b6-b1e7-2ccb98833397",
+                                "id": "86177acb-d727-49b8-b79c-8633530d8704",
                                 "selected": false,
                                 "text": {
-                                    "en": "Standing Buildings"
-                                }
-                            },
-                            {
-                                "id": "9145aaa1-db58-461d-a2fe-83dfea3e5f21",
-                                "selected": false,
-                                "text": {
-                                    "en": "Field Monuments"
+                                    "en": "Lacustrine"
                                 }
                             },
                             {
@@ -26313,10 +26306,31 @@
                                 }
                             },
                             {
-                                "id": "86177acb-d727-49b8-b79c-8633530d8704",
+                                "id": "9145aaa1-db58-461d-a2fe-83dfea3e5f21",
                                 "selected": false,
                                 "text": {
-                                    "en": "Aquatic Monuments"
+                                    "en": "Field Monuments"
+                                }
+                            },
+                            {
+                                "id": "52353731-b0ac-48b6-b1e7-2ccb98833397",
+                                "selected": false,
+                                "text": {
+                                    "en": "Standing Buildings"
+                                }
+                            },
+                            {
+                                "id": "1d58ba52-8c8a-4923-9459-642a5ee9a45c",
+                                "selected": false,
+                                "text": {
+                                    "en": "Riverine"
+                                }
+                            },
+                            {
+                                "id": "bb968650-d1c2-4e6e-87ca-cc9c26f432b1",
+                                "selected": false,
+                                "text": {
+                                    "en": "Marine"
                                 }
                             }
                         ]

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -22614,7 +22614,7 @@
                                 "id": "86177acb-d727-49b8-b79c-8633530d8704",
                                 "selected": false,
                                 "text": {
-                                    "en": "Aquatic Monuments"
+                                    "en": "Lacustrine"
                                 }
                             },
                             {
@@ -22636,6 +22636,20 @@
                                 "selected": false,
                                 "text": {
                                     "en": "Standing Buildings"
+                                }
+                            },
+                            {
+                                "id": "1d58ba52-8c8a-4923-9459-642a5ee9a45c",
+                                "selected": false,
+                                "text": {
+                                    "en": "Riverine"
+                                }
+                            },
+                            {
+                                "id": "bb968650-d1c2-4e6e-87ca-cc9c26f432b1",
+                                "selected": false,
+                                "text": {
+                                    "en": "Marine"
                                 }
                             }
                         ]

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=4, patch=9)
+APP_VERSION = semantic_version.Version(major=6, minor=4, patch=10)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
The category types on the monuments had reverted to an old domain list. This has been updated to match what is expected.

## Test
- Reload Monument and Monument Revision
- Check on the model - Category Type, domain list should include:
    - Lacustrine
    - Carved Stone
    - Field Monuments
    - Standing Buildings
    - Riverine
    - Marine
- Go to the add monument workflow
- In asset details check that these are showing in the category type drop down