### PR TITLE
feat: new enforcement scene

### DIFF
--- a/coral/media/js/views/components/reports/heritage-asset.js
+++ b/coral/media/js/views/components/reports/heritage-asset.js
@@ -9,6 +9,7 @@ define([
     'views/components/reports/scenes/name',
     'views/components/reports/scenes/json',
     'views/components/reports/scenes/all',
+    'views/components/reports/scenes/enforcements',
 ], function($, _, ko, arches, resourceUtils, reportUtils, heritageAssetReportTemplate) {
     return ko.components.register('heritage-asset-report', {
         viewModel: function(params) {
@@ -25,6 +26,7 @@ define([
                 {id: 'location', title: 'Location Data'},
                 {id: 'issue', title: 'Issue Reports'},
                 {id: 'related', title: 'Related Resources'},
+                {id: 'enforcements', title: 'Pending Enforcements'},
                 // {id: 'description', title: 'Descriptions and Citations'},
                 // {id: 'classifications', title: 'Classifications and Dating'},
                 // {id: 'protection', title: 'Designation and Protection Status'},

--- a/coral/media/js/views/components/reports/scenes/enforcements.js
+++ b/coral/media/js/views/components/reports/scenes/enforcements.js
@@ -1,0 +1,60 @@
+define([
+    'underscore',
+    'knockout',
+    'arches',
+    'utils/report',
+    'views/components/workflows/summary-step',
+    'views/components/resource-report-abstract',
+    'viewmodels/report', 
+    'templates/views/components/reports/scenes/enforcements.htm',
+    'bindings/datatable',
+    'views/components/workflows/render-nodes',
+], function(_, ko, arches, reportUtils, SummaryStep, resourceReportAbstract, ReportViewModel, allReportTemplate) {
+    return ko.components.register('views/components/reports/scenes/enforcements', {
+        viewModel: function(params) {
+            console.log("Enforcement Scene Enforcement", params)
+            
+            this.nodeGroups = params.nodeGroups ?? null;
+            this.hiddenNodes = params.hideNodes ?? null;
+            this.showCards = params.showCards ?? true;
+            this.showRelated = params.showRelated ?? true;
+            this.enforcements = ko.observable()
+            
+            ReportViewModel.apply(this, [params]);
+            console.log("this", this)
+
+            this.resourceinstanceid = this.report.attributes.resourceid
+
+            getEnforcements = async () => {
+                const enforcements = await $.ajax({
+                    type: 'GET',
+                    // advanced-search=[{"op"%3A"and"%2C"a78e548a-b554-11ee-805b-0242ac120006"%3A{"op"%3A""%2C"val"%3A["${this.resourceinstanceid}"]}}]
+                    url: `/search/resources?advanced-search=[{"op"%3A"and"%2C"a78e548a-b554-11ee-805b-0242ac120006"%3A{"op"%3A""%2C"val"%3A["${this.resourceinstanceid}"]}}]`,
+                    dataType: 'json',
+                    context: this,
+                    error: (response, status, error) => {
+                      console.error(response, status, error);
+                    }
+                })
+                console.log("got the enforcements", enforcements)
+                this.enforcements(enforcements.results.hits.hits.map(e => {return {name:e._source.displayname, url: `/report/${e._id}`}}))
+            }
+            getEnforcements()
+
+
+            this.relatedResources = Object.values(this.report.relatedResourcesLookup());
+            this.hasRelatedResources = this.relatedResources.some(resource => resource.totalRelatedResources > 0);
+            this.viewableCards = ko.observable(this.report.cards);
+
+            if (this.nodeGroups?.length > 0) {
+                this.viewableCards = this.report.cards.filter(card => {
+                    return this.nodeGroups.includes(card.nodegroupid);
+                });
+            }
+            else {
+                this.viewableCards = this.report.cards;
+            }
+        },
+        template: allReportTemplate
+    });
+});

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=6, patch=26)
+APP_VERSION = semantic_version.Version(major=7, minor=6, patch=27)
 
 GROUPINGS = {
     "groups": {

--- a/coral/templates/views/components/reports/heritage-asset.htm
+++ b/coral/templates/views/components/reports/heritage-asset.htm
@@ -161,6 +161,17 @@
                     }
                 }"></div>
             </div>
+            <!-- Enforcement Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'enforcements'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/enforcements',
+                    params: {
+                        data: resource,
+                        cards: nameCards,
+                        report: $data.report
+                    }
+                }"></div>
+            </div>
         </div>
     </div>            
     {% endblock body %}

--- a/coral/templates/views/components/reports/scenes/enforcements.htm
+++ b/coral/templates/views/components/reports/scenes/enforcements.htm
@@ -1,0 +1,5 @@
+<!-- ko foreach: {data: enforcements, as: 'enforcement'} -->
+<a data-bind="attr: {href:enforcement.url, title: enforcement.name}">
+    <h4 class="workflow-select-title" data-bind="text: enforcement.name"></h4>
+</a>
+<!-- /ko -->


### PR DESCRIPTION
This PR adds a very basic enforcement scene for heritage asset reports. 
![enforcement-scene](https://github.com/user-attachments/assets/b1a194c6-46d3-4364-9db7-2ad05885f940)
It's simply the name of any enforcements that relate to the heritage asset which serve as links to the respective enforcements report.

Test:
Create a heritage asset that has one or more enforcements flagged about it.
go to the heritage asset's report page
go to pending enforcement step
enfrocements should be present and clickable

As an enforcement admin mark one of the enforcements as received.
As a non admin, go back to the enforcement scene
The received enforcement should not be present.