### PR TITLE
Fix: Reverse the Enforcement tasks so newest is first

### DIFF
--- a/coral/media/js/views/components/plugins/view-enforcements.js
+++ b/coral/media/js/views/components/plugins/view-enforcements.js
@@ -207,8 +207,7 @@ define([
             const enforcements = json.results.hits.hits.map((hit) => {
               return hit._source;
             });
-            
-            this.tasks(enforcements);
+            this.tasks(enforcements.reverse());
             this.updatePaginatedItems();
           });
       }, 


### PR DESCRIPTION
# PR - Reverse the Enforcement tasks so newest is first

## Description of the Issue
The enforcement task list was showing the newest at the end. The list has been reversed

**Related Task:** []()

---

## Changes Proposed
- Reverse the fetched tasks

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- (Add workflows as needed)

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- (Add reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- Create several enforcements
- Navigate to the enforcement dashboard
- The last created should be the first in the list

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
