### PR TITLE
Fix: Dashboards - Filter name duplication and task card overflow 

### DIFF
--- a/coral/media/css/project.css
+++ b/coral/media/css/project.css
@@ -1072,8 +1072,8 @@ span.rp-tile-title {
 
 .dashboard-counter-card {
     width: 300px;
-    min-height: 120px;
-    margin:2rem 5rem;
+    max-height: 120px;
+    margin:1.22rem 5rem;
     padding: 0 1rem 1rem 1rem;
 }
 

--- a/coral/media/js/views/components/plugins/dashboard.js
+++ b/coral/media/js/views/components/plugins/dashboard.js
@@ -159,15 +159,6 @@ define([
         }
       })
 
-      window.addEventListener('resize', debounce(async () => {
-          const prevItemsPerPage = this.itemsPerPage();
-          updateItemsPerPage();
-          if (prevItemsPerPage === this.itemsPerPage()){
-            return
-          }
-          await getTasks('true');
-      }, 200));
-
       this.newPage = async (pageNumber) => {
           this.currentPage(pageNumber);
           await getTasks('false');

--- a/coral/templates/views/components/plugins/dashboard.htm
+++ b/coral/templates/views/components/plugins/dashboard.htm
@@ -1,4 +1,4 @@
-<div style="margin: 15px; display: flex; flex-direction: column; flex-wrap: wrap; width: 100%">
+<div style="margin: 15px; display: flex; flex-direction: column; width: 100%; height: 100vh; padding-bottom: 115px">
   <!--ko if: loading() -->
     <div class='loading-mask'></div>
   <!--/ko-->
@@ -55,7 +55,7 @@
       </select>
     <!--/ko-->
   </div>
-  <div style="display: flex; width: 100%; align-items: flex-start; justify-content: center; flex-grow: 1;">
+  <div style="display: flex; width: 100%; align-items: flex-start; justify-content: center; overflow: auto; flex-grow: 1;">
       <!--ko if: loadingCards() -->
         <div class='branch-list-loading-mask'></div>
       <!--/ko-->
@@ -74,7 +74,7 @@
   <!--ko if: resources().length -->
     <div id="paginator" data-bind="with: paginator" style="position: absolute; bottom: 0px; width: 100%">
       <nav class="text-center" aria-label="paginator">
-          <ul class="pagination" role="menubar">
+          <ul class="pagination" role="menubar" style="margin: 10px 0">
               <li><a data-bind="css: {'disabled': !has_previous()}, onEnterkeyClick, click: $parent.newPage.bind($parent, previous_page_number()), 
                   attr: {'aria-label': $root.translations.previousPage, 'aria-disabled': !has_previous(), 'role': 'menuitem'}" href="#">«</a></li>
               <!-- ko foreach: { data: pages, as: 'page' } -->

--- a/coral/views/dashboards/planning_strategy.py
+++ b/coral/views/dashboards/planning_strategy.py
@@ -160,7 +160,7 @@ class PlanningTaskStrategy(TaskStrategy):
                 groups_filter = [
                     {'id': TYPE_ASSIGN_HB, 'name': 'HB Group', 'type': 'group'}, 
                     {'id': TYPE_ASSIGN_HM, 'name': 'HM Group', 'type': 'group'}
-                ]       
+                ]     
 
             filter_options = [
                 {'id': 'all', 'name': 'All', 'type': 'all'}, 
@@ -175,16 +175,18 @@ class PlanningTaskStrategy(TaskStrategy):
     def get_group_members(self, groups):
         from arches_orm.models import Group
         with admin():
-            members_filter = []
+            members_filter = {}
             for group in groups:
                     group_resource = Group.find(group)
-                    members = [
-                        {'id': str(member.id), 'name': member.name[0].full_name, 'type': 'person'}
-                        for member in group_resource.members
-                        if type(member).__name__ == 'PersonRelatedResourceInstanceViewModel'
-                    ]
-                    members_filter.extend(members)
-            return members_filter
+                    for member in group_resource.members:
+                        if type(member).__name__ == 'PersonRelatedResourceInstanceViewModel':
+                            members_key = str(member.id)
+                            members_filter[members_key] = {
+                                'id': str(member.id), 
+                                'name': member.name[0].full_name, 
+                                'type': 'person'
+                            }
+            return list(members_filter.values())
     
     def build_data(self, consultation, groupId):
         from arches_orm.models import Consultation


### PR DESCRIPTION
# PR - Dashboards - Filter name duplication and task card overflow 

## Description of the Issue
This fixes an issue where the users names in the dashboard filter were duplicating
It fixes styling issues where the task cards were overflowing

**Related Task:** None

---

## Changes Proposed
- CSS updated to add an overflow to the task cards container
- CSS changed to reduce the size of the counters
- Updated the filter function when grabbing the group members to only allow unique entries

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- (Add workflows as needed)

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- (Add reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- Open the dashboard with multiple tasks
- Reduce the height of the screen - should create a scroll for the tasks
- When you resize the screen it shouldn't make a call for new tasks, this only happens on refresh
- In the filter drop down in planning you shouldn't see duplicates of the same name

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
