### PR TITLE
Fix: SMC Init Workflow Slug

### DIFF
--- a/coral/plugins/init-workflow.json
+++ b/coral/plugins/init-workflow.json
@@ -109,7 +109,7 @@
       },
       {
         "workflowid": "aa66f3d7-1bbb-407a-9447-736cb6d5203c",
-        "slug": "open-workflow?workflow-slug=scheduled-monument-consent-workflow",
+        "slug": "open-scheduled-monument-consent-workflow?workflow-slug=scheduled-monument-consent-workflow",
         "name": "SMC",
         "icon": "fa fa-file-text",
         "bgColor": "#86679c",


### PR DESCRIPTION
# PR - SMC Init Workflow Slug

## Description of the Issue
The SMC workflow slug had been changed during a merge conflict. This updates it to use the correct slug

**Related Task:** []()

---

## Changes Proposed
- Update the SMC workflow slug in init workflow

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- (Add workflows as needed)

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- (Add reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- (Add tests as needed)

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
