### PR TITLE
Fix/#2935 fix report layout

### DIFF
--- a/coral/media/js/views/components/reports/activity.js
+++ b/coral/media/js/views/components/reports/activity.js
@@ -25,36 +25,36 @@ define([
                 id: 'activity',
                 label: 'Activity',
                 ignoreNodes: []
-            }
+            };
 
             Object.assign(self, reportUtils);
             self.sections = [
-                {id: 'name', title: 'Names and Identifiers'},
-                {id: 'description', title: 'Descriptions and Citations'},
-                {id: 'classifications', title: 'Classifications and Dating'},
-                {id: 'location', title: 'Location Data'},
-                {id: 'protection', title: 'Designation and Protection Status'},
-                {id: 'archive', title: 'Archive Holding'},
-                {id: 'people', title: 'Associated People and Organizations'},
-                {id: 'resources', title: 'Associated Resources'},
                 {id: 'all', title: 'Full Report'},
-                {id: 'json', title: 'JSON'},
+                {id: 'name', title: 'Names and Identifiers'},
+                {id: 'location', title: 'Location Data'},
+                {id: 'resources', title: 'Associated Resources'},
+                // {id: 'description', title: 'Descriptions and Citations'},
+                // {id: 'classifications', title: 'Classifications and Dating'},
+                // {id: 'protection', title: 'Designation and Protection Status'},
+                // {id: 'archive', title: 'Archive Holding'},
+                // {id: 'people', title: 'Associated People and Organizations'},
+                // {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.activityArchive = ko.observableArray();
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
-            self.activeSection = ko.observable('name');
+            self.activeSection = ko.observable('all');
 
             self.activityArchiveConfig = {
                 ...self.defaultTableConfig,
                 columns: Array(5).fill(null)
-            }
+            };
 
             self.descriptionDataConfig = {
                 descriptions: 'activity descriptions',
                 citation: 'bibliographic source citation'
-            }
+            };
 
             self.nameDataConfig = {
                 name: 'activity',
@@ -76,7 +76,7 @@ define([
                 files: 'digital files',
                 assets: 'associated monuments and areas',
                 actors: undefined
-            }
+            };
 
             self.cards = {};
             self.nameCards = {};
@@ -89,9 +89,9 @@ define([
             self.summary = params.summary;
             self.visible = {
                 activityArchive: ko.observable(true)
-            }
+            };
 
-            const activityArchiveNode = self.getRawNodeValue(self.resource(), 'activity archive material')
+            const activityArchiveNode = self.getRawNodeValue(self.resource(), 'activity archive material');
             if(Array.isArray(activityArchiveNode)){
                 self.activityArchive(activityArchiveNode.map(node => {
                     const type = self.getNodeValue(node, 'archive material', 'archive source type');
@@ -114,7 +114,7 @@ define([
             if(params.report.cards){
                 const cards = params.report.cards;
 
-                self.cards = self.createCardDictionary(cards)
+                self.cards = self.createCardDictionary(cards);
 
                 Object.assign(self.cards, {
                     activityArchive: self.cards?.['activity archive material']
@@ -141,7 +141,7 @@ define([
                             namedLocations: 'named locations'
                         }
                     }
-                }
+                };
 
                 Object.assign(self.protectionCards, self.locationCards);
 
@@ -165,7 +165,7 @@ define([
                     archive: self.cards?.['associated archive objects'],
                     assets: self.cards?.['associated monuments and areas'],
                     files: self.cards?.['associated digital files'],
-                }
+                };
             }
 
         },

--- a/coral/media/js/views/components/reports/activity.js
+++ b/coral/media/js/views/components/reports/activity.js
@@ -32,7 +32,7 @@ define([
                 {id: 'all', title: 'Full Report'},
                 {id: 'name', title: 'Names and Identifiers'},
                 {id: 'location', title: 'Location Data'},
-                {id: 'resources', title: 'Associated Resources'},
+                {id: 'related', title: 'Related Resources'},
                 // {id: 'description', title: 'Descriptions and Citations'},
                 // {id: 'classifications', title: 'Classifications and Dating'},
                 // {id: 'protection', title: 'Designation and Protection Status'},

--- a/coral/media/js/views/components/reports/consultation.js
+++ b/coral/media/js/views/components/reports/consultation.js
@@ -7,7 +7,7 @@ define([
     'utils/report',
     'templates/views/components/reports/consultation.htm',
     'views/components/reports/scenes/name',
-    'views/components/reports/scenes/json'
+    'views/components/reports/scenes/resources'
 ], function($, _, ko, arches, resourceUtils, reportUtils, consultationReportTemplate) {
     return ko.components.register('consultation-report', {
         viewModel: function(params) {
@@ -19,21 +19,22 @@ define([
 
             Object.assign(self, reportUtils);
             self.sections = [
+                {id: 'all', title: 'Full Report'},
                 {id: 'details', title: 'Consultation Details'},
                 {id: 'location', title: 'Location Data'},
-                {id: 'references', title: 'Planning References'},
-                {id: 'contacts', title: 'Contacts'},
-                {id: 'progression', title: 'Consultation Progression'},
-                {id: 'correspondence', title: 'Correspondence'},
-                {id: 'sitevisits', title: 'Site Visits'},
                 {id: 'resources', title: 'Associated Resources'},
-                {id: 'all', title: 'Full Report'},
-                {id: 'json', title: 'JSON'},
+                // {id: 'references', title: 'Planning References'},
+                // {id: 'contacts', title: 'Contacts'},
+                // {id: 'progression', title: 'Consultation Progression'},
+                // {id: 'correspondence', title: 'Correspondence'},
+                // {id: 'sitevisits', title: 'Site Visits'},
+                
+                // {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
-            self.activeSection = ko.observable('details');
+            self.activeSection = ko.observable('all');
 
             self.nameDataConfig = {
                 name: 'consultation',
@@ -50,19 +51,22 @@ define([
             };
 
             self.locationDataConfig = {
-                location: ['Consultation Area'],
-                addresses: undefined,
-                locationDescription: undefined,
+                location: ['location data'],
+                addresses: 'addresses',
+                nationalGrid: 'national grid references',
+                locationDescription: 'location descriptions',
                 administrativeAreas: 'localities/administrative areas',
-                nationalGrid: undefined,
-                namedLocations: undefined
-            }
+                geometry: 'geometry',
+                namedLocations: 'named locations',
+            };
 
             self.resourcesDataConfig = {
-                assets: 'related monuments and areas',
-                files: 'file(s)',
-                relatedApplicationArea: 'consultation area',
-                actors: undefined
+                activities: 'associated activities',
+                consultations: 'associated consultations',
+                files: 'associated files',
+                assets: 'associated monuments and areas',
+                archive: 'associated archives',
+                actors: 'associated actors'
             };
 
             self.nameCards = {};
@@ -86,21 +90,21 @@ define([
                 action: ko.observable(true),
                 outcomes: ko.observable(true),
                 assessmentOfSignificance: ko.observable(true),
-            }
+            };
 
             self.createTableConfig = function(col) {
                 return {
                     ...self.defaultTableConfig,
                     columns: Array(col).fill(null)
                 };
-            }
+            };
 
             self.proposalTableConfig = {
                 ...self.defaultTableConfig,
                 "columns": [
                     { "width": "50%" },
                     { "width": "40%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -109,7 +113,7 @@ define([
                 "columns": [
                     { "width": "70%" },
                     { "width": "20%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -120,7 +124,7 @@ define([
                     { "width": "50%" },
                     { "width": "20%" },
                     { "width": "20%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -129,7 +133,7 @@ define([
                 "columns": [
                     { "width": "45%" },
                     { "width": "45%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -138,7 +142,7 @@ define([
                 "columns": [
                     { "width": "70%" },
                     { "width": "20%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -148,7 +152,7 @@ define([
                 "columns": [
                     { "width": "70%" },
                     { "width": "20%" },
-                   null,
+                    null,
                 ]
             };
 
@@ -183,7 +187,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {reference, source, note, noteDescType, url, urlLabel, tileid};
                 }));
-            };
+            }
 
             const systemReferencesNode = self.getRawNodeValue(self.resource(), 'references');
             if(Array.isArray(systemReferencesNode)){
@@ -195,7 +199,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {reference, referenceType, agency, agencyLink, tileid};
                 }));
-            };
+            }
 
             const correspondenceNode = self.getRawNodeValue(self.resource(), 'correspondence');
             if(Array.isArray(correspondenceNode)){
@@ -206,7 +210,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {letter, letterLink, letterType, tileid};
                 }));
-            };
+            }
 
             const proposalNode = self.getRawNodeValue(self.resource(), 'proposal');
             if(Array.isArray(proposalNode)){
@@ -217,7 +221,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {proposal, file, fileLink, tileid};
                 }));
-            };
+            }
 
             const adviceNode = self.getRawNodeValue(self.resource(), 'advice');
             if(Array.isArray(adviceNode)){
@@ -227,7 +231,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {advice, adviceType, tileid};
                 }));
-            };
+            }
 
             const actionNode = self.getRawNodeValue(self.resource(), 'action');
             if(Array.isArray(actionNode)){
@@ -238,7 +242,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {action, actionType, relatedAdvice, tileid};
                 }));
-            };
+            }
 
             const outcomesNode = self.getRawNodeValue(self.resource(), 'outcomes');
             if(outcomesNode){
@@ -246,7 +250,7 @@ define([
                 const auditOutcome = self.getNodeValue(outcomesNode, 'audit outcome');
                 const tileid = self.getTileId(outcomesNode);
                 self.outcomes({planningOutcome, auditOutcome, tileid});
-            };
+            }
 
             const assessmentOfSignificanceNode = self.getRawNodeValue(self.resource(), 'assessment of significance');
             if(Array.isArray(assessmentOfSignificanceNode)){
@@ -255,7 +259,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {notes, tileid};
                 }));
