### PR TITLE
Fix (Multiple Models): update the council domain list

### DIFF
--- a/coral/pkg/graphs/branches/Council.json
+++ b/coral/pkg/graphs/branches/Council.json
@@ -115,83 +115,83 @@
                           "fn": "arches.app.datatypes.datatypes.DomainDataType"
                       },
                       "options": [
-                          {
-                              "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
-                              "selected": false,
-                              "text": {
-                                  "en": "37: Ards and North Down"
-                              }
-                          },
-                          {
-                              "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
-                              "selected": false,
-                              "text": {
-                                  "en": "36: Newry Mourne and Down"
-                              }
-                          },
-                          {
-                              "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
-                              "selected": false,
-                              "text": {
-                                  "en": "35: Mid Ulster"
-                              }
-                          },
-                          {
-                              "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
-                              "selected": false,
-                              "text": {
-                                  "en": "34: Mid and East Antrim"
-                              }
-                          },
-                          {
-                              "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
-                              "selected": false,
-                              "text": {
-                                  "en": "33: Lisburn and Castlereagh"
-                              }
-                          },
-                          {
-                              "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
-                              "selected": false,
-                              "text": {
-                                  "en": "32: Fermanagh and Omagh"
-                              }
-                          },
-                          {
-                              "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
-                              "selected": false,
-                              "text": {
-                                  "en": "31: Derry City and Strabane"
-                              }
-                          },
-                          {
-                              "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
-                              "selected": false,
-                              "text": {
-                                  "en": "30: Causeway Coast and Glens"
-                              }
-                          },
-                          {
-                              "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
-                              "selected": false,
-                              "text": {
-                                  "en": "29: Belfast"
-                              }
-                          },
-                          {
-                              "id": "3c928df6-dbec-49b0-926d-da947391948e",
-                              "selected": false,
-                              "text": {
-                                  "en": "28: Armagh City Banbridge and Craigavon"
-                              }
-                          },
-                          {
-                              "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
-                              "selected": false,
-                              "text": {
-                                  "en": "27: Antrim and Newtownabbey"
-                              }
-                          }
+                        {
+                            "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
+                            "selected": false,
+                            "text": {
+                                "en": "LA01 - Causeway Coast and Glens Borough Council"
+                            }
+                        },
+                        {
+                            "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
+                            "selected": false,
+                            "text": {
+                                "en": "LA02 - Mid and East Antrim Borough Council"
+                            }
+                        },
+                        {
+                            "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
+                            "selected": false,
+                            "text": {
+                                "en": "LA03 - Antrim and Newtownabbey Borough Council"
+                            }
+                        },
+                        {
+                            "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
+                            "selected": false,
+                            "text": {
+                                "en": "LA04 - Belfast City Council"
+                            }
+                        },
+                        {
+                            "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
+                            "selected": false,
+                            "text": {
+                                "en": "LA05 - Lisburn and Castlereagh City Council"
+                            }
+                        },
+                        {
+                            "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
+                            "selected": false,
+                            "text": {
+                                "en": "LA06 - Ards and North Down Borough Council"
+                            }
+                        },
+                        {
+                            "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
+                            "selected": false,
+                            "text": {
+                                "en": "LA07 - Newry, Mourne and Down District Council"
+                            }
+                        },
+                        {
+                            "id": "3c928df6-dbec-49b0-926d-da947391948e",
+                            "selected": false,
+                            "text": {
+                                "en": "LA08 - Armagh City, Banbridge and Craigavon Borough Council"
+                            }
+                        },
+                        {
+                            "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
+                            "selected": false,
+                            "text": {
+                                "en": "LA09 - Mid Ulster District Council"
+                            }
+                        },                            
+                        {
+                            "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
+                            "selected": false,
+                            "text": {
+                                "en": "LA10 - Fermanagh and Omagh District Council"
+                            }
+                        },
+                        {
+                            "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
+                            "selected": false,
+                            "text": {
+                                "en": "LA11 - Derry City and Strabane District Council"
+                            }
+                        }
                       ]
                   },
                   "datatype": "domain-value",
