### PR TITLE
#2743 Fix (dashboard): set default sort order to desc

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=7, patch=15)
+APP_VERSION = semantic_version.Version(major=6, minor=7, patch=16)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/plugins/dashboard.htm
+++ b/coral/templates/views/components/plugins/dashboard.htm
@@ -34,7 +34,7 @@
     <select 
         style="text-align-last:unset; margin-left: 1rem" 
         data-bind="
-          options: [ {id: 'asc', name: 'Asc'}, {id: 'desc', name: 'Desc'} ],
+          options: [ {id: 'desc', name: 'Desc'}, {id: 'asc', name: 'Asc'} ],
           optionsText: 'name',
           optionsValue: 'id',
           value: sortOrder,

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -155,7 +155,7 @@ class TaskStrategy:
         raise NotImplementedError("Subclasses must implement this method")
 
 class PlanningTaskStrategy(TaskStrategy):
-    def get_tasks(self, groupId, userResourceId, sort_by='deadline', sort_order='asc', filter='All'):
+    def get_tasks(self, groupId, userResourceId, sort_by='deadline', sort_order='desc', filter='All'):
         from arches_orm.models import Consultation
         with admin():
             TYPE_ASSIGN_HM = '94817212-3888-4b5c-90ad-a35ebd2445d5'
@@ -269,7 +269,7 @@ class PlanningTaskStrategy(TaskStrategy):
         return resource_data
     
 class ExcavationTaskStrategy(TaskStrategy):
-    def get_tasks(self, groupId, userResourceId, sort_by='createdat', sort_order='asc', filter='all'):
+    def get_tasks(self, groupId, userResourceId, sort_by='createdat', sort_order='desc', filter='all'):
         from arches_orm.models import License
         utilities = Utilities()
         #states


### PR DESCRIPTION
## Description
The Excavation team wanted the newest task showing at the start of the list. Need to change the sort order to be desc by default. This needed to change the list order for the drop down so that desc was first and needed to change how the tasks were sorted on the backend when first fetched. Because of the change on the front, the planning team also now has default desc to show the newest task first.

## Test
- Reload containers
- Rebuild webpack
- Follow [tests](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2743)