### PR TITLE
fix: remove save from the map on ranger inspection

### DIFF
--- a/coral/plugins/ranger-inspection-workflow.json
+++ b/coral/plugins/ranger-inspection-workflow.json
@@ -87,6 +87,8 @@
         "name": "map-step",
         "title": "Map",
         "required": false,
+        "saveWithoutProgressing": true,
+        "hiddenWorkflowButtons": ["save", "undo"],
         "layoutSections": [
           {
             "componentConfigs": [
@@ -114,8 +116,7 @@
             ]
           }
         ],
-        "workflowstepclass": "workflow-form-component",
-        "hiddenWorkflowButtons": []
+        "workflowstepclass": "workflow-form-component"
       },
       {
         "name": "inspection-step",


### PR DESCRIPTION
# PR -remove save from the map on ranger inspection
## Description of the Issue
The report was having issues with displaying the map geoms. To avoid this the easiest solution is to prevent the map from saving in the workflow as it is only needed to display the HA locations

**Related Task:** []()

---

## Changes Proposed
- Changed the map step to only show next and previous step buttons

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [x] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- Ranger Inspection

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- (Add reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- (Add tests as needed)

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
