### PR TITLE
hotfix: remove extra assign node from hb response

### DIFF
--- a/coral/plugins/hb-planning-consultation-response-workflow.json
+++ b/coral/plugins/hb-planning-consultation-response-workflow.json
@@ -51,31 +51,6 @@
                 "parameters": {
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "a5e15f5c-51a3-11eb-b240-f875a44e0e11",
-                  "semanticName": "Action",
-                  "hiddenNodes":[
-                    "e2585f8a-51a3-11eb-a7be-f875a44e0e11",
-                    "c4413ac8-69b6-11ee-908a-0242ac120002",
-                    "06adec44-69b7-11ee-908a-0242ac120002",
-                    "ac905d54-ca65-11ee-b83c-0242ac180006",
-                    "19eef70c-69b8-11ee-8431-0242ac120002",
-                    "22c1c800-51a4-11eb-8254-f875a44e0e11",
-                    "bfd39106-51a3-11eb-9104-f875a44e0e11"
-                  ],
-                  "nodeOptions": {
-                    "8322f9f6-69b5-11ee-93a1-0242ac120002": {
-                      "allowInstanceCreation": false
-                    }
-                  }
-                },
-                "tilesManaged": "one",
-                "componentName": "default-card-util",
-                "uniqueInstanceName": "response-assigned-to"
-              },
-              {
-                "parameters": {
-                  "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
-                  "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "nodegroupid": "dc9bfb24-cfd9-11ee-8cc1-0242ac180006",
                   "semanticName": "Assignment",
                   "hiddenNodes": ["6b8f5866-2f0d-11ef-b37c-0242ac140006"],

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=3, patch=7)
+APP_VERSION = semantic_version.Version(major=6, minor=3, patch=8)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
HB Response had the planning consultation assign node still showing. This removes it.

## Tests
- coral reload
- rebuild webpack
- create a planning consultation assigned to hb
- assign a user
- open the hb response
- check on assign step that only one assign to node is visible and that it is disabled
- should have the user previously selected visible