### PR TITLE
Feat/#2712 Add HERONI Excavation Report Notifications

### DIFF
--- a/coral/functions/notifications/notification_base_strategy.py
+++ b/coral/functions/notifications/notification_base_strategy.py
@@ -18,6 +18,8 @@ class NotificationStrategy():
 
         if check_prefix and not self.name.startswith(check_prefix):
             return
+        
+        self._delete_existing_notification()
                                 
         self.notify_groups()
 
@@ -31,8 +33,6 @@ class NotificationStrategy():
         return  name
     
     def create_notification(self):
-        self._delete_existing_notification()
-
         message_template = self.config.get('message', None)
         message = message_template.format(name=self.name) if message_template else None
 
@@ -78,7 +78,6 @@ class NotificationStrategy():
 
         if 'email' in self.notification.context:
             self.update_email_details(user)
-
         user_x_notification = models.UserXNotification(
             notif = self.notification,
             recipient = user
@@ -103,7 +102,7 @@ class NotificationStrategy():
     def _delete_existing_notification(self):
         existing_notification = models.Notification.objects.filter(
             context__resource_instance_id=self.resource_instance_id
-        ).first()
+        ).exclude(pk=self.notification.pk).first()
 
         if existing_notification:
             existing_notification.delete()


### PR DESCRIPTION
# PR - Add HERONI Excavation Report Notifications

## Description of the Issue
This adds the Records and Designation user and manager groups to the excavation notifications. It looks for the 'Consultation Type' and if this is 'Final' will send a notification to the groups

**Related Task:** [2712](https://tree.taiga.io/project/viktoriabon-coral-phase-2/task/2712)

---

## Changes Proposed
- Adds the Record and Designation groups into the Report Strategy notification
- Update the change for the message string to affect the notification and not the config
- Add in a query to the EditLog to check for new tiles in the report and only ping notifications on a new tile or classification type change
- Moved the deletion of existing notification to the send as to not delete the notification when the function is triggered

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- [ ] (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- [ ] `Concept Name`: [Description of the concept.]
- [ ] (Add more concepts as needed)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- [ ] `Report Name`: [Description of changes.]
- [ ] (Add more reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- [ ] Add a user to the record and designations
- [ ] Open licence workflow as admin
- [ ] Create a new report with classification type as preliminary - save
- [ ] Log in as your user - should not have received a notification
- [ ] edit the report and set to final
- [ ] user should have received a notification
- [ ] create a second report and with preliminary and save
- [ ] should not have received a notification

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]