### PR TITLE
Fix: Dashboard SQL Builder

### DIFF
--- a/coral/views/dashboards/designation_strategy.py
+++ b/coral/views/dashboards/designation_strategy.py
@@ -134,17 +134,17 @@ class DesignationTaskStrategy(TaskStrategy):
         utilities = Utilities()
 
         resource_data = {
-            'id': str(resource.id),
-            'resourceid': resource.system_reference_numbers.uuid.resourceid,
+            'id': utilities.node_check(lambda: str(resource.id)),
+            'resourceid': utilities.node_check(lambda: resource.system_reference_numbers.uuid.resourceid),
             'state': 'HeritageAsset',
-            'displayname': resource._.resource.descriptors['en']['name'],
-            'hmcreferencenumber': resource.hmc_reference.hmc_reference_number,
-            'historicparksandgardens': resource.heritage_asset_references.historic_parks_and_gardens,
-            'ihrnumber': resource.heritage_asset_references.ihr_number,
-            'hbnumber': resource.heritage_asset_references.hb_number,
-            'smrnumber': resource.heritage_asset_references.smr_number,
+            'displayname': utilities.node_check(lambda: resource._.resource.descriptors['en']['name']),
+            'hmcreferencenumber': utilities.node_check(lambda: resource.hmc_reference.hmc_reference_number),
+            'historicparksandgardens': utilities.node_check(lambda: resource.heritage_asset_references.historic_parks_and_gardens),
+            'ihrnumber': utilities.node_check(lambda: resource.heritage_asset_references.ihr_number),
+            'hbnumber': utilities.node_check(lambda: resource.heritage_asset_references.hb_number),
+            'smrnumber': utilities.node_check(lambda: resource.heritage_asset_references.smr_number),
             'monumenttype': self.extract_value(utilities.node_check(lambda: resource.construction_phases[0].phase_classification.monument_type)),
-            'inputdatevalue': resource.garden_sign_off.input_date.input_date_value,
+            'inputdatevalue': utilities.node_check(lambda: resource.garden_sign_off.input_date.input_date_value),
             'statutoryconsulteenotificationdatevalue': utilities.node_check(lambda: resource.approvals[0].statutory_consultee_notification_date.statutory_consultee_notification_date_value)
         }
 

--- a/coral/views/dashboards/designation_strategy.py
+++ b/coral/views/dashboards/designation_strategy.py
@@ -72,11 +72,10 @@ class DesignationTaskStrategy(TaskStrategy):
             
             def get_counts():
                 results = run_sql_query(sort_by, count=True)
-                total = sum(x[1] for x in results)
-                print("TOTAL", total)
-                return {
-                    'total': total
-                }
+                counts = dict(results)
+                total = sum(counts.values())
+                counts['total'] = total
+                return counts
                 
 
             def _setup_default_conditions_and_get_count():
@@ -152,7 +151,8 @@ class DesignationTaskStrategy(TaskStrategy):
             # _apply_selectors()
 
             resource_counts = get_counts()
-            total_resources = resource_counts['total']
+            total_resources = resource_counts.get('total', 0)
+            counters = self.get_counters(counts=resource_counts)
 
             # start_index = (page -1) * page_size
             # end_index = (page * page_size)
@@ -174,8 +174,6 @@ class DesignationTaskStrategy(TaskStrategy):
                 else:
                     task = self.build_data(resource, groupId)
                 tasks.append(task)
-
-            counters = {} #self.get_counters()
             
             return tasks, total_resources, counters
     
@@ -208,12 +206,12 @@ class DesignationTaskStrategy(TaskStrategy):
                 {'id': 'stat_date', 'name': 'Statutory Consultee Notification Date', 'type': 'date'}
         ]
 
-    def get_counters(self):
+    def get_counters(self, counts):
         return {
             'Resource Types': {
-                'Heritage Assets': len(self.heritage_assets),
-                'Designations': len(self.heritage_asset_revisions),
-                'Evaluation Meetings': len(self.evaluation_meetings)
+                'Heritage Assets': counts.get('Monument', 0),
+                'Designations': counts.get('MonumentRevision', 0),
+                'Evaluation Meetings': counts.get('Consultation', 0)
             }
         }
     

