### PR TITLE
Fix: filter and sort tiles by HA number

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=6, patch=24)
+APP_VERSION = semantic_version.Version(major=7, minor=6, patch=25)
 
 GROUPINGS = {
     "groups": {

--- a/coral/utils/ha_number.py
+++ b/coral/utils/ha_number.py
@@ -1,6 +1,5 @@
 from arches.app.models.tile import Tile
-from django.db.models import Max
-
+from django.db.models.fields.json import KT
 
 SYSTEM_REFERENCE_NODEGROUP = "325a2f2f-efe4-11eb-9b0c-a87eeabdefba"
 SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID = "325a430a-efe4-11eb-810b-a87eeabdefba"
@@ -26,9 +25,10 @@ class HaNumber:
             if resource_instance_id:
                 query_result.exclude(resourceinstance_id=resource_instance_id)
             query_result = query_result.annotate(
-                most_recent=Max("resourceinstance__createdtime")
-            )
-            query_result = query_result.order_by("-most_recent")
+                    ha_id_number=KT(f"data__{SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID}__en__value")
+                ).filter(ha_id_number__startswith="HA/")
+            
+            query_result = query_result.order_by("-ha_id_number")
             latest_id_number_tile = query_result.first()
         except Exception as e:
             print(f"Failed querying for previous ID number tile: {e}")
@@ -91,7 +91,7 @@ class HaNumber:
             latest_id_number = self.get_latest_id_number(resource_instance_id)
         except Exception as e:
             print(f"Failed getting the previously used ID number: {e}")
-            return retry()
+            return # retry()
 
         if latest_id_number:
             # Offset attempts so it starts at 1 and will try to generate


### PR DESCRIPTION
## Description
The tile data was being sorted by the creation time of the resource instance which was causing issues when re-importing the data. This will organise by the actual HA number when querying the database.

## Test
[Heritage_Asset_2025-02-19_12-05-50 copy.json](https://github.com/user-attachments/files/18867911/Heritage_Asset_2025-02-19_12-05-50.copy.json)
[HA01.json](https://github.com/user-attachments/files/18867912/HA01.json)

In `utils/ha_number.py` change the generate_id_number retry attempts to 5 just for testing
- Import the `Heritage_Asset_2025-02-19_12-05-50 copy.json` - this imports HA/02 - HA/10
- Import `HA01.json` this imports HA/01.
- This should break the original method - if possible try this on the standard dev branch to see if the break occurs
- Reload the current branch and restart the containers
- Try to create a new HA and it should generate the next number
- Repeat the process to check it generates the correct increment