### PR TITLE
fix: use another view for the api middleware file upload

### DIFF
--- a/coral/urls.py
+++ b/coral/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls.static import static
 from django.conf.urls.i18n import i18n_patterns
 from django.urls import include, path
 from arches.app.views.user import UserManagerView
-from arches.app.views.file import TempFileView
+from coral.views.api_file import TempFileView
 from coral.views.group_manager import GroupManagerView
 from coral.views.person_user import PersonUserSignupView
 from arches.app.views.plugin import PluginView

--- a/coral/views/api_file.py
+++ b/coral/views/api_file.py
@@ -1,0 +1,49 @@
+import logging
+import uuid
+import base64
+from PIL import Image
+from django.utils.translation import gettext as _
+from django.views.generic import View
+from django.shortcuts import redirect
+from django.views.decorators.csrf import csrf_exempt
+from django.utils.decorators import method_decorator
+from arches.app.models.models import File, TempFile
+from arches.app.models.system_settings import settings
+from django.core.exceptions import PermissionDenied
+from arches.app.utils.response import JSONResponse
+from django.http import HttpResponse, HttpResponseNotFound
+from mimetypes import MimeTypes
+
+@method_decorator(csrf_exempt, name="dispatch")
+class TempFileView(View):
+    def get(self, request, file_id):
+        #file_id = request.GET.get("file_id")
+        file = TempFile.objects.get(pk=file_id)
+        try:    
+            with file.path.open('rb') as f:
+                # sending response 
+                contents = f.read()
+                file_mime = MimeTypes().guess_type(file.path.name)[0]
+                response = HttpResponse(contents, content_type=file_mime)
+                response['Content-Disposition'] = 'attachment; filename={}'.format(file.path.name.split('/')[1])
+
+        except IOError:
+            # handle file not exist case here
+            response = HttpResponseNotFound('<h1>File not exist</h1>')
+
+        return response
+    
+    def post(self, request):
+        file_id = uuid.uuid4()
+        file_name = request.POST.get("fileName", None)
+        file = request.FILES.get("file", None)
+        file.file_name = file_name
+        file.name = file_name
+        temp_file = TempFile.objects.create(fileid=file_id, path=file)
+        temp_file.save()
+
+        response_dict = {
+            "file_id": file_id
+        }
+
+        return JSONResponse(response_dict)


### PR DESCRIPTION
creates a new file to copy the temp_file view but with the csrf free decorator