### PR TITLE
Fix/#2812 #2835 Planning Group and SMM Permissions

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=5, patch=13)
+APP_VERSION = semantic_version.Version(major=7, minor=5, patch=14)
 
 GROUPINGS = {
     "groups": {

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -167,7 +167,6 @@ class PlanningTaskStrategy(TaskStrategy):
             is_hm_user = groupId in [HM_GROUP] 
             is_hb_user = groupId in [HB_GROUP] 
             is_admin = groupId in [PLANNING_GROUP]
-
             resources = [] 
 
             utilities = Utilities()
@@ -230,8 +229,8 @@ class PlanningTaskStrategy(TaskStrategy):
                     action_status = utilities.node_check(lambda: consultation.action[0].action_status )
                     action_type = utilities.node_check(lambda: consultation.action[0].action_type) 
                     assigned_to_list = utilities.node_check(lambda: consultation.action[0].assigned_to_n1)
-                    
-                    user_assigned = any(assigned_to_list)
+
+                    user_assigned = any(assigned_to_list or [])
                     is_assigned_to_user = False
 
                     if assigned_to_list:

--- a/coral/views/dashboard.py
+++ b/coral/views/dashboard.py
@@ -44,7 +44,6 @@ class Dashboard(View):
         with admin():
             user_id = request.user.id                     
             person_resource = Person.where(user_account = user_id)
-            
             if not person_resource:
                 return JsonResponse({"error": "User not found"}, status=404)
             
@@ -163,7 +162,6 @@ class PlanningTaskStrategy(TaskStrategy):
             TYPE_ASSIGN_HB = '12041c21-6f30-4772-b3dc-9a9a745a7a3f'
             TYPE_ASSIGN_BOTH = '7d2b266f-f76d-4d25-87f5-b67ff1e1350f'
             COUNCIL_NODE = '69500360-d7c5-11ee-a011-0242ac120006'
-            
             is_hm_manager = groupId in [HM_MANAGER] 
             is_hb_manager = groupId in [HB_MANAGER] 
             is_hm_user = groupId in [HM_GROUP] 
@@ -231,31 +229,16 @@ class PlanningTaskStrategy(TaskStrategy):
             for consultation in planning_consultations:
                     action_status = utilities.node_check(lambda: consultation.action[0].action_status )
                     action_type = utilities.node_check(lambda: consultation.action[0].action_type) 
-                    assigned_to_list = utilities.node_check(lambda: consultation.action[0].assigned_to_n1, [])
-                    reassigned_to_tiles = utilities.node_check(lambda: consultation.assignment, [])
-
+                    assigned_to_list = utilities.node_check(lambda: consultation.action[0].assigned_to_n1)
+                    
                     user_assigned = any(assigned_to_list)
-
-                    if not user_assigned:
-                        for tile in reassigned_to_tiles:
-                            if any(tile.re_assignee.re_assigned_to):
-                                user_assigned = True
-                                break 
-
                     is_assigned_to_user = False
 
-                    # first checks reassigned to as this overwrites the assigned to field if true
-                    if reassigned_to_tiles:
-                        for tile in reassigned_to_tiles:
-                            if any(user.id == userResourceId for user in tile.re_assignee.re_assigned_to):
-                                is_assigned_to_user = True
-                                break
-                    elif assigned_to_list:
+                    if assigned_to_list:
                         is_assigned_to_user = any(user.id == userResourceId for user in assigned_to_list)
                     
                     hm_status_conditions = [STATUS_OPEN, STATUS_HB_DONE, STATUS_EXTENSION_REQUESTED]
                     hb_status_conditions = [STATUS_OPEN, STATUS_HM_DONE, STATUS_EXTENSION_REQUESTED]
-
                     conditions_for_task = (
                         (is_hm_manager and action_status in hm_status_conditions and action_type in [TYPE_ASSIGN_HM, TYPE_ASSIGN_BOTH] and (not user_assigned or is_assigned_to_user)) or
                         (is_hb_manager and action_status in hb_status_conditions and action_type in [TYPE_ASSIGN_HB, TYPE_ASSIGN_BOTH] and (not user_assigned or is_assigned_to_user)) or


### PR DESCRIPTION
## Description

This adds the permissions to the planning group users and the SMM users, limiting what workflows they can see and what resources they are able to see.

This does not limit what they are able to create and delete. The permissions for this did not work with the current implementation of permissions.

## Test
- You need to work on dev to test
- Add users into each group to test, users have been set up here - [Planning Users](https://docs.google.com/spreadsheets/d/1NTklj81mw82TI6h_wefEaljrzdIhTm0CWmMTigNuRXc/edit?gid=0#gid=0) 
- Follow the tests here - [#2812](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2812?milestone=424249) [#2835](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2835?milestone=424249)
- The dashboard fix for the users will need to be tested locally.
- Add your user to one of the HM or HB User groups
- Create a task that is assigned to the team, assigned to the user and set as Open
- This should appear in their dashboard