### PR TITLE
hotfix: Show letter dropdown without letterOptions param

### DIFF
--- a/coral/templates/views/components/workflows/file-template.htm
+++ b/coral/templates/views/components/workflows/file-template.htm
@@ -305,44 +305,45 @@
             <!-- ko if: card.isFuncNode && card.isFuncNode()  -->
             <h4 class="is-function-node" data-bind="text: card.isFuncNode()"></h4>
             <!-- /ko -->
-             <!-- ko if: letterOptions -->
+            <!-- ko if: letterOptions -->
             <div
-            
-          data-bind="component: {
-          name: 'domain-select-widget',
-          node: {
-            'config': {
-              'options': letterOptions,
-              'multiple': true
-            },
-          },
-          params: {
-            node: {
-            'config': {
-              'options': letterOptions,
-              'multiple': true
-              },
-              'configKeys': configKeys
-            },
-            config: {
-              'label': 'Letter Type',
-              'options': letterOptions,
-              'multiple': true
-            },
-            value: document,
-            loading: loading,
-            form: $data,
-            pageVm: $root
-          }
-      }"
-        ></div>
-        <!-- /ko -->
+                    
+                data-bind="component: {
+                    name: 'domain-select-widget',
+                    node: {
+                        'config': {
+                            'options': letterOptions,
+                            'multiple': true,
+                        },
+                    },
+                    params: {
+                        node: {
+                        'config': {
+                            'options': letterOptions,
+                            'multiple': true,
+                        },
+                        'configKeys': configKeys
+                        },
+                        config: {
+                            'label': 'Letter Type',
+                            'options': letterOptions,
+                            'multiple': true,
+                            'placeholder': 'Select an Option'
+                        },
+                        value: document,
+                        loading: loading,
+                        form: $data,
+                        pageVm: $root
+                    }
+                }"
+            ></div>
+            <!-- /ko -->
 
             {% endblock form_header %}
             <!-- ko if: card.showSummary() === false -->
             <!-- ko if: card.widgets().length > 0 -->
             {% block form_widgets %}
-            <!-- ko if: ! letterOptions -->
+            <!-- ko if: !letterOptions()-->
             <form class="widgets" style="margin-bottom: 20px;">
                 <div data-bind="foreach: {
                         data:card.widgets, as: 'widget'


### PR DESCRIPTION
## Description
This fixes the issue that is hiding the letter options drop down.

- The letter options was pointing at an observable and was always reading it as true instead of reading the value. Unwrapped the observable
- Also added in a placeholder param when letter options are added as this was creating an error when deleting selection.
- Added some formating to the htm to improve readablility

## Test
- Rebuild containers
- Rebuild webpack
- Check the SMC workflow letters - Should see a 'Select an Option' place holder
- When clicking the drop down should see the following options:
    -  "SMC Addendum Letter"
    -  "SMC Provisional Letter"
    -  "SMC Refusal Letter"
    -  "SMC Final Letter"
    -  "SMC Final No Conditions Letter"
    -  "SMC Provisional No Conditions Letter"
    -  "SMC-CL Provisional Letter"
    -  "SMC-CL Final Letter"
- Check the licence workflow letter step - should see the drop down with the following options:
    - Excavation of Licence Letter
    - Extra Name on Licence Letter
    - Final Report Letter
    - Licence Cover Letter
    - Overdue Excavations Report Letter
    - Transfer of Licence Letter 