### PR TITLE
fix: issue with pagination

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -23,7 +23,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=12, patch=42)
+APP_VERSION = semantic_version.Version(major=7, minor=12, patch=43)
 
 GROUPINGS = {
     "groups": {

--- a/coral/views/dashboards/excavation_strategy.py
+++ b/coral/views/dashboards/excavation_strategy.py
@@ -61,8 +61,8 @@ class ExcavationTaskStrategy(TaskStrategy):
             """
             copyQueryBuilder = copy.deepcopy(queryBuilder) # ? We copy to not reference the main data as we can only apply 1 selector onto the query builder
             start_index = (page -1) * page_size
-            end_index = (page * page_size)
-            return copyQueryBuilder.offset(start_index, end_index)
+                
+            return copyQueryBuilder.offset(start_index, page_size)
     
         def get_count(queryBuilder: QueryBuilder) -> int:
             """

--- a/coral/views/dashboards/planning_strategy.py
+++ b/coral/views/dashboards/planning_strategy.py
@@ -164,7 +164,7 @@ class PlanningTaskStrategy(TaskStrategy):
                 """
                 copyQueryBuilder = copy.deepcopy(queryBuilder)
                 start_index = (page -1) * page_size
-                
+
                 return copyQueryBuilder.offset(start_index, page_size)
             
             def get_counters(queryBuilder: "QueryBuilder") -> Dict[str, Dict[str, int | None]]:
@@ -233,8 +233,6 @@ class PlanningTaskStrategy(TaskStrategy):
 
             total_resources = get_count(queryBuilder)
             resources = get_paginated_resources(queryBuilder)
-
-            print('LENGTH OF RESOURCES : ', len(resources))
 
             tasks = []
 

--- a/coral/views/dashboards/planning_strategy.py
+++ b/coral/views/dashboards/planning_strategy.py
@@ -164,8 +164,8 @@ class PlanningTaskStrategy(TaskStrategy):
                 """
                 copyQueryBuilder = copy.deepcopy(queryBuilder)
                 start_index = (page -1) * page_size
-                end_index = (page * page_size)
-                return copyQueryBuilder.offset(start_index, end_index)
+                
+                return copyQueryBuilder.offset(start_index, page_size)
             
             def get_counters(queryBuilder: "QueryBuilder") -> Dict[str, Dict[str, int | None]]:
                 """
@@ -233,6 +233,8 @@ class PlanningTaskStrategy(TaskStrategy):
 
             total_resources = get_count(queryBuilder)
             resources = get_paginated_resources(queryBuilder)
+
+            print('LENGTH OF RESOURCES : ', len(resources))
 
             tasks = []
 


### PR DESCRIPTION
# PR - ADD PR TITLE

## Description of the Issue
Fixed issue with pagination calulation towards dashboards
- excavation strategy
- planning strategy

Just as a future note that offset takes in the `.offset($offset, $amount)`

**Related Task:** []()

---

## Changes Proposed
- _Add a list of propsed changes_

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [X] Bug Fix

---

---
## Commands
```
make run
make webpack
```

## Tests
- Run a dashboard, one of the broken dashboard with data inside
- Click next page and it should only show 8 items, if the next page shows more than 8 items then it's still broken

---

