### PR TITLE
Fix/arches plugin dropdown

### DIFF
--- a/coral/pkg/graphs/resource_models/Group.json
+++ b/coral/pkg/graphs/resource_models/Group.json
@@ -980,7 +980,7 @@
                 {
                     "alias": "arches_plugins",
                     "config": {
-                        "graphs": [],
+                        "graphs": ["e828f30f-f4ef-4e9b-aeb0-3998bcb7678a"],
                         "searchDsl": "",
                         "searchString": ""
                     },

--- a/coral/pkg/graphs/resource_models/Group.json
+++ b/coral/pkg/graphs/resource_models/Group.json
@@ -980,7 +980,16 @@
                 {
                     "alias": "arches_plugins",
                     "config": {
-                        "graphs": ["e828f30f-f4ef-4e9b-aeb0-3998bcb7678a"],
+                        "graphs": [
+                            {
+                                "graphid": "e828f30f-f4ef-4e9b-aeb0-3998bcb7678a",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Arches Plugins",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            }
+                        ],
                         "searchDsl": "",
                         "searchString": ""
                     },

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=6, patch=28)
+APP_VERSION = semantic_version.Version(major=7, minor=6, patch=29)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
This PR is a small fix to make the Arches Plugin Drop down more usable when configuring groups.
![broken-dropdown](https://github.com/user-attachments/assets/2ea41a00-9c00-4393-8a32-938fc645729b)
Before this PR the dropdown shows all resources and does not allow the user to scroll.  

After this small fix it will just show arches plugins and the admin can scroll through them as expected.  
![improved-dropdown](https://github.com/user-attachments/assets/754c8dbd-1037-4e34-a9b3-a90758b15744)
