### PR TITLE
fix: error check list values

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=5, patch=14)
+APP_VERSION = semantic_version.Version(major=7, minor=5, patch=15)
 
 GROUPINGS = {
     "groups": {

--- a/coral/views/file_template.py
+++ b/coral/views/file_template.py
@@ -274,9 +274,10 @@ class FileTemplateView(View):
             if (isinstance(mapping[key], (bool))):
                 mapping[key] = str(mapping[key])
             if (isinstance(mapping[key], (list))):
-                mapping[key] = ", ".join(mapping[key])
+                if all(isinstance(item, str) for item in mapping[key]):
+                    mapping[key] = ", ".join(mapping[key])
             html = False
-            if htmlTags.search(mapping[key] if mapping[key] is not None else ""):
+            if htmlTags.search(str(mapping.get(key, ""))):
                 html = True
             self.replace_string(self.doc, key, mapping[key], html)
 


### PR DESCRIPTION
## Description
This is a fix for the letter generation bug that appeared for a completed Monument in the all of the workflows.
The error stemmed from the Map data being processed as a string during the mapping of the template.

## Test
- Rebuild containers
- Complete a new monument - fill out all data including a map location
- Open Designation workflow and start a new process with the monument
- Reopen the REV and navigate to the letters step
- Generate any letter
- The letter should generate without any error in the console