### PR TITLE
2650: Fix full reports not showing

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=4, patch=8)
+APP_VERSION = semantic_version.Version(major=6, minor=4, patch=9)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
### what does this PR do?

Pulls in `str` comparison fix in arches fork: [https://github.com/flaxandteal/arches/blob/master/arches/app/models/resource.py](https://github.com/flaxandteal/arches/blame/0dbebb23731ad1aff3d4796e6be331ddc17548f4/arches/app/models/resource.py#L266)