@@ -229,61 +229,83 @@
                       "fn": "arches.app.datatypes.datatypes.DomainDataType"
                   },
                   "options": [
-                      {
-                          "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
-                          "selected": false,
-                          "text": "37: Ards and North Down"
-                      },
-                      {
-                          "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
-                          "selected": false,
-                          "text": "36: Newry Mourne and Down"
-                      },
-                      {
-                          "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
-                          "selected": false,
-                          "text": "35: Mid Ulster"
-                      },
-                      {
-                          "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
-                          "selected": false,
-                          "text": "34: Mid and East Antrim"
-                      },
-                      {
-                          "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
-                          "selected": false,
-                          "text": "33: Lisburn and Castlereagh"
-                      },
-                      {
-                          "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
-                          "selected": false,
-                          "text": "32: Fermanagh and Omagh"
-                      },
-                      {
-                          "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
-                          "selected": false,
-                          "text": "31: Derry City and Strabane"
-                      },
-                      {
-                          "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
-                          "selected": false,
-                          "text": "30: Causeway Coast and Glens"
-                      },
-                      {
-                          "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
-                          "selected": false,
-                          "text": "29: Belfast"
-                      },
-                      {
-                          "id": "3c928df6-dbec-49b0-926d-da947391948e",
-                          "selected": false,
-                          "text": "28: Armagh City Banbridge and Craigavon"
-                      },
-                      {
-                          "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
-                          "selected": false,
-                          "text": "27: Antrim and Newtownabbey"
-                      }
+                    {
+                        "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
+                        "selected": false,
+                        "text": {
+                            "en": "LA11 - Derry City and Strabane District Council"
+                        }
+                    },
+                    {
+                        "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
+                        "selected": false,
+                        "text": {
+                            "en": "LA10 - Fermanagh and Omagh District Council"
+                        }
+                    },
+                    {
+                        "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
+                        "selected": false,
+                        "text": {
+                            "en": "LA09 - Mid Ulster District Council"
+                        }
+                    },
+                    {
+                        "id": "3c928df6-dbec-49b0-926d-da947391948e",
+                        "selected": false,
+                        "text": {
+                            "en": "LA08 - Armagh City, Banbridge and Craigavon Borough Council"
+                        }
+                    },
+                    {
+                        "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
+                        "selected": false,
+                        "text": {
+                            "en": "LA07 - Newry, Mourne and Down District Council"
+                        }
+                    },  
+                    {
+                        "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
+                        "selected": false,
+                        "text": {
+                            "en": "LA06 - Ards and North Down Borough Council"
+                        }
+                    },
+                    {
+                        "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
+                        "selected": false,
+                        "text": {
+                            "en": "LA05 - Lisburn and Castlereagh City Council"
+                        }
+                    },
+                    {
+                        "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
+                        "selected": false,
+                        "text": {
+                            "en": "LA04 - Belfast City Council"
+                        }
+                    },
+                    {
+                        "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
+                        "selected": false,
+                        "text": {
+                            "en": "LA03 - Antrim and Newtownabbey Borough Council"
+                        }
+                    },
+                    {
+                        "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
+                        "selected": false,
+                        "text": {
+                            "en": "LA02 - Mid and East Antrim Borough Council"
+                        }
+                    },                          
+                    {
+                        "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
+                        "selected": false,
+                        "text": {
+                            "en": "LA01 - Causeway Coast and Glens Borough Council"
+                        }
+                    }
                   ]
               },
               "datatype": "domain-value",

