### PR TITLE
HotFix: DAERA and Agri Workflow Number generation bug

### DIFF
--- a/coral/functions/afc_number_function.py
+++ b/coral/functions/afc_number_function.py
@@ -1,5 +1,6 @@
 from arches.app.functions.base import BaseFunction
 from coral.utils.afc_number import AfcNumber
+from coral.utils.ail_number import AilNumber
 from arches.app.models.tile import Tile
 
 SYSTEM_REFERENCE_NODEGROUP = "b37552ba-9527-11ea-96b5-f875a44e0e11"
@@ -14,8 +15,6 @@ details = {
     "classname": "AfcNumberFunction",
     "component": "",
 }
-
-
 class AfcNumberFunction(BaseFunction):
     def post_save(self, tile, request, context):
         if context and context.get('escape_function', False):
@@ -24,9 +23,22 @@ class AfcNumberFunction(BaseFunction):
         resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
         id_number = tile.data.get(SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID, None)
 
-        afcn = AfcNumber()
-        if afcn.validate_id(id_number, resource_instance_id):
-            print("AFC ID is valid: ", id_number)
-            return
+        id_number_string = id_number.get("en").get("value")
 
-        raise ValueError('This AFC Number has already been generated. This is a rare case where 2 people have generated the same number at the same time. Please try to save again.')
+        if id_number_string.startswith("AIL"):
+            daera_num = AilNumber()
+            if daera_num.validate_id(id_number, resource_instance_id):
+                print("AIL ID is valid: ", id_number)
+                return
+            raise ValueError(
+                'This ID number has already been generated. This is a rare case where 2 people have generated the same number at the same time. Please refresh and save again.'
+                )
+
+        elif id_number_string.startswith("AFC"):
+            afcn = AfcNumber()
+            if afcn.validate_id(id_number, resource_instance_id):
+                print("AFC ID is valid: ", id_number)
+                return
+            raise ValueError(
+                'This ID number has already been generated. This is a rare case where 2 people have generated the same number at the same time. Please refresh and save again.'
+                )

--- a/coral/media/js/views/components/workflows/agriculture-and-forestry-consultation-workflow/generate-afc-number.js
+++ b/coral/media/js/views/components/workflows/agriculture-and-forestry-consultation-workflow/generate-afc-number.js
@@ -15,7 +15,7 @@ define([
 
     if (ko.isObservable(this.tile().data[this.SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID])) {
       this.tile().data[this.SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID].subscribe((val) => {
-        if (val.en.value !== this.afcValue()) {
+        if (val.en.value.startsWith("CON")) {
           this.tile().data[this.SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID]({en: { direction: 'ltr', value: this.afcValue()}})
         }
       })

--- a/coral/media/js/views/components/workflows/daera-workflow/generate-ail-number.js
+++ b/coral/media/js/views/components/workflows/daera-workflow/generate-ail-number.js
@@ -14,7 +14,7 @@ define([
     this.ailValue = ko.observable()
     if (ko.isObservable(this.tile().data[this.SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID])) {
       this.tile().data[this.SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID].subscribe((val) => {
-        if (val.en.value !== this.ailValue()) {
+        if (val.en.value.startsWith("CON")) {
           this.tile().data[this.SYSTEM_REFERENCE_RESOURCE_ID_NODE_ID]({en: { direction: 'ltr', value: this.ailValue()}})
         }
       })

--- a/coral/media/js/views/components/workflows/get-selected-monument-details-with-count.js
+++ b/coral/media/js/views/components/workflows/get-selected-monument-details-with-count.js
@@ -11,9 +11,6 @@ define([
   function viewModel(params) {
     CardComponentViewModel.apply(this, [params]);
 
-    this.SYSTEM_REFERENCE_NODEGROUP = '325a2f2f-efe4-11eb-9b0c-a87eeabdefba';
-    this.SYSTEM_REFERENCE_RESOURCE_ID_NODE = '325a430a-efe4-11eb-810b-a87eeabdefba';
-
     this.HERRITAGE_ASSET_REFERENCES_NODEGROUP = 'e71df5cc-3aad-11ef-a2d0-0242ac120003'
     this.SMR_NUMBER_NODE = '158e1ed2-3aae-11ef-a2d0-0242ac120003';
 
@@ -144,7 +141,7 @@ define([
     
     this.getLatestTile = async () => {
       try {
-        const tiles = await this.fetchTileData(this.tile.resourceinstance_id);
+        const tiles = await this.fetchTileData(this.tile.resourceinstance_id, this.dataNode);
 
         if (!tiles?.length) return;
 


### PR DESCRIPTION
## Description
The number generation was not saving as the system reference tile was not saving correctly.
The issue is that the get selected monument component was pulling all the tiles and then iterating through and replacing the tile data. This was overwriting the already saved system reference number.

There was also no validation to stop duplicate numbers being saved

### Change
This change only calls the Related HA nodegroup as to not overwrite the other tiles.
It also updates the AFC validation function to include both AIL and AFC numbers to stop duplication