### PR TITLE
Fix: Migration Tool - Concept conversion and Group hydration

### DIFF
--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -251,9 +251,12 @@ class ScanForDataRisks():
             if self.mapping:
               mapping = next(value for key, value in self.mapping.items() if key == node)
             else:
-              answer = input("No mapping has been provided. Do you want to continue with the default mapping setting the value to null? [y/N]: ")
+              answer = input(f"No mapping has been provided for {node}. Do you want to continue with the default mapping setting the value to null? [y/N]: ")
               if answer.lower() == 'y':
-                 mapping = { 'default': None }
+                if self.mapping is None:
+                    self.mapping = {}
+                self.mapping[node] = { 'default': None }
+                mapping = { 'default': None }
           except Exception as e:
             raise ValueError(f"No mapping could be found in the file for the node {node}") from e
           TransformData().concept_to_concept(tile_json, node, mapping)

--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -599,7 +599,7 @@ class GroupTransform():
                 if self.MEMBER_NODE in tile["data"]:
                     if tile["data"][self.MEMBER_NODE]: 
                         if len(new_members) > 0:
-                            match = next((item for item in new_members if item['groupId'] == resource['resourceinstance']["resourceinstanceid"]), None)
+                            match = [item['value'] for item in new_members if item['groupId'] == resource['resourceinstance']["resourceinstanceid"]]
                             if match:
                                 tile["data"][self.MEMBER_NODE].append(match['value'])
                                 

--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -525,11 +525,12 @@ class TransformData():
                 new_value = Value.objects.filter(concept_id=mapping_value, valuetype='prefLabel').first().valueid
             else:
                 # Allows for a null value in the mapping
-                new_value = mapping_value
+                new_value = None
 
           except Exception as e:
               raise ValueError(f"The concept {mapping_value} was not found. Have you imported your new concept and collection?") from e
-          updated_values.append(str(new_value))
+          if new_value:
+            updated_values.append(str(new_value))
 
         if len(updated_values) > 1:
           tile_json['data'][node] = updated_values # this will update the list of concept values


### PR DESCRIPTION
# PR - Migration Tool - Concept conversion and Group hydration

## Description of the Issue
There were some issues in the data conversion tools. The concept conversion would error when looking at a list and the rehydrate members function was only adding a single member into the groups. The default mapping was asking if you want to use default for every entry.

**Related Task:** []()

---

## Changes Proposed
- Updated `concept_to_concept` to handle lists 
- Changed the next call to building a list for `rehydrate_members` to grab all the members
- Updated the `handle_concept_change` to set the global mapping when you choose default, and adds the node into the message

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- (Add workflows as needed)

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- (Add reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- Add multiple concepts to a concept list node
- Change the node concept
- Use the default None initially - check if it converts removing all the concepts
- Repeat the process with a mapping file - check it converts and updates the list as it should
- Add several members to a group
- run the `rehydrate_members` - check that all the members are still in the group

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