-            };
+            }
 
             const communicationsNode = self.getRawNodeValue(self.resource(), 'communications');
             if(Array.isArray(communicationsNode)){
@@ -272,7 +276,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {subject, type, date, attendees, note, followOnAction, relatedCondition, digitalFile, digitalFileLink, tileid};
                 }));
-            };
+            }
 
             const siteVisitsNode = self.getRawNodeValue(self.resource(), 'site visits');
             if(Array.isArray(siteVisitsNode)){
@@ -320,7 +324,7 @@ define([
                     const tileid = self.getTileId(node);
                     return {dateOfVisit, location, attendees, observations, recommendations, photographs, tileid};
                 }));
-            };
+            }
 
             const contactNode = self.getRawNodeValue(self.resource(), 'contacts');
             if(contactNode){
@@ -359,14 +363,14 @@ define([
 
                 self.contacts(
                     { consultingContact, planningOfficer, planningOfficerLink, planningBody, planningBodyLink, caseworkOfficer, caseworkOfficerLink, agents, owners, applicants, tileid }
-                )
-            };
+                );
+            }
 
             if(params.report.cards){
                 const cards = params.report.cards;
-
-                self.cards = self.createCardDictionary(cards)
-
+                
+                self.cards = self.createCardDictionary(cards);
+                
                 self.siteVisitSubCards = self.createCardDictionary(self.cards['site visits'].cards());
 
                 self.nameCards = {
@@ -394,7 +398,7 @@ define([
                     files: self.cards?.['associated digital files'],
                     relatedApplicationArea: self.cards?.['consultation location']
                 };
-            };
+            }
 
             self.consultationLocationDescription = ko.observable({
                 sections:

--- a/coral/media/js/views/components/reports/consultation.js
+++ b/coral/media/js/views/components/reports/consultation.js
@@ -22,7 +22,7 @@ define([
                 {id: 'all', title: 'Full Report'},
                 {id: 'details', title: 'Consultation Details'},
                 {id: 'location', title: 'Location Data'},
-                {id: 'resources', title: 'Associated Resources'},
+                {id: 'related', title: 'Related Resources'},
                 // {id: 'references', title: 'Planning References'},
                 // {id: 'contacts', title: 'Contacts'},
                 // {id: 'progression', title: 'Consultation Progression'},

--- a/coral/media/js/views/components/reports/digital-object.js
+++ b/coral/media/js/views/components/reports/digital-object.js
@@ -23,6 +23,7 @@ define([
                 {id: 'all', title: 'Full Report'},
                 {id: 'file', title: 'File Details'},
                 {id: 'name', title: 'Names and Identifiers'},
+                {id:'related', title: 'Related Resources'}
                 // {id: 'publication', title: 'Publication Details'},
                 // {id: 'json', title: 'JSON'},
             ];

--- a/coral/media/js/views/components/reports/digital-object.js
+++ b/coral/media/js/views/components/reports/digital-object.js
@@ -20,16 +20,16 @@ define([
 
             Object.assign(self, reportUtils);
             self.sections = [
-                {id: 'name', title: 'Names and Identifiers'},
-                {id: 'publication', title: 'Publication Details'},
-                {id: 'file', title: 'File Details'},
                 {id: 'all', title: 'Full Report'},
-                {id: 'json', title: 'JSON'},
+                {id: 'file', title: 'File Details'},
+                {id: 'name', title: 'Names and Identifiers'},
+                // {id: 'publication', title: 'Publication Details'},
+                // {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
-            self.activeSection = ko.observable('name');
+            self.activeSection = ko.observable('all');
 
             self.nameDataConfig = {};
 
@@ -41,19 +41,19 @@ define([
 
             self.visible = {
                 files: ko.observable(true),
-            }
+            };
 
             self.createTableConfig = function(col) {
                 return {
                     ...self.defaultTableConfig,
                     columns: Array(col).fill(null)
                 };
-            }
+            };
 
             if(params.report.cards){
                 const cards = params.report.cards;
                 
-                self.cards = self.createCardDictionary(cards)
+                self.cards = self.createCardDictionary(cards);
 
                 self.nameCards = {
                     name: self.cards?.['names'],
@@ -67,7 +67,7 @@ define([
 
                 self.copyrightCards = {
                     copyright: self.cards?.['copyright']
-                }
+                };
             }
 
             self.files = ko.observableArray();
@@ -81,7 +81,7 @@ define([
                     const link = self.getNodeValue(node, 'url');
                     return {name, link, tileid};
                 }));
-            };
+            }
 
             self.fileData = ko.observable({
                 sections:

--- a/coral/media/js/views/components/reports/heritage-asset.js
+++ b/coral/media/js/views/components/reports/heritage-asset.js
@@ -23,7 +23,7 @@ define([
                 {id: 'all', title: 'Full Report'},
                 {id: 'name', title: 'Names and Identifiers'},
                 {id: 'location', title: 'Location Data'},
-                {id: 'resources', title: 'Associated Resources'},
+                {id: 'related', title: 'Related Resources'},
                 // {id: 'description', title: 'Descriptions and Citations'},
                 // {id: 'classifications', title: 'Classifications and Dating'},
                 // {id: 'protection', title: 'Designation and Protection Status'},

--- a/coral/media/js/views/components/reports/heritage-asset.js
+++ b/coral/media/js/views/components/reports/heritage-asset.js
@@ -20,22 +20,22 @@ define([
 
             Object.assign(self, reportUtils);
             self.sections = [
-                {id: 'name', title: 'Names and Identifiers'},
-                {id: 'description', title: 'Descriptions and Citations'},
-                {id: 'classifications', title: 'Classifications and Dating'},
-                {id: 'location', title: 'Location Data'},
-                {id: 'protection', title: 'Designation and Protection Status'},
-                {id: 'assessments', title: 'Assessments'},
-                {id: 'images', title: 'Images'},
-                {id: 'people', title: 'Associated People and Organizations'},
-                {id: 'resources', title: 'Associated Resources'},
                 {id: 'all', title: 'Full Report'},
-                {id: 'json', title: 'JSON'},
+                {id: 'name', title: 'Names and Identifiers'},
+                {id: 'location', title: 'Location Data'},
+                {id: 'resources', title: 'Associated Resources'},
+                // {id: 'description', title: 'Descriptions and Citations'},
+                // {id: 'classifications', title: 'Classifications and Dating'},
+                // {id: 'protection', title: 'Designation and Protection Status'},
+                // {id: 'assessments', title: 'Assessments'},
+                // {id: 'images', title: 'Images'},
+                // {id: 'people', title: 'Associated People and Organizations'},
+                // {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
-            self.activeSection = ko.observable('name');
+            self.activeSection = ko.observable('all');
 
             self.nameDataConfig = {
                 name: 'heritage asset',
@@ -57,7 +57,7 @@ define([
                 activities: 'associated activities',
                 files: 'digital file(s)',
                 actors: undefined
-            }
+            };
 
             self.nameCards = {};
             self.descriptionCards = {};
@@ -71,24 +71,20 @@ define([
             self.summary = params.summary;
             self.cards = {};
 
-            self.resource = ko.observable(self.resource())
-            console.log(self.resource())
+            self.resource = ko.observable(self.resource());
 
             self.fullReportConfig = {
                 id: 'heritage-asset',
                 label: 'Heritage Asset',
                 ignoreNodes: []
-            }
+            };
 
             
 
             if(params.report.cards){
-                console.log("report cards")
                 const cards = params.report.cards;
 
-                self.cards = self.createCardDictionary(cards)
-                console.log("cards", cards)
-                console.log("card dict", self.cards)
+                self.cards = self.createCardDictionary(cards);
 
                 self.nameCards = {
                     name: self.cards?.['heritage asset names'],
@@ -96,7 +92,7 @@ define([
                     systemReferenceNumbers: self.cards?.['system reference numbers'],
                     parent: self.cards?.['parent assets'],
                 };
-                console.log("Heres the cards", self.cards)
+
                 self.descriptionCards = {
                     descriptions: self.cards?.['descriptions'],
                     citation: self.cards?.['bibliographic source citation']
@@ -114,7 +110,7 @@ define([
 
                 self.imagesCards = {
                     images: self.cards?.['photographs']
-                }
+                };
 
                 self.peopleCards = {
                     people: self.cards?.['associated people and organizations']
@@ -141,7 +137,7 @@ define([
                             namedLocations: 'named locations'
                         }
                     }
-                }
+                };
 
                 self.protectionCards = {
                     designations: self.cards?.['designation and protection assignment']

--- a/coral/media/js/views/components/reports/heritage-asset.js
+++ b/coral/media/js/views/components/reports/heritage-asset.js
@@ -23,6 +23,7 @@ define([
                 {id: 'all', title: 'Full Report'},
                 {id: 'name', title: 'Names and Identifiers'},
                 {id: 'location', title: 'Location Data'},
+                {id: 'issue', title: 'Issue Reports'},
                 {id: 'related', title: 'Related Resources'},
                 // {id: 'description', title: 'Descriptions and Citations'},
                 // {id: 'classifications', title: 'Classifications and Dating'},
@@ -36,6 +37,8 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('all');
+
+            self.issueNodeGroups = ['d3ff3fe6-d62b-11ee-9454-0242ac180006'];
 
             self.nameDataConfig = {
                 name: 'heritage asset',

--- a/coral/media/js/views/components/reports/licence.js
+++ b/coral/media/js/views/components/reports/licence.js
@@ -21,7 +21,7 @@ define([
             self.sections = [
                 {id: 'all', title: 'Full Report'},
                 {id: 'name', title: 'Names and Identifiers'},
-                {id: 'resources', title: 'Associated Resources'},
+                {id: 'related', title: 'Related Resources'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);

--- a/coral/media/js/views/components/reports/licence.js
+++ b/coral/media/js/views/components/reports/licence.js
@@ -1,39 +1,78 @@
 define([
-  'jquery',
-  'underscore',
-  'knockout',
-  'arches',
-  'utils/resource',
-  'utils/report',
-  'templates/views/components/reports/licence.htm',
-  'views/components/reports/scenes/name',
-  'views/components/reports/scenes/json'
+    'jquery',
+    'underscore',
+    'knockout',
+    'arches',
+    'utils/resource',
+    'utils/report',
+    'templates/views/components/reports/licence.htm',
+    'views/components/reports/scenes/name',
+    'views/components/reports/scenes/json'
 ], function($, _, ko, arches, resourceUtils, reportUtils, historicLandscapeCharacterizationReportTemplate) {
-  return ko.components.register('licence-report', {
-      viewModel: function(params) {
-          var self = this;
-          params.configKeys = ['tabs', 'activeTabIndex'];
-          this.configForm = params.configForm || false;
-          this.configType = params.configType || 'header';
-          this.report = params.report;
+    return ko.components.register('licence-report', {
+        viewModel: function(params) {
+            var self = this;
+            params.configKeys = ['tabs', 'activeTabIndex'];
+            this.configForm = params.configForm || false;
+            this.configType = params.configType || 'header';
+            this.report = params.report;
 
-          Object.assign(self, reportUtils);
-          self.sections = [
-              {id: 'all', title: 'Full Report'},
-          ];
-          self.reportMetadata = ko.observable(params.report?.report_json);
-          self.resource = ko.observable(self.reportMetadata()?.resource);
-          self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
-          self.activeSection = ko.observable('all');
-          self.historicLandscapeClassificationPhase = ko.observableArray();
-          self.print = ko.observable(window.location.href.indexOf("?print") > -1)
+            Object.assign(self, reportUtils);
+            self.sections = [
+                {id: 'all', title: 'Full Report'},
+                {id: 'name', title: 'Names and Identifiers'},
+                {id: 'resources', title: 'Associated Resources'},
+            ];
+            self.reportMetadata = ko.observable(params.report?.report_json);
+            self.resource = ko.observable(self.reportMetadata()?.resource);
+            self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
+            self.activeSection = ko.observable('all');
+            self.historicLandscapeClassificationPhase = ko.observableArray();
+            self.print = ko.observable(window.location.href.indexOf("?print") > -1);
 
-          self.fullReportConfig = {
-              id: 'historic-landscape-characterization',
-              label: 'Historic Landscape Characterization',
-              ignoreNodes: []
-          }
-      },
-      template: historicLandscapeCharacterizationReportTemplate
-  });
+            self.nameDataConfig = {
+                name: 'licence',
+                parent: 'parent_licence',
+                recordStatus: 'record_status_assignment'
+            };
+
+            self.resourcesDataConfig = {
+                archive: 'associated archive objects',
+                files: 'digital files',
+                assets: 'associated monuments and areas',
+                actors: undefined
+            };
+
+            self.cards = {};
+            self.nameCards = {};
+
+            if(params.report.cards){
+                const cards = params.report.cards;
+
+                self.cards = self.createCardDictionary(cards);
+
+                self.nameCards = {
+                    name: self.cards?.['licence names'],
+                    // externalCrossReferences: self.cards?.['external cross references'],
+                    // systemReferenceNumbers: self.cards?.['system reference numbers'],
+                    // parent: self.cards?.['parent activities'],
+                    // recordStatus: self.cards?.['record status']
+                };
+
+                self.resourcesCards = {
+                    consultations: self.cards?.['associated consultations'],
+                    activities: self.cards?.['associated activities'],
+                    archive: self.cards?.['associated archive objects'],
+                    assets: self.cards?.['associated monuments and areas'],
+                    files: self.cards?.['associated digital files'],
+                };
+            }
+            self.fullReportConfig = {
+                id: 'historic-landscape-characterization',
+                label: 'Historic Landscape Characterization',
+                ignoreNodes: []
+            };
+        },
+        template: historicLandscapeCharacterizationReportTemplate
+    });
 });

--- a/coral/media/js/views/components/reports/organization.js
+++ b/coral/media/js/views/components/reports/organization.js
@@ -17,7 +17,7 @@ define([
             this.configForm = params.configForm || false;
             this.configType = params.configType || 'header';
             this.report = params.report;
-            this.summary = params.summary
+            this.summary = params.summary;
 
             Object.assign(self, reportUtils);
             self.sections = [
@@ -35,6 +35,17 @@ define([
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
             self.activeSection = ko.observable('name');
+
+            self.fullReportConfig = {
+                id: 'organization',
+                label: 'Organization',
+                summaryNodeGroups: [
+                    "e8431c5d-8098-11ea-8348-f875a44e0e11",
+                    "af3b0116-29a9-11eb-8333-f875a44e0e11",
+                    "1b6f9cb4-51ae-11eb-a1fe-f875a44e0e11"
+                ],
+                ignoreNodes: []
+            };
 
             self.nameDataConfig = {
                 name: 'names',
@@ -79,7 +90,7 @@ define([
             if(params.report.cards){
                 const cards = params.report.cards;
 
-                self.cards = self.createCardDictionary(cards)
+                self.cards = self.createCardDictionary(cards);
 
                 self.nameCards = {
                     name: self.cards?.names,

--- a/coral/media/js/views/components/reports/person.js
+++ b/coral/media/js/views/components/reports/person.js
@@ -22,22 +22,22 @@ define([
               }
             Object.assign(self, reportUtils);
             self.sections = [
-                {id: 'name', title: 'Names and Classifications'},
+                {id: 'all', title: 'Full Report'},
                 {id: 'person-name', title: 'Person Name and Identifiers'},
                 {id: 'user-account', title: 'User Account'},
-                {id: 'description', title: 'Descriptions and Citations'},
-                {id: 'location', title: 'Location Data'},
-                {id: 'images', title: 'Images'},
-                {id: 'people', title: 'Associated People and Organizations'},
-                {id: 'contact', title: 'Biography and Contact Details'},
                 {id: 'resources', title: 'Associated Resources'},
-                {id: 'all', title: 'Full Report'},
-                {id: 'json', title: 'JSON'},
+                // {id: 'name', title: 'Names and Classifications'},
+                // {id: 'description', title: 'Descriptions and Citations'},
+                // {id: 'location', title: 'Location Data'},
+                // {id: 'images', title: 'Images'},
+                // {id: 'people', title: 'Associated People and Organizations'},
+                // {id: 'contact', title: 'Biography and Contact Details'},
+                // {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);
             self.resource = ko.observable(self.reportMetadata()?.resource);
             self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
-            self.activeSection = ko.observable('name');
+            self.activeSection = ko.observable('all');
             self.names = ko.observableArray();
 
             self.fullReportConfig = {
@@ -151,8 +151,8 @@ define([
 
                 self.peopleCards = {
                     people: self.cards?.['associated people and organizations']
-                };
-
+                }
+                
                 self.locationCards = {
                     cards: self.cards,
                     location: {
@@ -171,7 +171,7 @@ define([
                     activities: self.cards?.['associated activities'],
                     consultations: self.cards?.['associated consultations'],
                     files: self.cards?.['associated digital file(s)'],
-                    assets: self.cards?.['associated monuments, areas and artefacts']
+                    assets: self.cards?.['associated heritage assets, areas and artefacts']
                 };
             }
 

--- a/coral/media/js/views/components/reports/person.js
+++ b/coral/media/js/views/components/reports/person.js
@@ -25,7 +25,7 @@ define([
                 {id: 'all', title: 'Full Report'},
                 {id: 'person-name', title: 'Person Name and Identifiers'},
                 {id: 'user-account', title: 'User Account'},
-                {id: 'resources', title: 'Associated Resources'},
+                {id: 'related', title: 'Related Resources'},
                 // {id: 'name', title: 'Names and Classifications'},
                 // {id: 'description', title: 'Descriptions and Citations'},
                 // {id: 'location', title: 'Location Data'},
@@ -152,7 +152,7 @@ define([
                 self.peopleCards = {
                     people: self.cards?.['associated people and organizations']
                 }
-                
+
                 self.locationCards = {
                     cards: self.cards,
                     location: {

--- a/coral/media/js/views/components/reports/scenes/all.js
+++ b/coral/media/js/views/components/reports/scenes/all.js
@@ -32,8 +32,8 @@ define([
             
             ReportViewModel.apply(this, [params]);
 
-            this.relatedResources = Object.values(this.report.relatedResourcesLookup())
-            this.hasRelatedResources = this.relatedResources.some(resource => resource.totalRelatedResources > 1);
+            this.relatedResources = Object.values(this.report.relatedResourcesLookup());
+            this.hasRelatedResources = this.relatedResources.some(resource => resource.totalRelatedResources > 0);
             this.viewableCards = ko.observable(this.report.cards);
 
             if (this.nodeGroups?.length > 0) {

--- a/coral/media/js/views/components/reports/scenes/all.js
+++ b/coral/media/js/views/components/reports/scenes/all.js
@@ -22,13 +22,26 @@ define([
                 "preload_resource_data": true,
                 "templateid": "50000000-0000-0000-0000-000000000001"
             };
+    
+            this.nodeGroups = params.nodeGroups ?? null;
+            this.hiddenNodes = params.hideNodes ?? null;
+            this.showCards = params.showCards ?? true;
+            this.showRelated = params.showRelated ?? true;
 
             params.report.hideEmptyNodes = true;
 
             ReportViewModel.apply(this, [params]);
 
-            this.showCards = params.showCards ?? true;
-            this.showRelated = params.showRelated ?? true;
+            this.viewableCards = ko.observable(this.report.cards);
+
+            if (this.nodeGroups?.length > 0) {
+                this.viewableCards = this.report.cards.filter(card => {
+                    return this.nodeGroups.includes(card.nodegroupid);
+                });
+            }
+            else {
+                this.viewableCards = this.report.cards;
+            }
         },
         template: allReportTemplate
     });

--- a/coral/media/js/views/components/reports/scenes/all.js
+++ b/coral/media/js/views/components/reports/scenes/all.js
@@ -29,9 +29,11 @@ define([
             this.showRelated = params.showRelated ?? true;
 
             params.report.hideEmptyNodes = true;
-
+            
             ReportViewModel.apply(this, [params]);
 
+            this.relatedResources = Object.values(this.report.relatedResourcesLookup())
+            this.hasRelatedResources = this.relatedResources.some(resource => resource.totalRelatedResources > 1);
             this.viewableCards = ko.observable(this.report.cards);
 
             if (this.nodeGroups?.length > 0) {

--- a/coral/media/js/views/components/reports/scenes/all.js
+++ b/coral/media/js/views/components/reports/scenes/all.js
@@ -1,32 +1,35 @@
 define([
-  'underscore',
-  'knockout',
-  'arches',
-  'utils/report',
-  'views/components/workflows/summary-step',
-  'views/components/resource-report-abstract',
-  'viewmodels/report', 
-  'templates/views/components/reports/scenes/all.htm',
-  'bindings/datatable',
-  'views/components/workflows/render-nodes',
-], function (_, ko, arches, reportUtils, SummaryStep, resourceReportAbstract, ReportViewModel, allReportTemplate) {
-  return ko.components.register('views/components/reports/scenes/all', {
-    viewModel: function (params) {
-      params.report.template = {
-        "component": "reports/default",
-        "componentname": "default-report",
-        "defaultconfig": {},
-        "defaultconfig_json": "{}",
-        "description": "Default Template",
-        "name": "No Header Template",
-        "preload_resource_data": true,
-        "templateid": "50000000-0000-0000-0000-000000000001"
-      }
+    'underscore',
+    'knockout',
+    'arches',
+    'utils/report',
+    'views/components/workflows/summary-step',
+    'views/components/resource-report-abstract',
+    'viewmodels/report', 
+    'templates/views/components/reports/scenes/all.htm',
+    'bindings/datatable',
+    'views/components/workflows/render-nodes',
+], function(_, ko, arches, reportUtils, SummaryStep, resourceReportAbstract, ReportViewModel, allReportTemplate) {
+    return ko.components.register('views/components/reports/scenes/all', {
+        viewModel: function(params) {
+            params.report.template = {
+                "component": "reports/default",
+                "componentname": "default-report",
+                "defaultconfig": {},
+                "defaultconfig_json": "{}",
+                "description": "Default Template",
+                "name": "No Header Template",
+                "preload_resource_data": true,
+                "templateid": "50000000-0000-0000-0000-000000000001"
+            };
 
-      params.report.hideEmptyNodes = true;
+            params.report.hideEmptyNodes = true;
 
-      ReportViewModel.apply(this, [params])
-    },
-    template: allReportTemplate
-  });
+            ReportViewModel.apply(this, [params]);
+
+            this.showCards = params.showCards ?? true;
+            this.showRelated = params.showRelated ?? true;
+        },
+        template: allReportTemplate
+    });
 });

--- a/coral/media/js/views/components/reports/scenes/name.js
+++ b/coral/media/js/views/components/reports/scenes/name.js
@@ -14,9 +14,7 @@ define([
             self.nameTableConfig = {
                 ...self.defaultTableConfig,
                 "columns": [
-                    { "width": "50%" },
-                    { "width": "20%" },
-                    { "width": "20%" },
+                    { "width": "100%" },
                    null,
                 ]
             };
@@ -159,8 +157,8 @@ define([
             if(systemRefData) {
                 const systemRef = {};
                 systemRef.resourceId = self.getNodeValue(systemRefData, 'uuid', 'resourceid');
-                systemRef.legacyId = self.getNodeValue(systemRefData, 'legacyid', 'legacy id');
-                systemRef.primaryReferenceNumber = self.getNodeValue(systemRefData, 'primaryreferencenumber', 'primary reference number');
+                // systemRef.legacyId = self.getNodeValue(systemRefData, 'legacyid', 'legacy id');
+                // systemRef.primaryReferenceNumber = self.getNodeValue(systemRefData, 'primaryreferencenumber', 'primary reference number');
                 systemRef.tileid = self.getTileId(systemRefData);
                 self.systemReferenceNumbers(systemRef);
             }

--- a/coral/media/js/views/components/reports/scenes/resources.js
+++ b/coral/media/js/views/components/reports/scenes/resources.js
@@ -14,18 +14,18 @@ define([
             //Related Resource 2 column table configuration
             self.relatedResourceTwoColumnTableConfig = {
                 ...self.defaultTableConfig,
-                paging: true,
-                searching: true,
+                paging: false,
+                searching: false,
                 scrollY: "250px",
                 columns: Array(2).fill(null)
             };
 
-
+            console.log("PARAMS", params)
             //Related Resource 2 column table configuration
             self.archiveHolderTableConfig = {
                 ...self.defaultTableConfig,
-                paging: true,
-                searching: true,
+                paging: false,
+                searching: false,
                 scrollY: "250px",
                 columns: Array(4).fill(null)
             };
@@ -34,8 +34,8 @@ define([
             //Related Resource 3 column table configuration
             self.relatedResourceThreeColumnTableConfig = {
                 ...self.defaultTableConfig,
-                paging: true,
-                searching: true,
+                paging: false,
+                searching: false,
                 scrollY: "250px",
                 columns: Array(3).fill(null)
             };

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=6, patch=20)
+APP_VERSION = semantic_version.Version(major=7, minor=6, patch=21)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/reports/activity.htm
+++ b/coral/templates/views/components/reports/activity.htm
@@ -90,13 +90,13 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <!-- Related Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'related'">
                 <div data-bind="component: {
-                    name: 'views/components/reports/scenes/resources',
+                    name: 'views/components/reports/scenes/all',
                     params: {
-                        data: resource,
-                        cards: resourcesCards,
-                        dataConfig: resourceDataConfig
+                        report: $data.report,
+                        showCards: false
                     }
                 }"></div>
             </div>

--- a/coral/templates/views/components/reports/consultation.htm
+++ b/coral/templates/views/components/reports/consultation.htm
@@ -61,12 +61,6 @@
             <!-- Location Tab -->
             <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
                 <div data-bind="component: {
-                    name: 'views/components/reports/scenes/default',
-                    params: {
-                        data: consultationLocationDescription,
-                    }
-                }"></div>
-                <div data-bind="component: {
                     name: 'views/components/reports/scenes/location',
                     params: {
                         data: resource,

--- a/coral/templates/views/components/reports/consultation.htm
+++ b/coral/templates/views/components/reports/consultation.htm
@@ -780,14 +780,13 @@
                     <!-- /ko -->
                 </div>
             </div>
-            <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <!-- Related Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'related'">
                 <div data-bind="component: {
-                    name: 'views/components/reports/scenes/resources',
+                    name: 'views/components/reports/scenes/all',
                     params: {
-                        data: resource,
-                        cards: resourcesCards,
-                        dataConfig: resourcesDataConfig
+                        report: $data.report,
+                        showCards: false
                     }
                 }"></div>
             </div>

--- a/coral/templates/views/components/reports/digital-object.htm
+++ b/coral/templates/views/components/reports/digital-object.htm
@@ -121,6 +121,16 @@
                     }
                 }"></div>
             </div>
+            <!-- Related Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'related'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/all',
+                    params: {
+                        report: $data.report,
+                        showCards: false
+                    }
+                }"></div>
+            </div>
         </div>
     </div>            
     {% endblock body %}

--- a/coral/templates/views/components/reports/heritage-asset.htm
+++ b/coral/templates/views/components/reports/heritage-asset.htm
@@ -109,14 +109,13 @@
                     }
                 }"></div>
             </div>
-            <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <!-- Related Resources Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'related'">
                 <div data-bind="component: {
-                    name: 'views/components/reports/scenes/resources',
+                    name: 'views/components/reports/scenes/all',
                     params: {
-                        data: resource,
-                        cards: resourcesCards,
-                        dataConfig: resourceDataConfig
+                        report: $data.report,
+                        showCards: false
                     }
                 }"></div>
             </div>
@@ -125,7 +124,21 @@
                 <div data-bind="component: {
                     name: 'views/components/reports/scenes/all',
                     params: {
-                        report: $data.report
+                        report: $data.report,
+                        showCards: true,
+                        showRelated: true,
+                        nodeGroups: null
+                    }
+                }"></div>
+            </div>
+            <!-- Issue Report Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'issue'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/all',
+                    params: {
+                        report: $data.report,
+                        showRelated: false,
+                        nodeGroups: issueNodeGroups,
                     }
                 }"></div>
             </div>

--- a/coral/templates/views/components/reports/licence.htm
+++ b/coral/templates/views/components/reports/licence.htm
@@ -4,7 +4,7 @@
 {% block report %}
     {% block report_title_bar %}
     <!-- Custom Template Report Title Bar -->
-    <div class="relative">
+    <div class="aher-report-toolbar">
 
         <!-- Title Block -->
                   <!-- ko if: !print()-->
@@ -40,6 +40,28 @@
                     }
                 }"></div>
             </div>
+            <!-- Names Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/name',
+                    params: {
+                        data: resource,
+                        cards: nameCards,
+                        dataConfig: nameDataConfig
+                    }
+                }"></div>
+            </div>
+            <!-- Resources Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/resources',
+                    params: {
+                        data: resource,
+                        cards: resourcesCards,
+                        dataConfig: resourcesDataConfig
+                    }
+                }"></div>
+            </div>
         </div>
     </div>            
     {% endblock body %}
@@ -70,6 +92,38 @@
                 cards: descriptionCards,
             }
         }"></div>
+        <!-- Names Tab -->
+        <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+            <div data-bind="component: {
+                name: 'views/components/reports/scenes/name',
+                params: {
+                    data: resource,
+                    cards: nameCards,
+                    dataConfig: nameDataConfig
+                }
+            }"></div>
+        </div>
+        <!-- Description Tab -->
+        <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+            <div data-bind="component: {
+                name: 'views/components/reports/scenes/description',
+                params: {
+                    data: resource,
+                    dataConfig: descriptionDataConfig,
+                    cards: descriptionCards,
+                }
+            }"></div>
+        </div>
+        <!-- Location Tab -->
+        <div class="aher-report-page" data-bind="if: activeSection() === 'location'">
+            <div data-bind="component: {
+                name: 'views/components/reports/scenes/location',
+                params: {
+                    data: resource,
+                    cards: locationCards,
+                }
+            }"></div>
+        </div>
     </div>
 </div>
 

--- a/coral/templates/views/components/reports/licence.htm
+++ b/coral/templates/views/components/reports/licence.htm
@@ -51,14 +51,13 @@
                     }
                 }"></div>
             </div>
-            <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources'">
+            <!-- Related Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'related'">
                 <div data-bind="component: {
-                    name: 'views/components/reports/scenes/resources',
+                    name: 'views/components/reports/scenes/all',
                     params: {
-                        data: resource,
-                        cards: resourcesCards,
-                        dataConfig: resourcesDataConfig
+                        report: $data.report,
+                        showCards: false
                     }
                 }"></div>
             </div>

--- a/coral/templates/views/components/reports/person.htm
+++ b/coral/templates/views/components/reports/person.htm
@@ -119,14 +119,13 @@
                     }
                 }"></div>
             </div>
-            <!-- Resources Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'resources' || print()">
+            <!-- Related Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'related'">
                 <div data-bind="component: {
-                    name: 'views/components/reports/scenes/resources',
+                    name: 'views/components/reports/scenes/all',
                     params: {
-                        data: resource,
-                        cards: resourcesCards,
-                        dataConfig: resourceDataConfig
+                        report: $data.report,
+                        showCards: false
                     }
                 }"></div>
             </div>

--- a/coral/templates/views/components/reports/scenes/all.htm
+++ b/coral/templates/views/components/reports/scenes/all.htm
@@ -8,9 +8,10 @@
 <div class="report-provisional-flag"><span data-bind="text: $root.translations.pendingProvisionalEdits"></div>
 <!--/ko-->
 
+<!-- ko if: showCards -->
 <div class="rp-report-section relative rp-report-section-root" style="padding: 0;">
     <div class="rp-report-section-title" style="padding: 0;">
-        <!-- ko foreach: { data: report.cards, as: 'card' } -->
+        <!-- ko foreach: { data: viewableCards, as: 'card' } -->
             <!-- ko if: ($parent.hideEmptyNodes() === false || card.tiles().length > 0) && ko.unwrap(card.model.visible) -->
             <!-- ko if: $index() !== 0 --><hr class="rp-tile-separator"><!-- /ko -->
             <div class="rp-card-section" style="padding-bottom: 0; margin: 0 10px;">
@@ -21,7 +22,7 @@
                         preview: $parent.report.preview,
                         card: card,
                         pageVm: {...$root, report: $parent.report},
-                        hideEmptyNodes: $parent.hideEmptyNodes
+                        hideEmptyNodes: $parent.hideEmptyNodes,
                     }
                 } --> <!-- /ko -->
             </div>
@@ -29,12 +30,15 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: showRelated -->
 <div class="rp-report-section relative report-related-resources">
-  <div class="rp-report-section-title">
+  <div class="rp-report-section-title" style="padding: 0;">
     <div class="h4 rp-section-title" style="color: #2c4d70"><span data-bind="text: $root.translations.relatedResources"></span></div>
     <!-- ko foreach: { data: Object.values(report.relatedResourcesLookup()), as: 'resourceData' } -->
     <!-- ko if: resourceData.totalRelatedResources > 0 || !$parent.hideEmptyNodes() -->
+    <hr class="rp-tile-separator">
     <div class="rp-card-section" style="padding-bottom: 0.1rem">
         <div class="h5 rp-tile-title">
             <span class="rp-tile-title" data-bind="text: resourceData.name"></span>
@@ -71,10 +75,13 @@
         <!--/ko-->
     </div>
     <!-- /ko -->
-    <!-- /ko -->    
+    <!-- /ko -->
+    <!-- ko if: Object.values(report.relatedResourcesLookup()).length === 0 -->
+    <div class="aher-nodata-note">No resources are currently related</div> 
+    <!-- /ko -->     
   </div>
-  
 </div>  
+<!-- /ko --> 
 
 
 

--- a/coral/templates/views/components/reports/scenes/all.htm
+++ b/coral/templates/views/components/reports/scenes/all.htm
@@ -76,9 +76,9 @@
     </div>
     <!-- /ko -->
     <!-- /ko -->
-    <!-- ko if: Object.values(report.relatedResourcesLookup()).length === 0 -->
+    <!-- ko ifnot: hasRelatedResources -->
     <div class="aher-nodata-note">No resources are currently related</div> 
-    <!-- /ko -->     
+    <!-- /ko -->       
   </div>
 </div>  
 <!-- /ko --> 

--- a/coral/templates/views/components/reports/scenes/all.htm
+++ b/coral/templates/views/components/reports/scenes/all.htm
@@ -8,12 +8,12 @@
 <div class="report-provisional-flag"><span data-bind="text: $root.translations.pendingProvisionalEdits"></div>
 <!--/ko-->
 
-<div class="rp-report-section relative rp-report-section-root">
-    <div class="rp-report-section-title">
+<div class="rp-report-section relative rp-report-section-root" style="padding: 0;">
+    <div class="rp-report-section-title" style="padding: 0;">
         <!-- ko foreach: { data: report.cards, as: 'card' } -->
             <!-- ko if: ($parent.hideEmptyNodes() === false || card.tiles().length > 0) && ko.unwrap(card.model.visible) -->
             <!-- ko if: $index() !== 0 --><hr class="rp-tile-separator"><!-- /ko -->
-            <div class="rp-card-section">
+            <div class="rp-card-section" style="padding-bottom: 0; margin: 0 10px;">
                 <!-- ko component: {
                     name: card.model.cardComponentLookup[card.model.component_id()].componentname,
                     params: {
@@ -32,49 +32,48 @@
 
 <div class="rp-report-section relative report-related-resources">
   <div class="rp-report-section-title">
-      <div class="h4 rp-section-title"><span data-bind="text: $root.translations.relatedResources"></span></div>
+    <div class="h4 rp-section-title" style="color: #2c4d70"><span data-bind="text: $root.translations.relatedResources"></span></div>
+    <!-- ko foreach: { data: Object.values(report.relatedResourcesLookup()), as: 'resourceData' } -->
+    <!-- ko if: resourceData.totalRelatedResources > 0 || !$parent.hideEmptyNodes() -->
+    <div class="rp-card-section" style="padding-bottom: 0.1rem">
+        <div class="h5 rp-tile-title">
+            <span class="rp-tile-title" data-bind="text: resourceData.name"></span>
+        </div>
+        <!-- ko foreach: { data: resourceData.loadedRelatedResources(), as: 'relatedResource' } -->
+        <div class="rp-report-container-tile">
+            <div class="row rp-report-tile">
+                <dl class="dl-horizontal">
+                    <dt><a data-bind="text: relatedResource.displayName, attr: {href: relatedResource.link}"></a></dt>
+                    <!-- ko if: relatedResource.relationship -->
+                    <dd data-bind="text: '( ' + relatedResource.relationship + ' )'"></dd>
+                    <!-- /ko -->
+                </dl>
+            </div>
+        </div>
+        <!-- /ko -->
+
+        <!-- ko if: resourceData.paginator() && resourceData.paginator().has_next -->
+        <button class="btn btn-primary" data-bind="click: $parent.report.getRelatedResources.bind($parent.report, false)">
+            <span data-bind="text: $root.translations.loadMore" ></span>
+            <span data-bind="text: '(' + resourceData.remainingResources() + ')'"></span>
+        </button>
+
+        <button class="btn btn-primary" data-bind="click: $parent.report.getRelatedResources.bind($parent.report, true)">
+            <span data-bind="text: $root.translations.loadAll" ></span>
+            <span data-bind="text: '(' + (resourceData.totalRelatedResources - resourceData.loadedRelatedResources().length) + ')'"></span>
+        </button>
+        <!-- /ko -->
+            
+        <!--ko if: resourceData.totalRelatedResources === 0 -->	
+        <div class="rp-report-container-tile">	
+            <div class="row rp-report-tile rp-no-data"><span data-bind="text: $root.translations.noRelationshipsAdded"></span></div>	
+        </div>	
+        <!--/ko-->
+    </div>
+    <!-- /ko -->
+    <!-- /ko -->    
   </div>
   
-  <!-- ko foreach: { data: Object.values(report.relatedResourcesLookup()), as: 'resourceData' } -->
-  <!-- ko if: resourceData.totalRelatedResources > 0 || !$parent.hideEmptyNodes() -->
-  <div class="h5 rp-tile-title">
-      <span class="rp-tile-title-float" data-bind="text: resourceData.name"></span>
-  </div>
-
-  <div class="rp-card-section">
-      <!-- ko foreach: { data: resourceData.loadedRelatedResources(), as: 'relatedResource' } -->
-      <div class="rp-report-container-tile">
-          <div class="row rp-report-tile">
-              <dl class="dl-horizontal">
-                  <dt><a data-bind="text: relatedResource.displayName, attr: {href: relatedResource.link}"></a></dt>
-                  <!-- ko if: relatedResource.relationship -->
-                  <dd data-bind="text: '( ' + relatedResource.relationship + ' )'"></dd>
-                  <!-- /ko -->
-              </dl>
-          </div>
-      </div>
-      <!-- /ko -->
-
-      <!-- ko if: resourceData.paginator() && resourceData.paginator().has_next -->
-      <button class="btn btn-primary" data-bind="click: $parent.report.getRelatedResources.bind($parent.report, false)">
-          <span data-bind="text: $root.translations.loadMore" ></span>
-          <span data-bind="text: '(' + resourceData.remainingResources() + ')'"></span>
-      </button>
-
-      <button class="btn btn-primary" data-bind="click: $parent.report.getRelatedResources.bind($parent.report, true)">
-          <span data-bind="text: $root.translations.loadAll" ></span>
-          <span data-bind="text: '(' + (resourceData.totalRelatedResources - resourceData.loadedRelatedResources().length) + ')'"></span>
-      </button>
-      <!-- /ko -->
-          
-      <!--ko if: resourceData.totalRelatedResources === 0 -->	
-      <div class="rp-report-container-tile">	
-          <div class="row rp-report-tile rp-no-data"><span data-bind="text: $root.translations.noRelationshipsAdded"></span></div>	
-      </div>	
-      <!--/ko-->
-  </div>
-  <!-- /ko -->
-  <!-- /ko -->    
 </div>  
 
 

--- a/coral/templates/views/components/reports/scenes/all.htm
+++ b/coral/templates/views/components/reports/scenes/all.htm
@@ -39,7 +39,7 @@
     <!-- ko foreach: { data: Object.values(report.relatedResourcesLookup()), as: 'resourceData' } -->
     <!-- ko if: resourceData.totalRelatedResources > 0 || !$parent.hideEmptyNodes() -->
     <hr class="rp-tile-separator">
-    <div class="rp-card-section" style="padding-bottom: 0.1rem">
+    <div class="rp-card-section" style="padding-bottom: 0.1rem; margin: 0">
         <div class="h5 rp-tile-title">
             <span class="rp-tile-title" data-bind="text: resourceData.name"></span>
         </div>

--- a/coral/templates/views/components/reports/scenes/location.htm
+++ b/coral/templates/views/components/reports/scenes/location.htm
@@ -204,6 +204,7 @@
     </div>
 </div>
 
+<!-- ko if: descriptions().length -->
 <!-- Location Description -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.locationDescription">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.descriptions)}, css: {'fa-angle-double-right': visible.descriptions(), 'fa-angle-double-up': !visible.descriptions()}" class="fa toggle"></i> {% trans "Location Descriptions" %}</h2>
@@ -253,7 +254,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: administrativeAreas().length -->
 <!-- Admin Areas -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.administrativeAreas">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.administrativeAreas)}, css: {'fa-angle-double-right': visible.administrativeAreas(), 'fa-angle-double-up': !visible.administrativeAreas()}" class="fa toggle"></i> {% trans "Administrative Areas" %}</h2>
@@ -305,7 +308,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: buFusionId() -->
 <!-- BU Fusion ID section -->
 <div class="aher-report-section">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.buFusionId)}, css: {'fa-angle-double-right': visible.buFusionId(), 'fa-angle-double-up': !visible.buFusionId()}" class="fa toggle"></i> {% trans "BU Fusion ID" %}</h2>
@@ -336,7 +341,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: uniqueBuildingId() -->
 <!-- Unique Building ID section -->
 <div class="aher-report-section">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.uniqueBuildingId)}, css: {'fa-angle-double-right': visible.uniqueBuildingId(), 'fa-angle-double-up': !visible.uniqueBuildingId()}" class="fa toggle"></i> {% trans "Unique Building ID" %}</h2>
@@ -367,7 +374,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: lpFusionId() -->
 <!-- LP Fusion ID section -->
 <div class="aher-report-section">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.lpFusionId)}, css: {'fa-angle-double-right': visible.lpFusionId(), 'fa-angle-double-up': !visible.lpFusionId()}" class="fa toggle"></i> {% trans "LP Fusion ID" %}</h2>
@@ -398,7 +407,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: nationalGridReferences().length -->
 <!-- National Grid References -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.nationalGrid">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.nationalGrid)}, css: {'fa-angle-double-right': visible.nationalGrid(), 'fa-angle-double-up': !visible.nationalGrid()}" class="fa toggle"></i> {% trans "National Grid References" %}</h2>
@@ -446,7 +457,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: namedLocations().length -->
 <!-- Named Locations -->
 <div class="aher-report-section" data-bind="if: !!dataConfig.namedLocations">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.namedLocations)}, css: {'fa-angle-double-right': visible.namedLocations(), 'fa-angle-double-up': !visible.namedLocations()}" class="fa toggle"></i> {% trans "Named Locations" %}</h2>
@@ -494,6 +507,7 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
 {% endblock body %}
 {% endblock report %}

--- a/coral/templates/views/components/reports/scenes/name.htm
+++ b/coral/templates/views/components/reports/scenes/name.htm
@@ -75,18 +75,14 @@
                         <thead>
                             <tr class="aher-table-header">
                                 <th>{% trans "Name" %}</th>
-                                <th class="">{% trans "Name Use Type" %}</th>
-                                <th class="">{% trans "Name Currency" %}</th>
                                 <th class="aher-table-control all"></th>
                             </tr>
                         </thead>
                         <tbody data-bind="dataTablesForEach: { data: names, dataTableOptions: nameTableConfig }">
                             <tr>
                                 <td data-bind="text: name"></td>
-                                <td data-bind="text: nameUseType"></td>
-                                <td data-bind="text: currency"></td>
                                 <td class="aher-table-control">
-                                    <div data-bind="if: $parent.cards && $parent.cards.name">
+                                    <div style="display: flex" data-bind="if: $parent.cards && $parent.cards.name">
                                         <a href="#" data-bind="click: function() {$parent.edit(tileid, $parent.cards.name)}" onkeyup="if(event.which == 13 || event.keyCode == 13){ $(this).trigger('click'); }">
                                             <i class="fa fa-mail-reply"></i>
                                         </a>
@@ -106,6 +102,7 @@
 </div>
 <!-- /ko -->
 
+<!-- ko if: crossReferences().length -->
 <!-- External Reference -->
 <!-- ko ifnot: hideCrossReferences() -->
 <div data-bind="visible: !!dataConfig.xref" class="aher-report-section">
@@ -164,6 +161,7 @@
     </div>
 </div>
 <!-- /ko -->
+<!-- /ko -->
 
 <!-- System Reference Numbers section -->
 <div class="aher-report-section">
@@ -189,14 +187,18 @@
                         <h4 class="aher-block-key">Resource ID: </h4>
                         <div class="aher-block-value" data-bind="text:srn.resourceId"></div>
                     </div>
+                    <!-- ko if: srn.legacyId -->
                     <div class="aher-block-attributes">
                         <h4 class="aher-block-key">Legacy ID: </h4>
                         <div class="aher-block-value" data-bind="text:srn.legacyId"></div>
                     </div>
+                    <!-- /ko -->
+                     <!-- ko if: srn.primaryReferenceNumber -->
                     <div class="aher-block-attributes">
                         <h4 class="aher-block-key">Primary Reference Number: </h4>
                         <div class="aher-block-value" data-bind="text:srn.primaryReferenceNumber"></div>
                     </div>
+                    <!-- /ko -->
                 </div>
             </div>
         </div>

--- a/coral/templates/views/components/reports/scenes/resources.htm
+++ b/coral/templates/views/components/reports/scenes/resources.htm
@@ -3,6 +3,7 @@
 {% block report %}
 
 {% block body %}
+<!-- ko if: activities().length -->
 <!-- Associated Activities section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.activities">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.activities)}, css: {'fa-angle-double-right': visible.activities(), 'fa-angle-double-up': !visible.activities()}" class="fa toggle"></i> {% trans "Associated Activities" %}</h2>
@@ -56,7 +57,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: archive().length -->
 <!-- Associated Archive section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.archive">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.archive)}, css: {'fa-angle-double-right': visible.archive(), 'fa-angle-double-up': !visible.archive()}" class="fa toggle"></i> {% trans "Associated Archive Objects" %}</h2>
@@ -114,7 +117,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: consultations().length -->
 <!-- Associated Consultations section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.consultations">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.consultations)}, css: {'fa-angle-double-right': visible.consultations(), 'fa-angle-double-up': !visible.consultations()}" class="fa toggle"></i> {% trans "Associated Consultations" %}</h2>
@@ -167,7 +172,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: files().length -->
 <!-- Associated Digital Files section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.files">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.files)}, css: {'fa-angle-double-right': visible.files(), 'fa-angle-double-up': !visible.files()}" class="fa toggle"></i> {% trans "Associated Files" %}</h2>
@@ -220,7 +227,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: assets().length -->
 <!-- Associated Monuments section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.assets">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.assets)}, css: {'fa-angle-double-right': visible.assets(), 'fa-angle-double-up': !visible.assets()}" class="fa toggle"></i> {% trans "Associated Monuments/Areas/Artefacts" %}</h2>
@@ -276,8 +285,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
-
+<!-- ko if: actors().length -->
 <!-- Associated People and Organisations section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.actors">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.actors)}, css: {'fa-angle-double-right': visible.actors(), 'fa-angle-double-up': !visible.actors()}" class="fa toggle"></i> {% trans "Associated People and Organisations" %}</h2>
@@ -330,7 +340,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: applicationArea().length -->
 <!-- Related Application Area section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.relatedApplicationArea">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.applicationArea)}, css: {'fa-angle-double-right': visible.applicationArea(), 'fa-angle-double-up': !visible.applicationArea()}" class="fa toggle"></i> {% trans "Related Application Areas" %}</h2>
@@ -376,8 +388,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
-
+<!-- ko if: translation().length -->
 <!-- Translation section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.translation">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.translation)}, css: {'fa-angle-double-right': visible.translation(), 'fa-angle-double-up': !visible.translation()}" class="fa toggle"></i> {% trans "Translations" %}</h2>
@@ -423,7 +436,9 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 
+<!-- ko if: period().length -->
 <!-- Period section -->
 <div class="aher-report-section" data-bind="visible: !!dataConfig.period">
     <h2 class="aher-report-section-title"><i data-bind="click: function() {toggleVisibility(visible.period)}, css: {'fa-angle-double-right': visible.period(), 'fa-angle-double-up': !visible.period()}" class="fa toggle"></i> {% trans "Periods" %}</h2>
@@ -477,5 +492,6 @@
         <!-- /ko -->
     </div>
 </div>
+<!-- /ko -->
 {% endblock body %}
 {% endblock report %}


### PR DESCRIPTION
## Task
[#2935](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2935)

## Description
This cleans up the report pages for:
- Activity
- Licence
- Heritage Asset
- Heritage Asset Revision
- Person
- Consultation
- Digital Object

It puts the full report as the main report page and opens it first. 
It removes several tabs from the reports page.
It adds a related resources page using the full report as a base.
It creates an Issue Report page using the full report as a base

## Test
- Create resources for all of the models listed above
- Click on the instance created
- Should open to the full report page first
- Should have additional tabs for names, location, related resources
- Location tab should show the map and location if it is present
- The address should also show on the location page if present
- The HA model should have an Issue Report tab that shows only the issue reports
- The Related resources tab should show only the related resources
- It should also display no related resources if none are available