### PR TITLE
Fix/#2705 Excavation Letter Templates

### DIFF
--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -768,7 +768,10 @@ define([
                     letterTypeNode: '56364572-3928-11ef-b242-0242ac140006',
                     letterResourceNode: '21319570-3928-11ef-b242-0242ac140006',
                     config: {
-                      expand: ["associated_activities", "employing_body", "licensee"]
+                      expand: ["associated_activities", "employing_body", "licensee"],
+                      special: {
+                        today: "today"
+                      }
                     }
                   },
                   noTileSidebar: true,

--- a/coral/pkg/graphs/resource_models/Licence.json
+++ b/coral/pkg/graphs/resource_models/Licence.json
@@ -7834,41 +7834,9 @@
                 {
                     "alias": "letter_type",
                     "config": {
-                        "i18n_config": {
-                            "fn": "arches.app.datatypes.datatypes.DomainDataType"
-                        },
-                        "options": [
-                            {
-                                "id": "b777ebb6-7ab6-4de3-9825-f8564928eee8",
-                                "selected": false,
-                                "text": {
-                                    "en": "Licence Cover Letter"
-                                }
-                            },
-                            {
-                                "id": "f86784f0-0c94-4427-bcba-4dd222461e30",
-                                "selected": false,
-                                "text": {
-                                    "en": "Final Report Letter"
-                                }
-                            },
-                            {
-                                "id": "c9b643bd-2d28-4c91-9d2e-7e861ed34f0f",
-                                "selected": false,
-                                "text": {
-                                    "en": "Extra Name on Licence Letter"
-                                }
-                            },
-                            {
-                                "id": "78533d33-e712-48ee-ab4c-6bdc9f0ca51d",
-                                "selected": false,
-                                "text": {
-                                    "en": "Extension of Licence Letter"
-                                }
-                            }
-                        ]
+                        "rdmCollection": "75ba554a-9a0b-10fd-73d2-24c89b821e57"
                     },
-                    "datatype": "domain-value",
+                    "datatype": "concept",
                     "description": null,
                     "exportable": false,
                     "fieldname": null,

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=9, patch=19)
+APP_VERSION = semantic_version.Version(major=6, minor=9, patch=20)
 
 GROUPINGS = {
     "groups": {

--- a/coral/views/file_template.py
+++ b/coral/views/file_template.py
@@ -211,7 +211,7 @@ class FileTemplateView(View):
                 "provider": GenericTemplateProvider
             },
             "64865b40-1ab8-d59e-aacf-668b077f0e9a" : {
-                "filename": "licence-cover-letter.docx",
+                "filename": "licence-covering-letter.docx",
                 "provider": GenericTemplateProvider
             },
             "e3a1469c-ae0e-7a59-2e25-09c036647e89": {

--- a/coral/views/file_template.py
+++ b/coral/views/file_template.py
@@ -210,22 +210,31 @@ class FileTemplateView(View):
                 "filename": "smc-refusal-template.docx",
                 "provider": GenericTemplateProvider
             },
-            "b777ebb6-7ab6-4de3-9825-f8564928eee8" : {
-                "filename": "licence-test-letter.docx",
+            "64865b40-1ab8-d59e-aacf-668b077f0e9a" : {
+                "filename": "licence-cover-letter.docx",
                 "provider": GenericTemplateProvider
             },
-            "f86784f0-0c94-4427-bcba-4dd222461e30": {
+            "e3a1469c-ae0e-7a59-2e25-09c036647e89": {
                 "filename": "final-report-letter.docx",
                 "provider": GenericTemplateProvider,
             },
-            "c9b643bd-2d28-4c91-9d2e-7e861ed34f0f": {
+            "a346c0f8-7be6-4a7c-da2c-aef42b02ee26": {
                 "filename": "extra-name-on-letter.docx",
                 "provider": GenericTemplateProvider,
             },
-            "78533d33-e712-48ee-ab4c-6bdc9f0ca51d": {
+            "28e3fbdd-8dc8-4fb9-e378-91df6776e065": {
                 "filename": "extension-of-licence-letter.docx",
                 "provider": GenericTemplateProvider,
-            }
+            },
+            "28faad65-2403-b0b9-3ba8-bbbc99efd175": {
+                "filename": "overdue-excavations-report-letter.docx",
+                "provider": GenericTemplateProvider,
+            },
+            "f08c5baf-4434-ac59-a02c-e692ae79d455": {
+                "filename": "transfer-of-licence-letter.docx",
+                "provider": GenericTemplateProvider,
+            },
+
         }
         for key, value in list(template_dict.items()):
             if key == template_id:


### PR DESCRIPTION
## Description
Fix the excavation letters to use the Generic Template to pull the node values and generate the letters.
This also adds 2 new letter templates to the drop down list for a total of 6 letters:
- Licence Covering Letter
- Final Report Letter
- Extra Name on Letter
- Extension of licence letter
- Overdue excavations report letter
- Transfer of licence letter

Changed the model to use a concept instead of a domain value list

## Test
- Reload licence model
- Import the concept list and collections from [here](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2705?milestone=418255)
- restart containers
- coral reload
- webpack rebuild
- follow tests here [#2705](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2705?milestone=418255)