--- a/coral/pkg/graphs/resource_models/Activity.json
+++ b/coral/pkg/graphs/resource_models/Activity.json
@@ -13031,80 +13031,80 @@
                         },
                         "options": [
                             {
-                                "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
-                                "selected": false,
-                                "text": {
-                                    "en": "27: Antrim and Newtownabbey"
-                                }
-                            },
-                            {
-                                "id": "3c928df6-dbec-49b0-926d-da947391948e",
-                                "selected": false,
-                                "text": {
-                                    "en": "28: Armagh City Banbridge and Craigavon"
-                                }
-                            },
-                            {
-                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
-                                "selected": false,
-                                "text": {
-                                    "en": "29: Belfast"
-                                }
-                            },
-                            {
-                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
-                                "selected": false,
-                                "text": {
-                                    "en": "30: Causeway Coast and Glens"
-                                }
-                            },
-                            {
                                 "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
                                 "selected": false,
                                 "text": {
-                                    "en": "31: Derry City and Strabane"
+                                    "en": "LA11 - Derry City and Strabane District Council"
                                 }
                             },
                             {
                                 "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
                                 "selected": false,
                                 "text": {
-                                    "en": "32: Fermanagh and Omagh"
-                                }
-                            },
-                            {
-                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
-                                "selected": false,
-                                "text": {
-                                    "en": "33: Lisburn and Castlereagh"
-                                }
-                            },
-                            {
-                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
-                                "selected": false,
-                                "text": {
-                                    "en": "34: Mid and East Antrim"
+                                    "en": "LA10 - Fermanagh and Omagh District Council"
                                 }
                             },
                             {
                                 "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
                                 "selected": false,
                                 "text": {
-                                    "en": "35: Mid Ulster"
+                                    "en": "LA09 - Mid Ulster District Council"
+                                }
+                            },
+                            {
+                                "id": "3c928df6-dbec-49b0-926d-da947391948e",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA08 - Armagh City, Banbridge and Craigavon Borough Council"
                                 }
                             },
                             {
                                 "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
                                 "selected": false,
                                 "text": {
-                                    "en": "36: Newry Mourne and Down"
+                                    "en": "LA07 - Newry, Mourne and Down District Council"
                                 }
-                            },
+                            },  
                             {
                                 "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
                                 "selected": false,
                                 "text": {
-                                    "en": "37: Ards and North Down"
+                                    "en": "LA06 - Ards and North Down Borough Council"
+                                }
+                            },
+                            {
+                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA05 - Lisburn and Castlereagh City Council"
+                                }
+                            },
+                            {
+                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA04 - Belfast City Council"
+                                }
+                            },
+                            {
+                                "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA03 - Antrim and Newtownabbey Borough Council"
+                                }
+                            },
+                            {
+                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA02 - Mid and East Antrim Borough Council"
+                                }
+                            },                          
+                            {
+                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA01 - Causeway Coast and Glens Borough Council"
                                 }
                             }
                         ]

--- a/coral/pkg/graphs/resource_models/Consultation.json
+++ b/coral/pkg/graphs/resource_models/Consultation.json
@@ -27461,80 +27461,80 @@
                         },
                         "options": [
                             {
-                                "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
+                                "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
                                 "selected": false,
                                 "text": {
-                                    "en": "37: Ards and North Down"
-                                }
-                            },
-                            {
-                                "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
-                                "selected": false,
-                                "text": {
-                                    "en": "36: Newry Mourne and Down"
-                                }
-                            },
-                            {
-                                "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
-                                "selected": false,
-                                "text": {
-                                    "en": "35: Mid Ulster"
-                                }
-                            },
-                            {
-                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
-                                "selected": false,
-                                "text": {
-                                    "en": "34: Mid and East Antrim"
-                                }
-                            },
-                            {
-                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
-                                "selected": false,
-                                "text": {
-                                    "en": "33: Lisburn and Castlereagh"
+                                    "en": "LA11 - Derry City and Strabane District Council"
                                 }
                             },
                             {
                                 "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
                                 "selected": false,
                                 "text": {
-                                    "en": "32: Fermanagh and Omagh"
+                                    "en": "LA10 - Fermanagh and Omagh District Council"
                                 }
                             },
                             {
-                                "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
+                                "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
                                 "selected": false,
                                 "text": {
-                                    "en": "31: Derry City and Strabane"
-                                }
-                            },
-                            {
-                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
-                                "selected": false,
-                                "text": {
-                                    "en": "30: Causeway Coast and Glens"
-                                }
-                            },
-                            {
-                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
-                                "selected": false,
-                                "text": {
-                                    "en": "29: Belfast"
+                                    "en": "LA09 - Mid Ulster District Council"
                                 }
                             },
                             {
                                 "id": "3c928df6-dbec-49b0-926d-da947391948e",
                                 "selected": false,
                                 "text": {
-                                    "en": "28: Armagh City Banbridge and Craigavon"
+                                    "en": "LA08 - Armagh City, Banbridge and Craigavon Borough Council"
+                                }
+                            },
+                            {
+                                "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA07 - Newry, Mourne and Down District Council"
+                                }
+                            },  
+                            {
+                                "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA06 - Ards and North Down Borough Council"
+                                }
+                            },
+                            {
+                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA05 - Lisburn and Castlereagh City Council"
+                                }
+                            },
+                            {
+                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA04 - Belfast City Council"
                                 }
                             },
                             {
                                 "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
                                 "selected": false,
                                 "text": {
-                                    "en": "27: Antrim and Newtownabbey"
+                                    "en": "LA03 - Antrim and Newtownabbey Borough Council"
+                                }
+                            },
+                            {
+                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA02 - Mid and East Antrim Borough Council"
+                                }
+                            },                          
+                            {
+                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA01 - Causeway Coast and Glens Borough Council"
                                 }
                             }
                         ]

