### PR TITLE
Ensure Arches Plugin IDs are consistent, based on the slug (if poss.)

### DIFF
--- a/coral/permissions/casbin.py
+++ b/coral/permissions/casbin.py
@@ -213,6 +213,12 @@ class CasbinPermissionFramework(ArchesStandardPermissionFramework):
                 arches_plugins = group.arches_plugins
                 print(arches_plugins, "GAP")
                 for arches_plugin in arches_plugins:
+                    if not isinstance(arches_plugin, ArchesPlugin):
+                        try:
+                            logger.warn("A non-plugin resource was listed as an Arches plugin in a group: %s in %s", arches_plugin.id, group.id)
+                        except Exception as exc:
+                            logger.warn("A non-plugin resource was listed as an Arches plugin in a group: %s", str(exc))
+                        continue
                     print(arches_plugin, "AP")
                     try:
                         identifier = uuid.UUID(arches_plugin.plugin_identifier)

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=6, minor=9, patch=21)
+APP_VERSION = semantic_version.Version(major=7, minor=0, patch=0)
 
 GROUPINGS = {
     "groups": {

--- a/coral/utils/casbin.py
+++ b/coral/utils/casbin.py
@@ -1,5 +1,8 @@
-from arches.app.search.components.base import SearchFilterFactory
+import hashlib
+import time
+import uuid
 from urllib.parse import parse_qs
+from arches.app.search.components.base import SearchFilterFactory
 from arches.app.views.search import build_search
 from arches.app.search.elasticsearch_dsl_builder import Bool, Match, Query, Ids, Nested, Terms, MaxAgg, Aggregation, UpdateByQuery
 from arches.app.search.search_engine_factory import SearchEngineFactory
@@ -8,7 +11,10 @@ from arches.app.models.models import Plugin
 from arches.app.models.resource import Resource
 from arches_orm.models import Set, LogicalSet, ArchesPlugin
 from arches_orm.adapter import context_free
-import time
+
+def _consistent_hash(string: str):
+    hsh = hashlib.sha256(string.encode("utf-8"))
+    return uuid.UUID(hsh.hexdigest()[::2])
 
 class SetApplicator:
     def __init__(self, print_statistics, wait_for_completion):
@@ -62,9 +68,15 @@ class SetApplicator:
         plugins = {str(plugin.pk): plugin for plugin in Plugin.objects.all()}
         plugins.update({str(plugin.slug): plugin for plugin in plugins.values()})
         arches_plugins = ArchesPlugin.all()
+        for ap in arches_plugins:
+            if ap.plugin_identifier and ap.id != _consistent_hash(ap.plugin_identifier):
+                print("Found a plugin with an incorrect identifier - removing", ap.plugin_identifier, ap.id)
+                ap.delete()
+        arches_plugins = ArchesPlugin.all()
         known_plugins = set(str(plugins[str(plugin.plugin_identifier)].pk) for plugin in arches_plugins)
         known_plugins |= set(str(plugins[str(plugin.plugin_identifier)].slug) for plugin in arches_plugins)
         print(known_plugins)
+
         unknown_plugins = set(str(plugin.pk) for plugin in Plugin.objects.all()) - known_plugins
         print(unknown_plugins, "UP")
         for plugin in unknown_plugins:
@@ -72,6 +84,7 @@ class SetApplicator:
             ap = ArchesPlugin()
             ap.name = str(plugin.name) or "(unknown)"
             ap.plugin_identifier = str(plugin.slug or plugin.pk)
+            ap.id = _consistent_hash(ap.plugin_identifier)
             ap.save()
             ap._.index()
 


### PR DESCRIPTION
# BREAKING CHANGE

Ensure plugin IDs consistent, even if deletion is required. On update, this will check that every Django Plugin has a matching Arches Plugin whose UUID is consistently derived from the slug (if possible). If it finds any where it is not, the Arches Plugin will be deleted and replaced with a new Arches Plugin with a consistent UUID.

This should allow reuse of resources between instances/databases that reference Arches Plugins by ID (such as Groups), without needing to copy the Arches Plugin resources themselves.

## How to test

Running:

    docker exec -ti coral-arches_worker-1 /bin/bash -c ". ../ENV/bin/activate; celery -b \$CELERY_BROKER_URL call coral.tasks.recalculate_permissions_table"

and checking if [Add Building](http://localhost:8000/resource/61ffe499-4864-a03d-0dc9-c4075661dabc#) is present as Add Building. Try deleting it, and triggering the recalculate. It should reappear at the same URL.

**NOTE THAT** this will delete existing Arches Plugin resources so they will need to be re-added to the individual Groups.

(this should not be a breaking code change, only that the Arches Plugins will need to be readded to groups)