### PR TITLE
fix (#2779): force grade to update after checking tiles

### DIFF
--- a/coral/media/js/views/components/workflows/evaluation-meeting-workflow/get-designation-details.js
+++ b/coral/media/js/views/components/workflows/evaluation-meeting-workflow/get-designation-details.js
@@ -46,8 +46,12 @@ define([
           const gradeData = _.filter(tile.display_values, (value) => {return value.nodeid === '6af2b696-efc5-11eb-b0b5-a87eeabdefba'})
           this.grade(gradeData[0].value !== "" ? gradeData[0].value : "None")
         }
+        if (this.grade() === "Loading...") {
+          this.grade("None")
+        }
       }
       this.prepareResource()
+
     }
   
     ko.components.register('get-designation-details', {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=2, patch=9)
+APP_VERSION = semantic_version.Version(major=7, minor=2, patch=10)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
This PR fixes the issue where buildings that do not have a grade continue to show "Loading..." in the evaluation step when they are intended to show "None" when it's determined that there is no Grade.

Test
Make 3 heritage assets, 2 buildings and one which is not a building
With one of the buildings, complete the designation workflow and ensure you add a grade.
| Test | Expectation |
--- | --- |
Select the Evaluation Meeting Workflow | should go to an open workflow page |
Observe the page | There should be 2 dropdowns, "Start New" and "Open Selected" should be disabled |
Observe the first dropdown | it should have the placeholder "Please Select the Building" |
click the drop down | should show ONLY the buildings |
Select a building | "Start New" should be enabled, "Open Selected" still disabled |
Observe the second drop down | Label should Read "Selected Evaluation Meeting", placeholder should read "Select an Evaluation Meeting or Start New" |
Click the dropdown | List should be empty |
Click "Start New" | Redirect to evaluation meeting workflow |
Copy the generated id and save | redirect to details page |
Observe HB node | Should have the building from the open workflow; should be disabled; should not have an option to remove it |
Go to the evaluation Step | there should be a widget labelled "Existing Grade"  and one labelled "Criteria" |
Observe "Existing Grade" | It should state that it is loading then show the heritage asset's grade or None |
Click "New Grade" | The options should be the same as the Grade Drop Down for heritage assets |
Click "Criteria" | The options match those listed on [taiga](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2740) |
Save workflow and return to the evaluation meeting open workflow | |
Select the same building then click the second drop down | The evaluation meeting should be present |
Select the evaluation meeting | "Open Selected" should become enabled |
Select the other building | Second drop down should clear, "Open Selected" becomes disabled |
Click the second drop down again | The dropdown should be empty |

Complete the test twice to ensure that the correct value is displayed for a building with a grade, and one without