--- a/coral/views/dashboards/designation_strategy.py
+++ b/coral/views/dashboards/designation_strategy.py
@@ -5,7 +5,7 @@ from coral.views.dashboards.dashboard_utils import Utilities
 from arches_orm.view_models import ConceptListValueViewModel, ConceptValueViewModel
 from coral.views.dashboards.sql_query.builder import build_query
 from coral.views.dashboards.sql_query.config.designation_config import DESIGNATION_SQL_QUERY_CONFIG
-from django.db import connection
+from django.db import connection, DatabaseError
 from arches_orm.adapter import admin 
 from typing import List
 import pdb
@@ -49,11 +49,13 @@ class DesignationTaskStrategy(TaskStrategy):
                 else:
                     reverse = True if sort_order == 'desc' else False
                     query = build_query(sort_by, reverse=reverse, filter=filter_dict, limit=limit, offset=offset, config=DESIGNATION_SQL_QUERY_CONFIG)
-
-                with connection.cursor() as cursor:
-                    cursor.execute(query)
-                    results = cursor.fetchall()
-                return results
+                try:
+                    with connection.cursor() as cursor:
+                        cursor.execute(query)
+                        results = cursor.fetchall()
+                    return results
+                except Exception as e:
+                    raise DatabaseError(f"Error executing SQL query: {e}")
             
             def get_counts():
                 results = run_sql_query(count=True)

--- a/coral/views/dashboards/designation_strategy.py
+++ b/coral/views/dashboards/designation_strategy.py
@@ -71,7 +71,7 @@ class DesignationTaskStrategy(TaskStrategy):
                 filter_dict = {'id': filter, 'type': filter_type}
 
                 if count:
-                    query = build_query(sort_by, count=True)
+                    query = build_query(sort_by, filter=filter_dict, count=True)
                 else:
                     reverse = True if sort_order == 'desc' else False
                     query = build_query(sort_by, reverse=reverse, filter=filter_dict, limit=limit, offset=offset)

--- a/coral/views/dashboards/sql_query.py
+++ b/coral/views/dashboards/sql_query.py
@@ -122,7 +122,7 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
                     SELECT 1 FROM tiles t_filter
                     WHERE t_filter.resourceinstanceid = t_fixed.resourceinstanceid
                     AND t_filter.nodegroupid = '447973ce-d7e2-11ee-a4a1-0242ac120006'
-                    AND t_filter.tiledata ->> '447973ce-d7e2-11ee-a4a1-0242ac120006' = '{council_filter}'
+                    AND t_filter.tiledata ->> '447973ce-d7e2-11ee-a4a1-0242ac120006' = '{filter_value}'
                 )
                 """,
             'MonumentRevision': """
@@ -130,7 +130,7 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
                     SELECT 1 FROM tiles t_filter
                     WHERE t_filter.resourceinstanceid = t_fixed.resourceinstanceid
                     AND t_filter.nodegroupid = '02003ed4-b2b5-4fcc-847b-bc34e7c72ee3'
-                    AND t_filter.tiledata ->> '02003ed4-b2b5-4fcc-847b-bc34e7c72ee3' = '{council_filter}'
+                    AND t_filter.tiledata ->> '02003ed4-b2b5-4fcc-847b-bc34e7c72ee3' = '{filter_value}'
                 )
                 """,
             'Consultation': """
@@ -151,10 +151,29 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
                                 ) as value
                             )
                             AND t_council.nodegroupid = '447973ce-d7e2-11ee-a4a1-0242ac120006'
