### PR TITLE
Fix (Heritage Asset | Heritage Asset Revision): #2917- Correct duplicated edge node ids

### DIFF
--- a/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
@@ -15286,7 +15286,7 @@
                 {
                     "description": null,
                     "domainnode_id": "2af35abc-9dee-4438-a127-c0fb69e63124",
-                    "edgeid": "448093b0-9df6-4e18-9c3d-3a8d4d61ae9c",
+                    "edgeid": "84424e48-5b6f-488f-a831-3344e201fe58",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
@@ -15367,7 +15367,7 @@
                 {
                     "description": null,
                     "domainnode_id": "0132f890-1f4c-11ef-ac74-0242ac150006",
-                    "edgeid": "3642ac0f-3893-497f-ba93-25b21dfca6e4",
+                    "edgeid": "3aa550f9-f856-4d79-82d9-10de58e2d961",
                     "graph_id": "65b1be1a-dfa4-49cf-a736-a1a88c0bb289",
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",

--- a/coral/pkg/graphs/resource_models/Heritage Asset.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset.json
@@ -15511,15 +15511,6 @@
                 },
                 {
                     "description": null,
-                    "domainnode_id": "a05d0dd0-1f4b-11ef-ac74-0242ac150006",
-                    "edgeid": "3642ac0f-3893-497f-ba93-25b21dfca6e4",
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P19i_was_made_for",
-                    "rangenode_id": "fa70c068-3ea5-11ef-9023-0242ac140007"
-                },
-                {
-                    "description": null,
                     "domainnode_id": "de6b6af0-44e3-11ef-9114-0242ac120006",
                     "edgeid": "95a65ca1-7040-4cff-aacd-661af05c9c8a",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=6, patch=18)
+APP_VERSION = semantic_version.Version(major=7, minor=6, patch=19)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description

The 2 models shared an edge node id for one of the nodes. This was causing export issues for which ever model was loaded first.