--- a/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
@@ -22734,80 +22734,80 @@
                         },
                         "options": [
                             {
-                                "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
+                                "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
                                 "selected": false,
                                 "text": {
-                                    "en": "37: Ards and North Down"
-                                }
-                            },
-                            {
-                                "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
-                                "selected": false,
-                                "text": {
-                                    "en": "36: Newry Mourne and Down"
-                                }
-                            },
-                            {
-                                "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
-                                "selected": false,
-                                "text": {
-                                    "en": "35: Mid Ulster"
-                                }
-                            },
-                            {
-                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
-                                "selected": false,
-                                "text": {
-                                    "en": "34: Mid and East Antrim"
-                                }
-                            },
-                            {
-                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
-                                "selected": false,
-                                "text": {
-                                    "en": "33: Lisburn and Castlereagh"
+                                    "en": "LA11 - Derry City and Strabane District Council"
                                 }
                             },
                             {
                                 "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
                                 "selected": false,
                                 "text": {
-                                    "en": "32: Fermanagh and Omagh"
+                                    "en": "LA10 - Fermanagh and Omagh District Council"
                                 }
                             },
                             {
-                                "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
+                                "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
                                 "selected": false,
                                 "text": {
-                                    "en": "31: Derry City and Strabane"
-                                }
-                            },
-                            {
-                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
-                                "selected": false,
-                                "text": {
-                                    "en": "30: Causeway Coast and Glens"
-                                }
-                            },
-                            {
-                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
-                                "selected": false,
-                                "text": {
-                                    "en": "29: Belfast"
+                                    "en": "LA09 - Mid Ulster District Council"
                                 }
                             },
                             {
                                 "id": "3c928df6-dbec-49b0-926d-da947391948e",
                                 "selected": false,
                                 "text": {
-                                    "en": "28: Armagh City Banbridge and Craigavon"
+                                    "en": "LA08 - Armagh City, Banbridge and Craigavon Borough Council"
+                                }
+                            },
+                            {
+                                "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA07 - Newry, Mourne and Down District Council"
+                                }
+                            },  
+                            {
+                                "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA06 - Ards and North Down Borough Council"
+                                }
+                            },
+                            {
+                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA05 - Lisburn and Castlereagh City Council"
+                                }
+                            },
+                            {
+                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA04 - Belfast City Council"
                                 }
                             },
                             {
                                 "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
                                 "selected": false,
                                 "text": {
-                                    "en": "27: Antrim and Newtownabbey"
+                                    "en": "LA03 - Antrim and Newtownabbey Borough Council"
+                                }
+                            },
+                            {
+                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA02 - Mid and East Antrim Borough Council"
+                                }
+                            },                          
+                            {
+                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA01 - Causeway Coast and Glens Borough Council"
                                 }
                             }
                         ]