-                            AND t_council.tiledata ->> '447973ce-d7e2-11ee-a4a1-0242ac120006' = '{council_filter}'
+                            AND t_council.tiledata ->> '447973ce-d7e2-11ee-a4a1-0242ac120006' = '{filter_value}'
                     )
             )
                 """,
+        },
+        'date': {
+            'Monument': """
+                EXISTS (
+                    SELECT 1 FROM tiles t_filter
+                    WHERE t_filter.resourceinstanceid = t_fixed.resourceinstanceid
+                    AND t_filter.nodegroupid = '7e0533aa-37b7-11ef-9263-0242ac150006'
+                    AND t_filter.tiledata ->> '85396d94-37bc-11ef-9263-0242ac150006' IS NOT NULL
+                )
+                """,
+            'MonumentRevision': """
+                EXISTS (
+                    SELECT 1 FROM tiles t_filter
+                    WHERE t_filter.resourceinstanceid = t_fixed.resourceinstanceid
+                    AND t_filter.nodegroupid = '3c51740c-dbd0-11ee-8835-0242ac120006'
+                    AND t_filter.tiledata ->> 'd70da550-3798-11ef-a167-0242ac150006' IS NOT NULL
+                )
+                """,
+            'Consultation': ""
         },
     }
 
@@ -168,14 +187,14 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
         nodegroupid = ref_paths[model_type]['nodegroupid']
         sql_path = ref_paths[model_type]['sql']
         base_filter = base_filters[model_type]
-        if filter and filter['type'] == 'council':
-            council_filter = filter['id']
-            extra = extra_filters['council'][model_type].format(council_filter=council_filter)
+        if filter and filter['type'] in extra_filters.keys():
+            filter_value = filter['id']
+            extra = extra_filters[filter['type']][model_type].format(filter_value=filter_value)  
         else:
-            extra = extra_filters.get(model_type)
+            extra = None          
 
         full_filter = base_filter
-        print("EXTRA", extra)
+
         if extra:
             full_filter = f"({base_filter}) AND ({extra})"
 

--- a/coral/views/dashboards/sql_query.py
+++ b/coral/views/dashboards/sql_query.py
@@ -1,0 +1,177 @@
+def build_query(sort_by, reverse=False, limit=6, offset=0):
+
+    base_sort = {
+        'Monument': {
+            'sql': "'325a430a-efe4-11eb-810b-a87eeabdefba' -> 'en' ->> 'value'",
+            'nodegroupid': '325a2f2f-efe4-11eb-9b0c-a87eeabdefba'
+        },
+        'MonumentRevision': {
+            'sql': "'52403903-9f4c-400f-81ce-09a5e8b9d925' -> 'en' ->> 'value'",
+            'nodegroupid': 'cbf55769-eaf1-4074-84d9-8a47310dfbc2'
+        },
+        'Consultation': {
+            'sql': "'b37552be-9527-11ea-9213-f875a44e0e11' -> 'en' ->> 'value'",
+            'nodegroupid': 'b37552ba-9527-11ea-96b5-f875a44e0e11'
+        }
+    }
+
+    sort_options = {
+        'resourceid': {
+            'Monument': {
+                'sql': "'325a430a-efe4-11eb-810b-a87eeabdefba' -> 'en' ->> 'value'",
+                'nodegroupid': '325a2f2f-efe4-11eb-9b0c-a87eeabdefba'
+            },
+            'MonumentRevision': {
+                'sql': "'52403903-9f4c-400f-81ce-09a5e8b9d925' -> 'en' ->> 'value'",
+                'nodegroupid': 'cbf55769-eaf1-4074-84d9-8a47310dfbc2'
+            },
+            'Consultation': {
+                'sql': "'b37552be-9527-11ea-9213-f875a44e0e11' -> 'en' ->> 'value'",
+                'nodegroupid': 'b37552ba-9527-11ea-96b5-f875a44e0e11'
+            }
+        },
+        'hb_number': {
+            'Monument': {
+                'sql': "'250002fe-3aae-11ef-91fd-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': 'e71df5cc-3aad-11ef-a2d0-0242ac120003'
+            },
+            'MonumentRevision': {
+                'sql': "'b6ec253e-3aaf-11ef-a2d0-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': '2948f54a-3aaf-11ef-91fd-0242ac120003'
+            },
+            'Consultation': {
+                'sql': "",
+                'nodegroupid': ""
+            }
+        },
+        'smr_number': {
+            'Monument': {
+                'sql': "'158e1ed2-3aae-11ef-a2d0-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': 'e71df5cc-3aad-11ef-a2d0-0242ac120003'
+            },
+            'MonumentRevision': {
+                'sql': "'59a7f542-3aaf-11ef-a2d0-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': '2948f54a-3aaf-11ef-91fd-0242ac120003'
+            },
+            'Consultation': {
+                'sql': "",
+                'nodegroupid': ""
+            }
+        },
+        'ihr_number': {
+            'Monument': {
+                'sql': "'1de9abf0-3aae-11ef-91fd-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': 'e71df5cc-3aad-11ef-a2d0-0242ac120003'
+            },
+            'MonumentRevision': {
+                'sql': "'7968e094-3aaf-11ef-91fd-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': '2948f54a-3aaf-11ef-91fd-0242ac120003'
+            },
+            'Consultation': {
+                'sql': "",
+                'nodegroupid': ""
+            }
+        },
+        'historic_parks_and_gardens': {
+            'Monument': {
+                'sql': "'2c2d02fc-3aae-11ef-91fd-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': 'e71df5cc-3aad-11ef-a2d0-0242ac120003'
+            },
+            'MonumentRevision': {
+                'sql': "'e7ee4eaa-3aaf-11ef-a2d0-0242ac120003' -> 'en' ->> 'value'",
+                'nodegroupid': '2948f54a-3aaf-11ef-91fd-0242ac120003'
+            },
+            'Consultation': {
+                'sql': "",
+                'nodegroupid': ""
+            }
+        },
+    }
+
+    base_filters = {
+        'Monument': """
+            EXISTS (
+                SELECT 1 FROM tiles t2
+                WHERE t2.resourceinstanceid = t_fixed.resourceinstanceid
+                AND t2.nodegroupid = '3897b87a-1902-11ef-aa9f-0242ac150006'
+                AND t2.tiledata ->> '3a0ab672-190b-11ef-aa9c-0242ac150006' = '7f81d135-45ac-483f-96f4-2fa8ca882d79'
+            )
+        """,
+        'MonumentRevision': """
+            EXISTS (
+                SELECT 1 FROM tiles t2
+                WHERE t2.resourceinstanceid = t_fixed.resourceinstanceid
+                AND t2.nodegroupid = '3c51740c-dbd0-11ee-8835-0242ac120006'
+                AND t2.tiledata ->> 'ad22dad6-dbd0-11ee-b0db-0242ac120006' IS NULL
+            )
+        """,
+        'Consultation': """
+            t_fixed.tiledata -> 'b37552be-9527-11ea-9213-f875a44e0e11' -> 'en' ->> 'value' LIKE 'EVM%'
+            AND EXISTS (
+                SELECT 1 FROM tiles t2
+                WHERE t2.resourceinstanceid = t_fixed.resourceinstanceid
+                AND t2.tiledata ->> '5ffdc00e-03ad-11ef-948f-0242ac150003' IS NULL
+            )
+        """
+    }
+
+    extra_filters = {}
+
+    if sort_by not in sort_options:
+        raise ValueError(f"Invalid sort option: {sort_by}")
+
+    ref_paths = sort_options[sort_by]
+    order_direction = "DESC" if reverse else "ASC"
+
+    def build_subquery(model_type):
+        nodegroupid = ref_paths[model_type]['nodegroupid']
+        sql_path = ref_paths[model_type]['sql']
+        base_filter = base_filters[model_type]
+        extra = extra_filters.get(model_type)
+
+        full_filter = base_filter
+        if extra:
+            full_filter = f"({base_filter}) AND ({extra})"
+
+        base_nodegroupid = base_sort[model_type]['nodegroupid']
+
+        if not nodegroupid or not sql_path:
+            # No join, just select NULL for sort_value
+            return f"""
+            SELECT DISTINCT ON (t_fixed.resourceinstanceid)
+                t_fixed.resourceinstanceid,
+                NULL AS sort_value,
+                '{model_type}' AS type
+            FROM tiles t_fixed
+            WHERE t_fixed.nodegroupid = '{base_nodegroupid}'
+            AND {full_filter}
+            """
+        else:
+            return f"""
+            SELECT DISTINCT ON (t_fixed.resourceinstanceid)
+                t_fixed.resourceinstanceid,
+                t_sort.tiledata -> {sql_path} AS sort_value,
+                '{model_type}' AS type
+            FROM tiles t_fixed
+            LEFT JOIN tiles t_sort
+            ON t_fixed.resourceinstanceid = t_sort.resourceinstanceid
+            AND t_sort.nodegroupid = '{nodegroupid}'
+            WHERE t_fixed.nodegroupid = '{base_nodegroupid}'
+            AND {full_filter}
+            """
+
+    subqueries = [
+        build_subquery('Monument'),
+        build_subquery('MonumentRevision'),
+        build_subquery('Consultation'),
+    ]
+
+    full_query = f"""
+    SELECT * FROM (
+        {' UNION ALL '.join([q for q in subqueries if q])}
+    ) AS main
+    ORDER BY sort_value IS NULL, sort_value {order_direction}
+    LIMIT {limit} OFFSET {offset};
+    """
+
+    return full_query

--- a/coral/views/dashboards/sql_query.py
+++ b/coral/views/dashboards/sql_query.py
@@ -1,4 +1,4 @@
-def build_query(sort_by, reverse=False, limit=6, offset=0):
+def build_query(sort_by, count=False, reverse=False, limit=8, offset=0):
 
     base_sort = {
         'Monument': {
@@ -165,6 +165,15 @@ def build_query(sort_by, reverse=False, limit=6, offset=0):
         build_subquery('MonumentRevision'),
         build_subquery('Consultation'),
     ]
+
+    if count is True:
+        count_query = f"""
+        SELECT type, COUNT(*) AS count FROM (
+            {' UNION ALL '.join([q for q in subqueries if q])}
+        ) AS main
+        GROUP BY type
+        """
+        return count_query
 
     full_query = f"""
     SELECT * FROM (

--- a/coral/views/dashboards/sql_query/__init__.py
+++ b/coral/views/dashboards/sql_query/__init__.py
@@ -1,0 +1,1 @@
+from .builder import build_query

--- a/coral/views/dashboards/sql_query/builder.py
+++ b/coral/views/dashboards/sql_query/builder.py
@@ -1,0 +1,120 @@
+from .validation import validate_arguments
+
+def build_query(
+    sort_by,
+    count=False,
+    filter={'id':'all', 'type': 'all'},
+    reverse=False,
+    limit=8,
+    offset=0,
+    config=None,
+):
+    validate_arguments(
+        sort_by,
+        count,
+        filter,
+        reverse,
+        limit,
+        offset,
+        config,
+    )
+    return _build_query(
+        sort_by,
+        count,
+        filter,
+        reverse,
+        limit,
+        offset,
+        config
+    )
+
+def _build_query(
+    sort_by,
+    count,
+    filter,
+    reverse,
+    limit,
+    offset,
+    config
+):
+    # config is expected to be a dict with keys: base_sort, sort_options, base_filters, extra_filters
+    base_sort = config['base_sort']
+    sort_options = config['sort_options']
+    base_filters = config['base_filters']
+    extra_filters = config['extra_filters']
+
+    ref_paths = sort_options.get(sort_by, None)
+    order_direction = "DESC" if reverse else "ASC"
+
+    def build_subquery(model_type, filter=None):
+        nodegroupid = ref_paths[model_type]['nodegroupid']
+        sql_path = ref_paths[model_type]['sql']
+        base_filter = base_filters[model_type]
+        if filter and filter['type'] in extra_filters.keys():
+            extra_template = extra_filters[filter['type']][model_type]
+            if not extra_template:
+                return None
+            filter_value = filter['id']
+            extra = extra_filters[filter['type']][model_type].format(filter_value=filter_value)  
+        else:
+            extra = None          
+
+        full_filter = base_filter
+
+        if extra:
+            full_filter = f"({base_filter}) AND ({extra})"
+
+        base_nodegroupid = base_sort[model_type]['nodegroupid']
+
+        if not nodegroupid or not sql_path:
+            # No join, just select NULL for sort_value
+            return f"""
+            SELECT DISTINCT ON (t_fixed.resourceinstanceid)
+                t_fixed.resourceinstanceid,
+                NULL AS sort_value,
+                '{model_type}' AS type
+            FROM tiles t_fixed
+            WHERE t_fixed.nodegroupid = '{base_nodegroupid}'
+            AND {full_filter}
+            """
+        else:
+            return f"""
+            SELECT DISTINCT ON (t_fixed.resourceinstanceid)
+                t_fixed.resourceinstanceid,
+                t_sort.tiledata -> {sql_path} AS sort_value,
+                '{model_type}' AS type
+            FROM tiles t_fixed
+            LEFT JOIN tiles t_sort
+            ON t_fixed.resourceinstanceid = t_sort.resourceinstanceid
+            AND t_sort.nodegroupid = '{nodegroupid}'
+            WHERE t_fixed.nodegroupid = '{base_nodegroupid}'
+            AND {full_filter}
+            """
+
+    if filter['id'] in base_sort.keys():
+        subqueries = [ build_subquery(filter['id']) ]
+    else:
+        subqueries = [
+            build_subquery('Monument', filter),
+            build_subquery('MonumentRevision', filter),
+            build_subquery('Consultation', filter),
+        ]
+
+    if count is True:
+        count_query = f"""
+        SELECT type, COUNT(*) AS count FROM (
+            {' UNION ALL '.join([q for q in subqueries if q])}
+        ) AS main
+        GROUP BY type
+        """
+        return count_query
+
+    full_query = f"""
+    SELECT * FROM (
+        {' UNION ALL '.join([q for q in subqueries if q])}
+    ) AS main
+    ORDER BY sort_value IS NULL, sort_value {order_direction}
+    LIMIT {limit} OFFSET {offset};
+    """
+
+    return full_query

--- a/coral/views/dashboards/sql_query/builder.py
+++ b/coral/views/dashboards/sql_query/builder.py
@@ -94,11 +94,8 @@ def _build_query(
     if filter['id'] in base_sort.keys():
         subqueries = [ build_subquery(filter['id']) ]
     else:
-        subqueries = [
-            build_subquery('Monument', filter),
-            build_subquery('MonumentRevision', filter),
-            build_subquery('Consultation', filter),
-        ]
+        model_types = list(base_sort.keys())
+        subqueries = [build_subquery(model, filter) for model in model_types]
 
     if count is True:
         count_query = f"""

--- a/coral/views/dashboards/sql_query/config/__init__.py
+++ b/coral/views/dashboards/sql_query/config/__init__.py
@@ -1,0 +1,1 @@
+# empty file to mark config as a package

--- a/coral/views/dashboards/sql_query/config/designation_config.py
+++ b/coral/views/dashboards/sql_query/config/designation_config.py
@@ -1,6 +1,5 @@
-def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, reverse=False, limit=8, offset=0):
-
-    base_sort = {
+DESIGNATION_SQL_QUERY_CONFIG = {
+    "base_sort": {
         'Monument': {
             'sql': "'325a430a-efe4-11eb-810b-a87eeabdefba' -> 'en' ->> 'value'",
             'nodegroupid': '325a2f2f-efe4-11eb-9b0c-a87eeabdefba'
@@ -13,9 +12,8 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
             'sql': "'b37552be-9527-11ea-9213-f875a44e0e11' -> 'en' ->> 'value'",
             'nodegroupid': 'b37552ba-9527-11ea-96b5-f875a44e0e11'
         }
-    }
-
-    sort_options = {
+    },
+    "sort_options": {
         'resourceid': {
             'Monument': {
                 'sql': "'325a430a-efe4-11eb-810b-a87eeabdefba' -> 'en' ->> 'value'",
@@ -86,9 +84,8 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
                 'nodegroupid': ""
             }
         },
-    }
-
-    base_filters = {
+    },
+    "base_filters": {
         'Monument': """
             EXISTS (
                 SELECT 1 FROM tiles t2
@@ -113,9 +110,8 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
                 AND t2.tiledata ->> '5ffdc00e-03ad-11ef-948f-0242ac150003' IS NULL
             )
         """
-    }
-
-    extra_filters = {
+    },
+    "extra_filters": {
         'council': {
             'Monument': """
                 EXISTS (
@@ -175,81 +171,8 @@ def build_query(sort_by, count=False, filter={'id':'all', 'type': 'all'}, revers
                 """,
             'Consultation': ""
         },
+        'heritage_asset': {},
+        'meetings': {},
+        'revision': {}
     }
-
-    if sort_by not in sort_options:
-        raise ValueError(f"Invalid sort option: {sort_by}")
-
-    ref_paths = sort_options[sort_by]
-    order_direction = "DESC" if reverse else "ASC"
-
-    def build_subquery(model_type, filter=None):
-        nodegroupid = ref_paths[model_type]['nodegroupid']
-        sql_path = ref_paths[model_type]['sql']
-        base_filter = base_filters[model_type]
-        if filter and filter['type'] in extra_filters.keys():
-            filter_value = filter['id']
-            extra = extra_filters[filter['type']][model_type].format(filter_value=filter_value)  
-        else:
-            extra = None          
-
-        full_filter = base_filter
-
-        if extra:
-            full_filter = f"({base_filter}) AND ({extra})"
-
-        base_nodegroupid = base_sort[model_type]['nodegroupid']
-
-        if not nodegroupid or not sql_path:
-            # No join, just select NULL for sort_value
-            return f"""
-            SELECT DISTINCT ON (t_fixed.resourceinstanceid)
-                t_fixed.resourceinstanceid,
-                NULL AS sort_value,
-                '{model_type}' AS type
-            FROM tiles t_fixed
-            WHERE t_fixed.nodegroupid = '{base_nodegroupid}'
-            AND {full_filter}
-            """
-        else:
-            return f"""
-            SELECT DISTINCT ON (t_fixed.resourceinstanceid)
-                t_fixed.resourceinstanceid,
-                t_sort.tiledata -> {sql_path} AS sort_value,
-                '{model_type}' AS type
-            FROM tiles t_fixed
-            LEFT JOIN tiles t_sort
-            ON t_fixed.resourceinstanceid = t_sort.resourceinstanceid
-            AND t_sort.nodegroupid = '{nodegroupid}'
-            WHERE t_fixed.nodegroupid = '{base_nodegroupid}'
-            AND {full_filter}
-            """
-
-    if filter['id'] in base_sort.keys():
-        subqueries = [ build_subquery(filter['id']) ]
-    else:
-        subqueries = [
-            build_subquery('Monument', filter),
-            build_subquery('MonumentRevision', filter),
-            build_subquery('Consultation', filter),
-        ]
-
-    if count is True:
-        count_query = f"""
-        SELECT type, COUNT(*) AS count FROM (
-            {' UNION ALL '.join([q for q in subqueries if q])}
-        ) AS main
-        GROUP BY type
-        """
-        return count_query
-
-    full_query = f"""
-    SELECT * FROM (
-        {' UNION ALL '.join([q for q in subqueries if q])}
-    ) AS main
-    ORDER BY sort_value IS NULL, sort_value {order_direction}
-    LIMIT {limit} OFFSET {offset};
-    """
-    print(full_query)
-
-    return full_query
+}

--- a/coral/views/dashboards/sql_query/config/designation_config.py
+++ b/coral/views/dashboards/sql_query/config/designation_config.py
@@ -143,7 +143,11 @@ DESIGNATION_SQL_QUERY_CONFIG = {
                             t_council.resourceinstanceid IN (
                                 SELECT (value::jsonb->>'resourceId')::uuid
                                 FROM jsonb_array_elements(
-                                    t_rel.tiledata -> '58a2b98f-a255-11e9-9a30-00224800b26d'
+                                    CASE
+                                        WHEN jsonb_typeof(t_rel.tiledata -> '58a2b98f-a255-11e9-9a30-00224800b26d') = 'array'
+                                        THEN t_rel.tiledata -> '58a2b98f-a255-11e9-9a30-00224800b26d'
+                                        ELSE '[]'::jsonb
+                                    END
                                 ) as value
                             )
                             AND t_council.nodegroupid = '447973ce-d7e2-11ee-a4a1-0242ac120006'

--- a/coral/views/dashboards/sql_query/validation.py
+++ b/coral/views/dashboards/sql_query/validation.py
@@ -1,0 +1,53 @@
+import re
+
+def validate_arguments(
+    sort_by,
+    count,
+    filter,
+    reverse,
+    limit,
+    offset,
+    config,
+):
+    # Validate sort_by
+    sort_options = config.get('sort_options', {})
+    if sort_options and sort_by not in sort_options:
+        raise ValueError(f"Invalid sort_by: {sort_by}")
+
+    # Validate reverse
+    if not isinstance(reverse, bool):
+        raise ValueError("reverse must be a boolean")
+    
+    # Validate count
+    if not isinstance(count, bool):
+        raise ValueError("count must be a boolean")
+
+    # Validate limit and offset
+    if not (isinstance(limit, int) and 0 < limit <= 100):
+        raise ValueError("limit must be an integer between 1 and 100")
+    if not (isinstance(offset, int) and offset >= 0):
+        raise ValueError("offset must be a non-negative integer")
+
+    # Validate filter
+    if not isinstance(filter, dict):
+        raise ValueError("filter must be a dict")
+    filter_id = filter.get('id', 'all')
+    filter_type = filter.get('type', 'all')
+
+    extra_filters = config.get('extra_filters', {})
+    allowed_filter_types = set(['all', 'default']) | set(extra_filters.keys())
+    if filter_type not in allowed_filter_types:
+        raise ValueError(f"Invalid filter type: {filter_type}")
+
+    uuid_regex = re.compile(r'^[a-f0-9\-]{36}$', re.IGNORECASE)
+    safe_string_regex = re.compile(r'^[\w\-\/]+$')  # allows alphanum, _, -, /
+
+    def is_safe_filter_id(filter_id):
+        if uuid_regex.match(str(filter_id)):
+            return True
+        if safe_string_regex.match(str(filter_id)):
+            return True
+        return False
+
+    if not is_safe_filter_id(filter_id):
+        raise ValueError("Invalid filter id")


### PR DESCRIPTION
# PR - Dashboard SQL Builder

## Description of the Issue
The designation dashboard was throwing errors trying to load the resources. The queries could not be optimised with the Arches-ORM anymore than they currently were. The approach of this PR is to rebuild the queries as raw SQL queries that are implemented through Django cursor. These dynamically build queries and allow us to query against multiple models in one go with sorting and pagination.

**Related Task:** N/A

---

## Changes Proposed
- added a sql query builder
- refactored designation_strategy to use the sql query builder
- added validation for the arguments to prevent SQL injection
- built a config file for the designation tile queries

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [x] Features Added
- [x] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- (Add workflows as needed)

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- (Add reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- Create a user and add them to the records and designation group
- Create HA's that are provisional, HA Revisions and Evaluation Meetings
- Open the dashboard and check that they are visible
- Check the sorting and filtering
- Open the tasks and check it opens into the correct group

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
