### PR TITLE
Feat/#2079/add new smc letters

### DIFF
--- a/coral/media/js/views/components/workflows/file-template.js
+++ b/coral/media/js/views/components/workflows/file-template.js
@@ -40,6 +40,9 @@ define([
 
     this.selectedLetterType = ko.observable();
     this.uploadedFiles = ko.observableArray();
+    this.document = ko.observable();
+    this.configKeys = ko.observable({ placeholder: 0 });
+    this.letterOptions = ko.observable(params.letterOptions)
 
     if(!ko.isObservable(this.tile.data[this.LETTER_TYPE_NODE])){
       this.tile.data[this.LETTER_TYPE_NODE] = ko.observable(this.tile.data[this.LETTER_TYPE_NODE]);
@@ -47,6 +50,11 @@ define([
     this.tile.data[this.LETTER_TYPE_NODE].subscribe((value) => {
       this.selectedLetterType(value);
     }, this);
+
+    this.document.subscribe((value) => {
+      console.log("value will be", value)
+      this.selectedLetterType(value);
+    }, this)
 
     this.retrieveFile = async () => {
       // this.loading(true);
@@ -125,7 +133,7 @@ define([
     this.saveRelationship = async (resourceId) => {
       const id = uuid.generate();
 
-      this.tile.data[this.LETTER_TYPE_NODE] = this.selectedLetterType();
+      this.tile.data[this.LETTER_TYPE_NODE] = "08bb630d-a27b-45bc-a13f-567b428018c5";
       this.tile.data[this.LETTER_METATYPE] = '956f9779-3524-448e-b2de-eabf2de95d51';
       this.tile.data[this.LETTER_RESOURCE_NODE] = [
         {
@@ -139,7 +147,7 @@ define([
       const fileTileTemplate = {
         tileid: '',
         data: {
-          [this.LETTER_TYPE_NODE]: this.selectedLetterType(),
+          [this.LETTER_TYPE_NODE]: "08bb630d-a27b-45bc-a13f-567b428018c5",
           [this.LETTER_METATYPE]: '956f9779-3524-448e-b2de-eabf2de95d51',
           [this.LETTER_RESOURCE_NODE]: [
             {

--- a/coral/plugins/scheduled-monument-consent-workflow.json
+++ b/coral/plugins/scheduled-monument-consent-workflow.json
@@ -401,40 +401,6 @@
           }
         ],
         "workflowstepclass": "workflow-form-component"
-      },
-      {
-        "name": "ea74e8cb-ce03-49c6-aeef-b5a0e62f8cdf",
-        "title": "Letter",
-        "required": false,
-        "saveWithoutProgressing": true,
-        "layoutSections": [
-          {
-            "componentConfigs": [
-              {
-                "parameters": {
-                  "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                  "resourceid": "['heritage-asset-step']['438ed643-4d7d-446b-91a8-e1d966d2504d'][0]['resourceid']['resourceInstanceId']",
-                  "hiddenNodes": ["49c65ece-f5af-11ee-9f07-0242ac170006", "218a5601-5eb9-415a-886a-c7900dc5443b"],
-                  "nodegroupid": "49c65316-f5af-11ee-9f07-0242ac170006",
-                  "semanticName": "Correspondence",
-                  "letterMetatype": "49c65b86-f5af-11ee-9f07-0242ac170006",
-                  "letterTypeNode": "49c6587a-f5af-11ee-9f07-0242ac170006",
-                  "letterResourceNode": "49c65ece-f5af-11ee-9f07-0242ac170006",
-                  "config": {
-                    "special": {
-                      "today": "today"
-                    }
-                  }
-                },
-                "noTileSidebar": true,
-                "tilesManaged": "many",
-                "componentName": "file-template",
-                "uniqueInstanceName": "letter-template"
-              }
-            ]
-          }
-        ],
-        "workflowstepclass": "workflow-form-component"
       }
     ],
     "initWorkflow": {

--- a/coral/plugins/scheduled-monument-consent-workflow.json
+++ b/coral/plugins/scheduled-monument-consent-workflow.json
@@ -349,6 +349,16 @@
                   "letterMetatype": "49c65b86-f5af-11ee-9f07-0242ac170006",
                   "letterTypeNode": "49c6587a-f5af-11ee-9f07-0242ac170006",
                   "letterResourceNode": "49c65ece-f5af-11ee-9f07-0242ac170006",
+                  "letterOptions": [
+                    { "text": "SMC Addendum Letter", "id": "smc-addendum-template.docx" },
+                    { "text": "SMC Provisional Letter", "id": "smc-provisional-template.docx"},
+                    { "text": "SMC Refusal Letter", "id": "smc-refusal-template.docx"},
+                    { "text": "SMC Final Letter", "id": "smc-final-template.docx"},
+                    { "text": "SMC Final No Conditions Letter", "id": "smc-final-no-conditions-template.docx"},
+                    { "text": "SMC Provisional No Conditions Letter", "id": "smc-provisional-no-conditions-template.docx"},
+                    { "text": "SMC-CL Provisional Letter", "id": "smc-cl-provisional-template.docx"},
+                    { "text": "SMC-CL Final Letter", "id": "smc-cl-final-template.docx"}
+                  ],
                   "config": {
                     "special": {
                       "today": "today",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=2, patch=8)
+APP_VERSION = semantic_version.Version(major=7, minor=2, patch=9)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/workflows/file-template.htm
+++ b/coral/templates/views/components/workflows/file-template.htm
@@ -305,11 +305,44 @@
             <!-- ko if: card.isFuncNode && card.isFuncNode()  -->
             <h4 class="is-function-node" data-bind="text: card.isFuncNode()"></h4>
             <!-- /ko -->
+             <!-- ko if: letterOptions -->
+            <div
+            
+          data-bind="component: {
+          name: 'domain-select-widget',
+          node: {
+            'config': {
+              'options': letterOptions,
+              'multiple': true
+            },
+          },
+          params: {
+            node: {
+            'config': {
+              'options': letterOptions,
+              'multiple': true
+              },
+              'configKeys': configKeys
+            },
+            config: {
+              'label': 'Letter Type',
+              'options': letterOptions,
+              'multiple': true
+            },
+            value: document,
+            loading: loading,
+            form: $data,
+            pageVm: $root
+          }
+      }"
+        ></div>
+        <!-- /ko -->
 
             {% endblock form_header %}
             <!-- ko if: card.showSummary() === false -->
             <!-- ko if: card.widgets().length > 0 -->
             {% block form_widgets %}
+            <!-- ko if: ! letterOptions -->
             <form class="widgets" style="margin-bottom: 20px;">
                 <div data-bind="foreach: {
                         data:card.widgets, as: 'widget'
@@ -336,6 +369,7 @@
             }, event: { mouseover: function(){ if (self.preview){widget.hovered(true) } }, mouseout: function(){ if (self.preview){widget.hovered(null)} } }, visible: widget.visible'></div>
                 </div>
             </form>
+            <!-- /ko -->
             {% endblock form_widgets %}
             <!-- /ko -->
             <!-- ko if: showChildCards -->

--- a/coral/views/file_template.py
+++ b/coral/views/file_template.py
@@ -245,8 +245,7 @@ class FileTemplateView(View):
         for key, value in list(template_dict.items()):
             if key == template_id:
                 return value
-
-        return None
+        return { "filename": template_id, "provider": GenericTemplateProvider}
 
     def edit_letter(self, resource, provider, config):
         # include = []
@@ -562,7 +561,8 @@ class GenericTemplateProvider:
             with admin():
                 person = Person.where(user_account=self.config["user"].id)
                 person = person[0] if len(person) else self.config["user"] 
-                person = person.name[0].full_name
+                # person = person["name"][0]["full_name"]
+                str(person)
         except Resource.DoesNotExist:
             person = self.config["user"]
 


### PR DESCRIPTION
This PR allows letters to be configured from the workflow meaning they can be changed, updated or added to without model or concept changes.

It also adds the addtional smc letter types as selections

Note:
`person = person.name[0].full_name` was erroring for me so I returned to str(person) It should work now that people wont be undefined. If it continues to cause problems then we will need to catch one and try the other.

To test this PR
Destroy containers
Coral reload
Check if all the smc letters are in the drop down.

This PR does not include the providing templates because I didn't want to just guess nodes for the example letters.
