### PR TITLE
fix(assign-consultation-wf): removed irish grid reference from assign…

### DIFF
--- a/coral/plugins/assign-consultation-workflow.json
+++ b/coral/plugins/assign-consultation-workflow.json
@@ -255,18 +255,6 @@
                 "parameters": {
                   "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
                   "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
-                  "nodegroupid": "083e226c-ca61-11ee-afca-0242ac180006",
-                  "parenttileid": "['initial-step-step']['system-reference'][0]['resourceid']['locationData']",
-                  "semanticName": "Irish Grid Reference"
-                },
-                "tilesManaged": "one",
-                "componentName": "fetch-latest-tile",
-                "uniqueInstanceName": "irish-grid-reference"
-              },
-              {
-                "parameters": {
-                  "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
-                  "resourceid": "['initial-step-step']['system-reference'][0]['resourceid']['resourceInstanceId']",
                   "hiddenNodes": ["083f146a-ca61-11ee-afca-0242ac180006"],
                   "nodegroupid": "083e1bb4-ca61-11ee-afca-0242ac180006",
                   "parenttileid": "['initial-step-step']['system-reference'][0]['resourceid']['locationData']",


### PR DESCRIPTION
## changes:

- Removed Irish grid reference nodes from assign consultation workflow in location step

## Test:

- Clone this branch and run the following cmd `make manage CMD="coral reload"`
- Then navigate to assign consultation workflow and ensure that the irish grid reference is no longer present in location details step

## Reviewers
@OwenGalvia @StuCM  

