### PR TITLE
Feature: Update Groups

### DIFF
--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -435,7 +435,7 @@ class GroupTransform():
         if files:
             latest_file = max(files, key=os.path.getmtime)
             today = datetime.datetime.today().strftime('%Y-%m-%d_%H-%M-%S')
-            group_with_members = os.path.join(os.path.dirname(latest_file), f"backup_Group_with_members_{today}.json")
+            group_with_members = os.path.join(os.path.dirname(latest_file), f"backup_Previous_Group_with_members_{today}.json")
             os.rename(latest_file, group_with_members)
         
             with open(group_with_members, 'r') as new_file:
@@ -446,7 +446,7 @@ class GroupTransform():
             for resource in new_resource_instances:    
                 for tile in resource["tiles"]:
                     if self.MEMBER_NODE in tile["data"]:
-                        members = [{'value': member, 'name': resource['resourceinstance']["name"]} for member in (tile["data"].get(self.MEMBER_NODE)or []) if member['resourceId'] not in group_ids]
+                        members = [{'value': member, 'groupId': resource['resourceinstance']["resourceinstanceid"]} for member in (tile["data"].get(self.MEMBER_NODE)or []) if member['resourceId'] not in group_ids]
                         new_members.extend(members)
         
         for resource in resource_instances:    
@@ -454,9 +454,10 @@ class GroupTransform():
                 if self.MEMBER_NODE in tile["data"]:
                     if tile["data"][self.MEMBER_NODE]: 
                         if len(new_members) > 0:
-                            match = next((item for item in new_members if item['name'] == resource['resourceinstance']["name"]), None)
+                            match = next((item for item in new_members if item['groupId'] == resource['resourceinstance']["resourceinstanceid"]), None)
                             if match:
                                 tile["data"][self.MEMBER_NODE].append(match['value'])
+                                
 
 
         data['business_data']['resources'] = resource_instances

--- a/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
@@ -30318,7 +30318,7 @@
                 {
                     "alias": "damage_type",
                     "config": {
-                        "rdmCollection": "9881e48c-95f1-42da-bc55-76a6b6f34f22"
+                        "rdmCollection": "618bb431-f54f-4783-aed8-7b7d4f877ed4"
                     },
                     "datatype": "concept-list",
                     "description": null,

--- a/coral/pkg/graphs/resource_models/Heritage Asset.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset.json
@@ -35642,7 +35642,7 @@
                 {
                     "alias": "damage_type",
                     "config": {
-                        "rdmCollection": "9881e48c-95f1-42da-bc55-76a6b6f34f22"
+                        "rdmCollection": "618bb431-f54f-4783-aed8-7b7d4f877ed4"
                     },
                     "datatype": "concept-list",
                     "description": null,


### PR DESCRIPTION
## Description
Adds features to allow you to remove the members from the groups and rehydrate the groups with new members from the current environment.

To remove members run:
`python manage.py migrate_safely -o remove_members`

This will export a backup file with the members and an empty groups file to:
`coral/pkg/business_data/files`

To rehydrate you need to be in the environment that has your members. You will need to move the new empty group model into your environment and then run:

`python manage.py migrate_safely -o rehydrate_members -s 'empy_members_model'`

This will then add the members into the updated group, export the data to the business data, remove the old groups and import the updated groups with the members

## Test

#### Remove
- Import the groups
- Add links between groups in the members
- Add person instances to the group members
- Run `make manage CMD="migrate_safely -o remove_members"`
- Delete your current group instances
- Import the empty members json
- Check that the person instances were removed but the group links remain

#### Rehydrating
- Add members and group links to the groups
- Make a change to a group, such as a name change
- Strip the members from the groups using the above command
- Reload the old groups
- Run `make manage CMD="migrate_safely -o rehydrate_members -s 'path/to/your/empty/members"`
- Check the groups have loaded the updated models and kept the links between groups
- Check that the members have been correctly added back in
