### PR TITLE
fix(#2674): remove date consulted from assign consultation

### DIFF
--- a/coral/plugins/assign-consultation-workflow.json
+++ b/coral/plugins/assign-consultation-workflow.json
@@ -150,28 +150,6 @@
                 "parameters": {
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
-                  "hiddenNodes": [
-                    "7224417b-893a-11ea-b383-f875a44e0e11",
-                    "40eff4ce-893a-11ea-ae2e-f875a44e0e11"
-                  ],
-                  "nodegroupid": "40eff4c9-893a-11ea-ac3a-f875a44e0e11",
-                  "semanticName": "Consultation Dates",
-                  "nodeOptions": {
-                    "40eff4cd-893a-11ea-b0cc-f875a44e0e11": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    }
-                  }
-                },
-                "tilesManaged": "one",
-                "componentName": "default-card",
-                "uniqueInstanceName": "consultation-dates"
-              },
-              {
-                "parameters": {
-                  "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
-                  "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "hiddenNodes": [],
                   "nodegroupid": "82f8a163-951a-11ea-b58e-f875a44e0e11",
                   "semanticName": "Consultation Descriptions"

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=4, patch=10)
+APP_VERSION = semantic_version.Version(major=6, minor=4, patch=11)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
Remove 'Date Consulted' from the 'Assign Consultation' 'Assignment Details' step.

## Tests
- coral reload
- open planning consultation
- navigate to the assignment details page
- make sure date consulted is not visible