### PR TITLE
fix: fixed typo in agriculture letters dropdown

### DIFF
--- a/coral/plugins/agriculture-and-forestry-consultation-workflow.json
+++ b/coral/plugins/agriculture-and-forestry-consultation-workflow.json
@@ -240,7 +240,7 @@
                 "letterTypeNode": "6d09da12-e53e-11ef-93e2-0242ac120004",
                 "letterResourceNode": "b15ee596-e53d-11ef-8521-0242ac120004",
                 "letterOptions": [
-                    { "text": "Foreestry Response Letter", "id": "forestry-consult-response-template.docx" },
+                    { "text": "Forestry Response Letter", "id": "forestry-consult-response-template.docx" },
                     { "text": "Daera Consultation Response Letter", "id": "daera-consultation-response-template.docx"}
                   ],
                 "config": {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=8, patch=31)
+APP_VERSION = semantic_version.Version(major=7, minor=8, patch=32)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
## Changes: 

Updated typo in agriculture letters dropdown `Foreestry Response Letter` to `Forestry Response Letter`

## Test: 

- Clone branch and run `make manage CMD="coral reload"` 
- Then go to Agriculture and forestry workflow and ensure that the correct spelling is present in the letters dropdown 

## Reviewers: 
@StuCM @OwenGalvia 