--- a/coral/pkg/graphs/resource_models/Heritage Asset.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset.json
@@ -25245,80 +25245,80 @@
                         },
                         "options": [
                             {
-                                "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
-                                "selected": false,
-                                "text": {
-                                    "en": "27: Antrim and Newtownabbey"
-                                }
-                            },
-                            {
-                                "id": "3c928df6-dbec-49b0-926d-da947391948e",
-                                "selected": false,
-                                "text": {
-                                    "en": "28: Armagh City Banbridge and Craigavon"
-                                }
-                            },
-                            {
-                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
-                                "selected": false,
-                                "text": {
-                                    "en": "29: Belfast"
-                                }
-                            },
-                            {
-                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
-                                "selected": false,
-                                "text": {
-                                    "en": "30: Causeway Coast and Glens"
-                                }
-                            },
-                            {
                                 "id": "5b370006-3baa-4c71-bea7-cbbbf7ed4271",
                                 "selected": false,
                                 "text": {
-                                    "en": "31: Derry City and Strabane"
+                                    "en": "LA11 - Derry City and Strabane District Council"
                                 }
                             },
                             {
                                 "id": "34d99a63-3864-43b3-bad9-a84026d74aa5",
                                 "selected": false,
                                 "text": {
-                                    "en": "32: Fermanagh and Omagh"
-                                }
-                            },
-                            {
-                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
-                                "selected": false,
-                                "text": {
-                                    "en": "33: Lisburn and Castlereagh"
-                                }
-                            },
-                            {
-                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
-                                "selected": false,
-                                "text": {
-                                    "en": "34: Mid and East Antrim"
+                                    "en": "LA10 - Fermanagh and Omagh District Council"
                                 }
                             },
                             {
                                 "id": "fa6dc908-f8b4-4dcb-9452-0c6b888fc6d7",
                                 "selected": false,
                                 "text": {
-                                    "en": "35: Mid Ulster"
+                                    "en": "LA09 - Mid Ulster District Council"
+                                }
+                            },
+                            {
+                                "id": "3c928df6-dbec-49b0-926d-da947391948e",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA08 - Armagh City, Banbridge and Craigavon Borough Council"
                                 }
                             },
                             {
                                 "id": "c3fb7b10-9117-46ac-b1ef-65bca03e9896",
                                 "selected": false,
                                 "text": {
-                                    "en": "36: Newry Mourne and Down"
+                                    "en": "LA07 - Newry, Mourne and Down District Council"
                                 }
-                            },
+                            },  
                             {
                                 "id": "61b1e8b1-8bc1-4bfc-a7c6-13f554f6f239",
                                 "selected": false,
                                 "text": {
-                                    "en": "37: Ards and North Down"
+                                    "en": "LA06 - Ards and North Down Borough Council"
+                                }
+                            },
+                            {
+                                "id": "fe1633e5-a7fa-4550-91c1-a00ce3393ccf",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA05 - Lisburn and Castlereagh City Council"
+                                }
+                            },
+                            {
+                                "id": "4d61c510-0a59-4995-9ec5-a38f640864f6",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA04 - Belfast City Council"
+                                }
+                            },
+                            {
+                                "id": "72a92f38-f802-4926-9758-d1d0f38e1f00",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA03 - Antrim and Newtownabbey Borough Council"
+                                }
+                            },
+                            {
+                                "id": "1b9efca1-96cf-4b7e-8e31-8ca21d1c73fd",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA02 - Mid and East Antrim Borough Council"
+                                }
+                            },                          
+                            {
+                                "id": "c1fda31a-5fcc-45f4-b73c-75db4555284b",
+                                "selected": false,
+                                "text": {
+                                    "en": "LA01 - Causeway Coast and Glens Borough Council"
                                 }
                             }
                         ]

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=9, patch=33)
+APP_VERSION = semantic_version.Version(major=7, minor=9, patch=34)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
Models updated: Consultation, Activity, Heritage Asset, Heritage Asset Revision
Branches updated: Council

## Description
This updates the council lists for the above models. It uses the new NI council list and orders them correctly

## Tests
Reload the models listed above, reload the council branch first
Follow tests here - [#2884](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2884?milestone=433804)