### PR TITLE
fix(#2656)- add escape function to the transfer of licence

### DIFF
--- a/coral/functions/transfer_licence_function.py
+++ b/coral/functions/transfer_licence_function.py
@@ -33,6 +33,8 @@ details = {
 
 class TransferOfLicenceFunction(BaseFunction):
     def save(self, tile, request, context=None):
+        if context and context.get('escape_function', False):
+            return
         # Many tiles save themselves again each time a new one saves to circumvent
         # old transfer getting applied again and failed this node will be set to
         # true after it has been used


### PR DESCRIPTION
## Description
Add escape function context to the save of transfer of licence