### PR TITLE
Fix: 3062 Enforcement Report Link Removal

### DIFF
--- a/coral/templates/views/components/reports/scenes/enforcements.htm
+++ b/coral/templates/views/components/reports/scenes/enforcements.htm
@@ -1,5 +1,5 @@
 <!-- ko foreach: {data: enforcements, as: 'enforcement'} -->
-<span data-bind="attr: {href:enforcement.url, title: enforcement.name}">
+<span>
     <h4 class="workflow-select-title" data-bind="text: enforcement.name"></h4>
 </span>
 <!-- /ko -->

--- a/coral/templates/views/components/reports/scenes/enforcements.htm
+++ b/coral/templates/views/components/reports/scenes/enforcements.htm
@@ -1,5 +1,5 @@
 <!-- ko foreach: {data: enforcements, as: 'enforcement'} -->
-<a data-bind="attr: {href:enforcement.url, title: enforcement.name}">
+<span data-bind="attr: {href:enforcement.url, title: enforcement.name}">
     <h4 class="workflow-select-title" data-bind="text: enforcement.name"></h4>
-</a>
+</span>
 <!-- /ko -->


### PR DESCRIPTION
# PR - Report Enforcement Link Removal

## Description of the Issue
This removes the a link from the Enforcement ID when displayed on the report page of a Heritage Asset

**Related Task:** [3062](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/3062)

---

## Changes Proposed
Updates the enforcements.htm to use a span instead of a 

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- [ ] (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- [ ] `Concept Name`: [Description of the concept.]
- [ ] (Add more concepts as needed)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- [ ] `Report Name`: [Description of changes.]
- [ ] (Add more reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- [ ] Create a new enforcement and attach it to a HA
- [ ] Navigate to the report page of the HA
- [ ] Navigate to pending enforcements
- [ ] The enforcement should be displayed shouldn't have a link

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
