### PR TITLE
Fix (Consultation): #2725 Planning Notifications 

### DIFF
--- a/coral/functions/notify_planning.py
+++ b/coral/functions/notify_planning.py
@@ -75,6 +75,10 @@ class NotifyPlanning(BaseFunction):
         resource = Resource.objects.get(pk=resource_instance_id)
         name = resource.displayname()
         
+        # The existing notification stops groups from being sent multiple of the same notification
+        # Use this notification as the primary notification
+        # The other 2 notifications are used to allow multiple groups with different slugs to be notified
+        
         if not existing_notification:
             notification = models.Notification(
                 message=f"{name} has been assigned to you",

--- a/coral/pkg/graphs/resource_models/Consultation.json
+++ b/coral/pkg/graphs/resource_models/Consultation.json
@@ -17398,7 +17398,9 @@
                 {
                     "config": {
                         "triggering_nodegroups": [
-                            "a5e15f5c-51a3-11eb-b240-f875a44e0e11"
+                            "a5e15f5c-51a3-11eb-b240-f875a44e0e11",
+                            "af7677ba-cfe2-11ee-8a4e-0242ac180006",
+                            "dc9bfb24-cfd9-11ee-8cc1-0242ac180006"
                         ]
                     },
                     "function_id": "e5de46d7-dd01-418b-a71d-f5b27c143de4",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=8, patch=32)
+APP_VERSION = semantic_version.Version(major=7, minor=8, patch=33)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Description
This updates the logic for the planning notifications.
The save type has been changed to `save` instead of `post_save`
Logic has been updated to send to admins when it is assigned
Additional notifications have been added to allow multiple groups with different workflows assigned to be updated at the same time (slug was originally changing depending on the last group updated)
The model also did not have all the triggering functions set on it.

## Test
- Reload the consultation model
- Follow the tests here [#2725](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2725?milestone=431103)