### PR TITLE
Feature/migration concept changes

### DIFF
--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -435,7 +435,7 @@ class GroupTransform():
         if files:
             latest_file = max(files, key=os.path.getmtime)
             today = datetime.datetime.today().strftime('%Y-%m-%d_%H-%M-%S')
-            group_with_members = os.path.join(os.path.dirname(latest_file), f"backup_Group_with_members_{today}.json")
+            group_with_members = os.path.join(os.path.dirname(latest_file), f"backup_Previous_Group_with_members_{today}.json")
             os.rename(latest_file, group_with_members)
         
             with open(group_with_members, 'r') as new_file:
@@ -446,7 +446,7 @@ class GroupTransform():
             for resource in new_resource_instances:    
                 for tile in resource["tiles"]:
                     if self.MEMBER_NODE in tile["data"]:
-                        members = [{'value': member, 'name': resource['resourceinstance']["name"]} for member in (tile["data"].get(self.MEMBER_NODE)or []) if member['resourceId'] not in group_ids]
+                        members = [{'value': member, 'groupId': resource['resourceinstance']["resourceinstanceid"]} for member in (tile["data"].get(self.MEMBER_NODE)or []) if member['resourceId'] not in group_ids]
                         new_members.extend(members)
         
         for resource in resource_instances:    
@@ -454,9 +454,10 @@ class GroupTransform():
                 if self.MEMBER_NODE in tile["data"]:
                     if tile["data"][self.MEMBER_NODE]: 
                         if len(new_members) > 0:
-                            match = next((item for item in new_members if item['name'] == resource['resourceinstance']["name"]), None)
+                            match = next((item for item in new_members if item['groupId'] == resource['resourceinstance']["resourceinstanceid"]), None)
                             if match:
                                 tile["data"][self.MEMBER_NODE].append(match['value'])
+                                
 
 
         data['business_data']['resources'] = resource_instances

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=6, patch=29)
+APP_VERSION = semantic_version.Version(major=7, minor=7, patch=29)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
Adds functionality for mapping an existing concept to a new concept.
It allows for a mapping file to be input in the initial migration command. 
This can include multiple nodes. 
The keys will be the original concept id and the value the new concept id.
A default value can be set to fall back to if an existing concept is not found.

#### Example mapping
```
{
    "6af2b696-efc5-11eb-b0b5-a87eeabdefba": {
        "default": null,
        "dd8cc868-1730-41bd-8a52-43127a0ea938": "35fb8f55-70a2-6117-9300-cd2a08bdef05",
        "a3c88145-d3a6-4f76-8fb9-d78156fde631": "a79351a1-67dd-7789-ff50-f945670e6d8c",
    }
}
```
Various errors are raised if values are not supplied to stop unwanted change to the data.

## Test
- Make a change to an existing concept and set it as a new concept that is currently registered
- Create a mapping file. Set changed node as the initial key and the value as an object with key value pairs. The keys are the original concept id, the value is the new concept id you want to change it to.
- Create an instance or several with the original concepts saved.
- Run the migration command `make manage CMD="migrate_safely -o migrate -m Heritage\ Asset -M mapping.json"`
- You should see a message stating that the node concept has been updated
- Continue with the conversion
- It will change the graph and load the new data. You should see the new mapped selection in the drop down for the instance.

Error Checks:
- Change the node slightly so it doesn't match
- Should receive an error that the node could not be found
- Change the original concept so it doesn't match
- Should set the default value for the node
- Remove the default value and have an incorrect original concept id
- Should receive an error that the node doesn't match and no default is set
- Have correct original ids, set an incorrect new concept id
- Should receive an error that the value doesn't exist and you may need to import the new concept