### PR TITLE
Fix (Heritage Asset | Heritage Asset Revision): Update Damage Type Concept

### DIFF
--- a/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
@@ -30318,7 +30318,7 @@
                 {
                     "alias": "damage_type",
                     "config": {
-                        "rdmCollection": "9881e48c-95f1-42da-bc55-76a6b6f34f22"
+                        "rdmCollection": "618bb431-f54f-4783-aed8-7b7d4f877ed4"
                     },
                     "datatype": "concept-list",
                     "description": null,

--- a/coral/pkg/graphs/resource_models/Heritage Asset.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset.json
@@ -35642,7 +35642,7 @@
                 {
                     "alias": "damage_type",
                     "config": {
-                        "rdmCollection": "9881e48c-95f1-42da-bc55-76a6b6f34f22"
+                        "rdmCollection": "618bb431-f54f-4783-aed8-7b7d4f877ed4"
                     },
                     "datatype": "concept-list",
                     "description": null,

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=6, patch=23)
+APP_VERSION = semantic_version.Version(major=7, minor=6, patch=24)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
This updates the Heritage Asset and Heritage Asset Revision 'Damage Type' node to use the Historic England Threats
The concepts have been updated and will show additional drop downs

## Test
Import the concept and the collection to your local branch, can be found here:
[#2819](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2819)

Reload the models for HA and HA Revision
Open the Issue Report and navigate to the Record of the Issue
Open the Damage Type and you should see the Historic England Threat Types
Search for:

Field Improvement – Should be a child to Agricultural Requirements

Clearance – Should be a child to Field Improvement

Cultivation – Should be a child to Agricultural Requirements

Tree planting – Should be a child to Cultivation and Gardening

Reservoir – Should be a child to Public Utilities

Turf cutting – Should be a child to Human Activity