### PR TITLE
#2992: cover null sets in ES and --synchronous for apply_by_sets

### DIFF
--- a/coral/management/commands/apply_sets.py
+++ b/coral/management/commands/apply_sets.py
@@ -45,6 +45,14 @@ class Command(BaseCommand):
             help="Do extra searches to provide relevant statistics?",
         )
 
+        parser.add_argument(
+            "-S",
+            "--synchronous",
+            action="store_true",
+            dest="synchronous",
+            help="Run update-by-query synchronously",
+        )
+
 
     def handle(self, *args, **options):
         # Cannot be imported until Django ready
@@ -52,8 +60,9 @@ class Command(BaseCommand):
         from coral.utils.casbin import SetApplicator
 
         print_statistics = True if options["print_statistics"] else False
+        synchronous = True if options["synchronous"] else False
 
-        set_applicator = SetApplicator(print_statistics=print_statistics, wait_for_completion=True)
+        set_applicator = SetApplicator(print_statistics=print_statistics, wait_for_completion=True, synchronous=synchronous)
         try:
             set_applicator.apply_sets()
         except psycopg2.OperationalError:

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -22,7 +22,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=10, patch=36)
+APP_VERSION = semantic_version.Version(major=7, minor=10, patch=37)
 
 GROUPINGS = {
     "groups": {

--- a/coral/utils/casbin.py
+++ b/coral/utils/casbin.py
@@ -17,9 +17,10 @@ def _consistent_hash(string: str):
     return uuid.UUID(hsh.hexdigest()[::2])
 
 class SetApplicator:
-    def __init__(self, print_statistics, wait_for_completion):
+    def __init__(self, print_statistics, wait_for_completion, synchronous=False):
         self.print_statistics = print_statistics
         self.wait = wait_for_completion
+        self.synchronous = synchronous
 
     def _apply_set(self, se, set_id, set_query, resourceinstanceid=None):
         results = []
@@ -54,7 +55,7 @@ class SetApplicator:
                     "logicalSets": sets
                 }
             })
-            results.append(update_by_query.run(index=RESOURCES_INDEX, wait_for_completion=False))
+            results.append(update_by_query.run(index=RESOURCES_INDEX, wait_for_completion=self.synchronous))
         return results
 
     @context_free

--- a/coral/utils/casbin.py
+++ b/coral/utils/casbin.py
@@ -19,7 +19,7 @@ def _consistent_hash(string: str):
 class SetApplicator:
     def __init__(self, print_statistics, wait_for_completion, synchronous=False):
         self.print_statistics = print_statistics
-        self.wait = wait_for_completion
+        self.wait = wait_for_completion and (not synchronous)
         self.synchronous = synchronous
 
     def _apply_set(self, se, set_id, set_query, resourceinstanceid=None):

--- a/coral/utils/casbin.py
+++ b/coral/utils/casbin.py
@@ -20,6 +20,14 @@ class SetApplicator:
     def __init__(self, print_statistics, wait_for_completion, synchronous=False):
         self.print_statistics = print_statistics
         self.wait = wait_for_completion and (not synchronous)
+        if synchronous:
+            print("""
+                WARNING: synchronous currently 409s due to a
+                limitation of Elasticsearch:
+                  https://stackoverflow.com/questions/56602137/wait-for-completion-of-updatebyquery-with-the-elasticsearch-dsl
+                This may still be useful for debugging purposes.
+                TODO: use the lower-level refresh API for passing retry_on_conflict.
+            """)
         self.synchronous = synchronous
 
     def _apply_set(self, se, set_id, set_query, resourceinstanceid=None):

--- a/coral/utils/casbin.py
+++ b/coral/utils/casbin.py
@@ -45,7 +45,12 @@ class SetApplicator:
             else:
                 bool_query.must(set_query())
                 bool_query.must_not(Nested(path="sets", query=Terms(field="sets.id", terms=[str(set_id)])))
-                source = "ctx._source.sets.addAll(params.logicalSets)"
+                source = """
+                if (ctx._source.sets == null) {
+                    ctx._source.sets = [];
+                }
+                ctx._source.sets.addAll(params.logicalSets);
+                """
                 sets = [{"id": str(set_id)}]
             dsl.add_query(bool_query)
             update_by_query = UpdateByQuery(se=se, query=dsl, script={


### PR DESCRIPTION
# What does this PR do

- Checks whether a sets member is null, as arches#coral-7.6 now has that possibility
- Adds a flag to force synchronous execution of update-by-query to see errors.

# How to test

1 - Try creating a logset that matches everything
2 - Create a new resource that will be matched
3 - The resource is correctly matched and the visibility updates with the new resource

---

Run `apply_sets` manually with `python manage.py apply_sets --synchronous` on an instance with logsets and many resources.
See Elasticsearch timeout as the run takes too long.
You can try introducing an issue to the Painless script, if running locally, and this will appear only when the `-S` flag is used.

# Who should test

@StuCM or @OwenGalvia 