### PR TITLE
fix(#2237): heritage asset descriptions are mandatory

### DIFF
--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -788,17 +788,21 @@ define([
               componentConfigs: [
                 {
                   componentName: 'transfer-of-licence',
-                  componentName: 'transfer-of-licence',
                   uniqueInstanceName: 'transfer-of-licence',
                   tilesManaged: 'many',
-                  manyTitle: 'Transfers',
                   manyTitle: 'Transfers',
                   parameters: {
                     title: 'Transfer of Licence',
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
                     nodegroupid: '6397b05c-c443-11ee-94bf-0242ac180006',
                     resourceid: "['init-step']['app-id'][0]['resourceid']['resourceInstanceId']",
+                    hiddenNodes: ["1938e0ac-703d-11ef-934d-0242ac120006"],
                     nodeOptions: {
+                      "1938e0ac-703d-11ef-934d-0242ac120006": {
+                        "node": {
+                          "visible": false
+                        }
+                      },
                       "058ccf60-c44d-11ee-94bf-0242ac180006": {
                         "allowInstanceCreation": false
                       },

--- a/coral/plugins/add-building-workflow.json
+++ b/coral/plugins/add-building-workflow.json
@@ -110,7 +110,7 @@
                   "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
                 },
                 "tilesManaged": "many",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
               },
               {
@@ -147,10 +147,22 @@
                   "hiddenNodes": [
                     "ba345579-b554-11ea-9232-f875a44e0e11"
                   ],
-                  "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11"
+                  "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11",
+                  "nodeOptions": {
+                    "ba345577-b554-11ea-a9ee-f875a44e0e11": {
+                      "node": {
+                        "isrequired": true
+                      }
+                    },
+                    "ba34557b-b554-11ea-ab95-f875a44e0e11": {
+                      "node": {
+                        "isrequired": true
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "many",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "cf509aa4-8caa-4362-bce4-444d434be934"
               }
             ]

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -119,7 +119,7 @@
                   "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
                 },
                 "tilesManaged": "many",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
               },
               {

--- a/coral/plugins/add-ihr-workflow.json
+++ b/coral/plugins/add-ihr-workflow.json
@@ -116,7 +116,7 @@
                   "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
                 },
                 "tilesManaged": "many",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
               }
             ]
@@ -137,7 +137,19 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['start-step']['f100407e-3c79-459d-bf91-21b4358c17f6'][0]['resourceid']['resourceInstanceId']",
                   "hiddenNodes": ["ba345579-b554-11ea-9232-f875a44e0e11"],
-                  "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11"
+                  "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11",
+                  "nodeOptions": {
+                    "ba345577-b554-11ea-a9ee-f875a44e0e11": {
+                      "node": {
+                        "isrequired": true
+                      }
+                    },
+                    "ba34557b-b554-11ea-ab95-f875a44e0e11": {
+                      "node": {
+                        "isrequired": true
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "many",
                 "componentName": "default-card",

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -138,7 +138,7 @@
                   "nodegroupid": "a1d4ee93-efc5-11eb-b117-a87eeabdefba"
                 },
                 "tilesManaged": "many",
-                "componentName": "default-card-util",
+                "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
               },
               {
@@ -187,7 +187,19 @@
                   "hiddenNodes": [
                     "ba345579-b554-11ea-9232-f875a44e0e11"
                   ],
-                  "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11"
+                  "nodegroupid": "ba342e69-b554-11ea-a027-f875a44e0e11",
+                  "nodeOptions": {
+                    "ba345577-b554-11ea-a9ee-f875a44e0e11": {
+                      "node": {
+                        "isrequired": true
+                      }
+                    },
+                    "ba34557b-b554-11ea-ab95-f875a44e0e11": {
+                      "node": {
+                        "isrequired": true
+                      }
+                    }
+                  }
                 },
                 "tilesManaged": "many",
                 "componentName": "default-card-util",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=5, patch=13)
+APP_VERSION = semantic_version.Version(major=6, minor=5, patch=14)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
This PR makes description and description types mandatory for heritage asset many selects
needs a coral reload

Test:

```table
Workflow           | Step          | Field            | Mandatory Fields                  | Pass/Fail
Add IHR            | Descriptions  | Description Type | “Description Type”, “Description” |  
Add Building       | Description   | Description Type | “Description Type”, “Description” |  
Add Monument       | Description   | Description Type | “Description Type”, “Description” |  
Add Garden         | Description   | Description Type | “Description Type”, “Description” |  
```


I've also accidentally added the fix for #2369 here as well.

To test it you will need a coral reload then create a licence.
Then use the amendments step to transfer the nominated excavation director multiple times.