### PR TITLE
Feat #2660 #2666 #2667 #2668 

### DIFF
--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -4398,6 +4398,28 @@
                     "widget_id": "10000000-0000-0000-0000-000000000016"
                 },
                 {
+                    "card_id": "458dcc3f-5b44-4a08-852b-2dacb074f26d",
+                    "config": {
+                        "defaultValue": "",
+                        "en": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Priority Rating",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "273d24c8-d196-43b6-ad10-9216a6e9c2b0",
+                    "label": {
+                        "en": "Priority Rating"
+                    },
+                    "node_id": "42a68087-ff73-442b-8831-9216a6e9c2b0",
+                    "sortorder": 0,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000016"
+                },
+                {
                     "card_id": "e6181b8e-1d2e-4096-ab15-d188838538e0",
                     "config": {
                         "dateFormat": "YYYY-MM-DD",
@@ -17057,6 +17079,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "8cb405ca-ac9f-427d-9be4-92639b3641a0"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "e28fe749-c298-449b-b6ab-5e2ccf17bcd1",
+                    "edgeid": "48a4942b-ff73-442b-8831-4b1a175d527d",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "42a68087-ff73-442b-8831-9216a6e9c2b0"
                 },
                 {
                     "description": null,
@@ -31735,6 +31766,68 @@
                     "name": "Action Type",
                     "nodegroup_id": "e28fe749-c298-449b-b6ab-5e2ccf17bcd1",
                     "nodeid": "8cb405ca-ac9f-427d-9be4-92639b3641a0",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "priority_rating",
+                    "config": {
+                        "i18n_config": {
+                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
+                        },
+                        "options": [
+                            {
+                                "id": "803f79ba-ff73-442b-8831-9216a6e9c2b0",
+                                "selected": false,
+                                "text": {
+                                    "en": "1"
+                                }
+                            },
+                            {
+                                "id": "42a68087-982f-442b-8831-9216a6e9c2b0",
+                                "selected": false,
+                                "text": {
+                                    "en": "2"
+                                }
+                            },
+                            {
+                                "id": "42a68087-8d96-49a2-84de-477ab973cbb6",
+                                "selected": false,
+                                "text": {
+                                    "en": "3"
+                                }
+                            },
+                            {
+                                "id": "42a68087-9f46-426b-83e3-eee965818a5f",
+                                "selected": false,
+                                "text": {
+                                    "en": "4"
+                                }
+                            },
+                            {
+                                "id": "42a68087-ff73-426b-83e3-eee965818a5f",
+                                "selected": false,
+                                "text": {
+                                    "en": "5"
+                                }
+                            }
+                        ]
+                    },
+                    "datatype": "domain-value-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Priority Rating",
+                    "nodegroup_id": "e28fe749-c298-449b-b6ab-5e2ccf17bcd1",
+                    "nodeid": "42a68087-ff73-442b-8831-9216a6e9c2b0",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -8172,6 +8172,55 @@
                     "config": {
                         "dateFormat": "DD-MM-YYYY",
                         "defaultValue": "",
+                        "label": "Council Response Date",
+                        "maxDate": false,
+                        "minDate": false,
+                        "placeholder": "Enter date",
+                        "viewMode": "days"
+                    },
+                    "id": "7cf58377-a742-4607-ae80-08bc58fcaac8",
+                    "label": {
+                        "en": "Council Response Date"
+                    },
+                    "node_id": "36b51a2b-baf3-4dc4-b714-08bc58fcaac8",
+                    "sortorder": 21,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                },
+                {
+                    "card_id": "bd9292aa-4b19-4d57-ba07-8bb144bd507e",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Council Response",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "395b20aa-0a71-4137-9476-35070cd3d2a5",
+                    "label": {
+                        "en": "Council Response"
+                    },
+                    "node_id": "395b20aa-3851-4799-b179-90d31e5ca214",
+                    "sortorder": 21,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                },
+                {
+                    "card_id": "bd9292aa-4b19-4d57-ba07-8bb144bd507e",
+                    "config": {
+                        "dateFormat": "DD-MM-YYYY",
+                        "defaultValue": "",
                         "label": "Local Authority Notification Date",
                         "maxDate": false,
                         "minDate": false,
@@ -20414,6 +20463,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "3c51740c-dbd0-11ee-8835-0242ac120006",
+                    "edgeid": "395b20aa-5d9b-4112-b0b0-fed308d2bda8",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "395b20aa-3851-4799-b179-90d31e5ca214"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "889116a6-c94c-44c3-96e5-a8442b1e00f8",
                     "edgeid": "ce9a4cc2-f002-41b7-9a1e-85d7a47ef495",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
@@ -20456,6 +20514,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
                     "rangenode_id": "36b51a2b-2fad-45fb-9e93-088016aa0fc9"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "cffa2b86-3797-11ef-a167-0242ac150006",
+                    "edgeid": "cffa606a-3797-11ef-a167-08bc58fcaac8",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "rangenode_id": "36b51a2b-baf3-4dc4-b714-08bc58fcaac8"
                 },
                 {
                     "description": null,
@@ -36156,6 +36223,50 @@
                     "nodeid": "36b51a2b-2fad-45fb-9e93-088016aa0fc9",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "council_response_date",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Council Response Date",
+                    "nodegroup_id": "3c51740c-dbd0-11ee-8835-0242ac120006",
+                    "nodeid": "36b51a2b-baf3-4dc4-b714-08bc58fcaac8",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "council_response",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Council Response",
+                    "nodegroup_id": "3c51740c-dbd0-11ee-8835-0242ac120006",
+                    "nodeid": "395b20aa-3851-4799-b179-90d31e5ca214",
+                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/coral/pkg/graphs/resource_models/Monument Revision.json
+++ b/coral/pkg/graphs/resource_models/Monument Revision.json
@@ -8152,6 +8152,26 @@
                     "config": {
                         "dateFormat": "DD-MM-YYYY",
                         "defaultValue": "",
+                        "label": "Council Consulted Date",
+                        "maxDate": false,
+                        "minDate": false,
+                        "placeholder": "Enter date",
+                        "viewMode": "days"
+                    },
+                    "id": "7cf58377-a742-4607-ae80-088016aa0fc9",
+                    "label": {
+                        "en": "Council Consulted Date"
+                    },
+                    "node_id": "36b51a2b-2fad-45fb-9e93-088016aa0fc9",
+                    "sortorder": 21,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                },
+                {
+                    "card_id": "bd9292aa-4b19-4d57-ba07-8bb144bd507e",
+                    "config": {
+                        "dateFormat": "DD-MM-YYYY",
+                        "defaultValue": "",
                         "label": "Local Authority Notification Date",
                         "maxDate": false,
                         "minDate": false,
@@ -20427,6 +20447,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "3bebbbfd-327f-43ec-8e4e-30f67181b1e8"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "cffa2b86-3797-11ef-a167-0242ac150006",
+                    "edgeid": "cffa606a-3797-11ef-a167-088016aa0fc9",
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "rangenode_id": "36b51a2b-2fad-45fb-9e93-088016aa0fc9"
                 },
                 {
                     "description": null,
@@ -36104,6 +36133,29 @@
                     "nodeid": "cffa2b86-3797-11ef-a167-0242ac150006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E52_Time-Span",
                     "parentproperty": "http://www.ics.forth.gr/isl/CRMdig/L54i_is_same-as",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "council_consulted_date",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Council Consulted Date",
+                    "nodegroup_id": "3c51740c-dbd0-11ee-8835-0242ac120006",
+                    "nodeid": "36b51a2b-2fad-45fb-9e93-088016aa0fc9",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -4845,6 +4845,26 @@
                     "config": {
                         "dateFormat": "DD-MM-YYYY",
                         "defaultValue": "",
+                        "label": "Council Consulted Date",
+                        "maxDate": false,
+                        "minDate": false,
+                        "placeholder": "Enter date",
+                        "viewMode": "days"
+                    },
+                    "id": "1b3561f6-380f-4620-a3f1-c8486cbf457d",
+                    "label": {
+                        "en": "Council Consulted Date"
+                    },
+                    "node_id": "1b3561f6-7ad7-4c11-822e-57d6685cc89d",
+                    "sortorder": 12,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                },
+                {
+                    "card_id": "52cbc3a5-4007-4edc-880c-f02c96e0ce2a",
+                    "config": {
+                        "dateFormat": "DD-MM-YYYY",
+                        "defaultValue": "",
                         "label": "Local Authority Notification Date",
                         "maxDate": false,
                         "minDate": false,
@@ -20099,6 +20119,15 @@
                 {
                     "description": null,
                     "domainnode_id": "98c4287a-37be-11ef-a167-0242ac150006",
+                    "edgeid": "1b3561f6-37be-11ef-a167-0242ac150006",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "rangenode_id": "1b3561f6-7ad7-4c11-822e-57d6685cc89d"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "98c4287a-37be-11ef-a167-0242ac150006",
                     "edgeid": "98c4584a-37be-11ef-a167-0242ac150006",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "name": null,
@@ -35060,6 +35089,29 @@
                     "nodeid": "98a851e2-d62d-11ee-9454-0242ac180006",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "council_consulted_date",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Council Consulted Date",
+                    "nodegroup_id": "7e0533aa-37b7-11ef-9263-0242ac150006",
+                    "nodeid": "1b3561f6-7ad7-4c11-822e-57d6685cc89d",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -4819,6 +4819,28 @@
                     "widget_id": "10000000-0000-0000-0000-000000000016"
                 },
                 {
+                    "card_id": "a1f10404-d648-11ee-9a11-0242ac180006",
+                    "config": {
+                        "defaultValue": "",
+                        "en": "",
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Priority Rating",
+                        "placeholder": {
+                            "en": "Select an option"
+                        }
+                    },
+                    "id": "4dc5897b-7105-4850-a826-65fe7bb4195e",
+                    "label": {
+                        "en": "Priority Rating"
+                    },
+                    "node_id": "dff3a4d2-b4f6-4850-a826-65fe7bb4195e",
+                    "sortorder": 0,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000016"
+                },
+                {
                     "card_id": "52cbc3a5-4007-4edc-880c-f02c96e0ce2a",
                     "config": {
                         "dateFormat": "DD-MM-YYYY",
@@ -20865,6 +20887,15 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "dff3a4d2-d648-11ee-8b04-0242ac180006"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "a1f0e104-d648-11ee-9a11-0242ac180006",
+                    "edgeid": "b792595f-b4f6-4850-a826-64d47cb0761b",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "dff3a4d2-b4f6-4850-a826-65fe7bb4195e"
                 },
                 {
                     "description": null,
@@ -38262,6 +38293,68 @@
                     "name": "Action Type",
                     "nodegroup_id": "a1f0e104-d648-11ee-9a11-0242ac180006",
                     "nodeid": "dff3a4d2-d648-11ee-8b04-0242ac180006",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "priority_rating",
+                    "config": {
+                        "i18n_config": {
+                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
+                        },
+                        "options": [
+                            {
+                                "id": "73cb47c8-b4f6-4850-a826-65fe7bb4195e",
+                                "selected": false,
+                                "text": {
+                                    "en": "1"
+                                }
+                            },
+                            {
+                                "id": "73cb47c8-b4f6-4850-a826-477ab973cbb6",
+                                "selected": false,
+                                "text": {
+                                    "en": "2"
+                                }
+                            },
+                            {
+                                "id": "73cb47c8-b4f6-4850-a826-eaac04a18d88",
+                                "selected": false,
+                                "text": {
+                                    "en": "3"
+                                }
+                            },
+                            {
+                                "id": "73cb47c8-b4f6-4850-a826-e94a1b298cfe",
+                                "selected": false,
+                                "text": {
+                                    "en": "4"
+                                }
+                            },
+                            {
+                                "id": "73cb47c8-b4f6-4850-a826-e94a1b24195e",
+                                "selected": false,
+                                "text": {
+                                    "en": "5"
+                                }
+                            }
+                        ]
+                    },
+                    "datatype": "domain-value-list",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Priority Rating",
+                    "nodegroup_id": "a1f0e104-d648-11ee-9a11-0242ac180006",
+                    "nodeid": "dff3a4d2-b4f6-4850-a826-65fe7bb4195e",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "sortorder": 0,

--- a/coral/pkg/graphs/resource_models/Monument.json
+++ b/coral/pkg/graphs/resource_models/Monument.json
@@ -4865,6 +4865,55 @@
                     "config": {
                         "dateFormat": "DD-MM-YYYY",
                         "defaultValue": "",
+                        "label": "Council Response Date",
+                        "maxDate": false,
+                        "minDate": false,
+                        "placeholder": "Enter date",
+                        "viewMode": "days"
+                    },
+                    "id": "2e710ae3-380f-4620-a3f1-c8486cbf457d",
+                    "label": {
+                        "en": "Council Response Date"
+                    },
+                    "node_id": "2e710ae3-bb74-4ab1-8288-97eb5aaff6d6",
+                    "sortorder": 12,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000004"
+                },
+                {
+                    "card_id": "52cbc3a5-4007-4edc-880c-f02c96e0ce2a",
+                    "config": {
+                        "defaultValue": {
+                            "en": {
+                                "direction": "ltr",
+                                "value": ""
+                            }
+                        },
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "Council Response",
+                        "maxLength": null,
+                        "placeholder": {
+                            "en": "Enter text"
+                        },
+                        "uneditable": false,
+                        "width": "100%"
+                    },
+                    "id": "c37832db-0a71-4137-9476-35070cd3d2a5",
+                    "label": {
+                        "en": "Council Response"
+                    },
+                    "node_id": "c37832db-6077-4228-9bd7-73f53f2149a2",
+                    "sortorder": 21,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000005"
+                },
+                {
+                    "card_id": "52cbc3a5-4007-4edc-880c-f02c96e0ce2a",
+                    "config": {
+                        "dateFormat": "DD-MM-YYYY",
+                        "defaultValue": "",
                         "label": "Local Authority Notification Date",
                         "maxDate": false,
                         "minDate": false,
@@ -20128,6 +20177,24 @@
                 {
                     "description": null,
                     "domainnode_id": "98c4287a-37be-11ef-a167-0242ac150006",
+                    "edgeid": "2e710ae3-37be-11ef-a167-0242ac150006",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "rangenode_id": "2e710ae3-bb74-4ab1-8288-97eb5aaff6d6"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "98c4287a-37be-11ef-a167-0242ac150006",
+                    "edgeid": "c37832db-5d9b-4112-b0b0-fed308d2bda8",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
+                    "rangenode_id": "c37832db-6077-4228-9bd7-73f53f2149a2"
+                },
+                {
+                    "description": null,
+                    "domainnode_id": "98c4287a-37be-11ef-a167-0242ac150006",
                     "edgeid": "98c4584a-37be-11ef-a167-0242ac150006",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                     "name": null,
@@ -35112,6 +35179,50 @@
                     "nodeid": "1b3561f6-7ad7-4c11-822e-57d6685cc89d",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "council_response_date",
+                    "config": {
+                        "dateFormat": "YYYY-MM-DD"
+                    },
+                    "datatype": "date",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Council Response Date",
+                    "nodegroup_id": "7e0533aa-37b7-11ef-9263-0242ac150006",
+                    "nodeid": "2e710ae3-bb74-4ab1-8288-97eb5aaff6d6",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E61_Time_Primitive",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P82a_begin_of_the_begin",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
+                    "alias": "council_response",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": true,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": false,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "Council Response",
+                    "nodegroup_id": "7e0533aa-37b7-11ef-9263-0242ac150006",
+                    "nodeid": "c37832db-6077-4228-9bd7-73f53f2149a2",
+                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null
                 },

--- a/coral/plugins/hb-planning-consultation-response-workflow.json
+++ b/coral/plugins/hb-planning-consultation-response-workflow.json
@@ -166,7 +166,7 @@
       },
       {
         "name": "action-step",
-        "title": "Action",
+        "title": "Summary",
         "required": false,
         "layoutSections": [
           {

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -340,52 +340,17 @@
                     "ad22dad6-dbd0-11ee-b0db-0242ac120006": {
                       "allowInstanceCreation": false
                     },
-                    "2cbc7bf7-ccbb-4ac2-bb29-bc3bc597c753": {
+                    "36b51a2b-2fad-45fb-9e93-088016aa0fc9": {
                       "config":{
                         "maxDate":"today"
                       }
                     },
-                    "0ccb08ee-dbc4-11ee-b0db-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "8623e2d5-5407-4b57-b769-89c934941ac5": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "e1d85f71-85d2-4357-951f-9318f1df36b5": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1f1d69ee-99c8-4808-b2b2-2b33b1364dda": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "a54ab030-d2c9-4e1f-bde9-7e234f3f3e58": {
+                    "cffa2fc8-3797-11ef-a167-0242ac150006": {
                       "config":{
                         "maxDate":"today"
                       }
                     },
                     "0cd0998c-dbd6-11ee-b0db-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "229d12d0-1908-11ef-aa9f-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "257efb18-2d61-11ef-8722-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "7f932826-1908-11ef-aa9c-0242ac150006": {
                       "config":{
                         "maxDate":"today"
                       }
@@ -396,57 +361,8 @@
                         "label": "Owner Notified Date"
                       }
                     },
-                    "cffa2fc8-3797-11ef-a167-0242ac150006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "603015fe-3afe-4475-87e7-771a9d625503": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "1752059c-1e67-4876-94a1-605dbbb4a03d": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "379e65bc-555b-4dd9-bd6d-cf7b6de20527": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "7e1a19c8-676d-4382-a039-0cd28a9a1c28": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "f98b388c-db09-4519-bbd2-0d7bc339c805": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "6b901bcd-724a-48b8-9ff7-8ec917dbfec7": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "577bd652-c9dc-4954-9765-7546ba0cabac": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "c2736493-9ba2-4d59-a358-45eef0086a16": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
-                    "af5fd406-dbd1-11ee-b0db-0242ac120006": {
-                      "config":{
-                        "maxDate":"today"
-                      }
-                    },
                     "59935456-379a-11ef-9263-0242ac150006": {
+                      "label": "Director Sign Off Date",
                       "config":{
                         "maxDate":"today",
                         "label": "Director Sign Off Date"

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -340,6 +340,11 @@
                     "ad22dad6-dbd0-11ee-b0db-0242ac120006": {
                       "allowInstanceCreation": false
                     },
+                    "36b51a2b-baf3-4dc4-b714-08bc58fcaac8": {
+                      "config":{
+                        "maxDate":"today"
+                      }
+                    },
                     "36b51a2b-2fad-45fb-9e93-088016aa0fc9": {
                       "config":{
                         "maxDate":"today"

--- a/coral/plugins/hm-planning-consultation-response-workflow.json
+++ b/coral/plugins/hm-planning-consultation-response-workflow.json
@@ -146,7 +146,7 @@
       },
       {
         "name": "action-step",
-        "title": "Action",
+        "title": "Summary",
         "required": false,
         "layoutSections": [
           {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=4, patch=13)
+APP_VERSION = semantic_version.Version(major=6, minor=5, patch=13)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
This PR adds 
Council Consulted Date
Council Response Date
Council Response
Priority Rating

to heritage asset and heritage asset revision.

It trims unused Node Options and adds the new nodeOptions for the new dates.

It renames the Action Step to Summary.

## Test
To test you'll need to delete and re-import heritage asset and asset designation,
coral reload
Make a heritage asset

Go to the incident report workflow and check that there is a priority rating in the proposal step.
Ensure the domain options 1-5 are available

Go to the heritage asset designation workflow
Ensure Council Consulted Date,  Council Response Date, Council Response nodes are present in the Approval step

Ensure all dates are still limited to today as the max date

Go to the response workflows, check the action step has been renamed to Summary