### PR TITLE
fix: change stale data import location to pkg folder

### DIFF
--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -375,7 +375,7 @@ class ScanForDataRisks():
       
       management.call_command("packages",
             operation="import_business_data",
-            source=f"stale_data_{sanitised_model_name}.json",
+            source=f"coral/pkg/business_data/files/stale_data_{sanitised_model_name}.json",
             overwrite="overwrite",
             prevent_indexing=False,
             escape_function=True


### PR DESCRIPTION
## Description

When no data changes have been made it was still trying to import the stale data from root but its saved location had been moved to the pkg folder.

This PR updates the import dir