### PR TITLE
Fix #2764 Minus 1 day from the valid until date

### DIFF
--- a/coral/media/js/views/components/workflows/licensing-workflow/fetch-updated-dates.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/fetch-updated-dates.js
@@ -67,6 +67,7 @@ define([
         const date = new Date(dateString);
 
         date.setMonth(date.getMonth() + 6);
+        date.setDate(date.getDate() - 1);
       
         const year = date.getFullYear();
         const month = (date.getMonth() + 1).toString().padStart(2, '0');

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=7, patch=16)
+APP_VERSION = semantic_version.Version(major=6, minor=7, patch=17)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
The valid until date was being created exactly 6 months after the issue date, 6/12/24 - 6/6/25. This needs to be one day before this - 5/6/24

## Test
- Rebuild containers
- Rebuild webpack
- Coral Reload
- Follow tests here [#2741](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2741)