### PR TITLE
Feat: change the smc to allow multi select HA

### DIFF
--- a/coral/media/js/views/components/plugins/open-scheduled-monument-consent-workflow.js
+++ b/coral/media/js/views/components/plugins/open-scheduled-monument-consent-workflow.js
@@ -18,7 +18,7 @@ define([
   
       this.addtionalConfigData = ko.observable({
         parentTileIds: {},
-        haId: [{}],
+        haId: [],
         resourceInstanceId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
       });
   
@@ -87,7 +87,10 @@ define([
           return;
         }
         this.getParentTileOptions(resourceId);
-        this.addtionalConfigData()['haId'] = [{"resourceId":resourceId}]
+        this.addtionalConfigData()['haId'] = [];
+        for (const resource of resourceId){
+          this.addtionalConfigData()['haId'].push({"resourceId":resource});
+        }
         this.setAdditionalOpenConfigData()
       });
   

--- a/coral/media/js/views/components/plugins/open-scheduled-monument-consent-workflow.js
+++ b/coral/media/js/views/components/plugins/open-scheduled-monument-consent-workflow.js
@@ -15,6 +15,8 @@ define([
       this.selectedHA = ko.observable();
 
       this.configKeys = ko.observable({ placeholder: 0 });
+
+      this.smrSearchString = `/search/resources?advanced-search=[{"op":"and","2c2d02fc-3aae-11ef-91fd-0242ac120003":{"op":"~","lang":"en","val":""},"1de9abf0-3aae-11ef-91fd-0242ac120003":{"op":"~","lang":"en","val":""},"158e1ed2-3aae-11ef-a2d0-0242ac120003":{"op":"not_null","lang":"en","val":""},"250002fe-3aae-11ef-91fd-0242ac120003":{"op":"~","lang":"en","val":""}}]`;
   
       this.addtionalConfigData = ko.observable({
         parentTileIds: {},

--- a/coral/templates/views/components/plugins/open-scheduled-monument-consent-workflow.htm
+++ b/coral/templates/views/components/plugins/open-scheduled-monument-consent-workflow.htm
@@ -13,7 +13,8 @@
             placeholder: 'Please select a Heritage Asset',
           },
           renderContext: 'workflow',
-          value: selectedHA
+          value: selectedHA,
+          searchString: smrSearchString
         }
       }"
     ></div>

--- a/coral/templates/views/components/plugins/open-scheduled-monument-consent-workflow.htm
+++ b/coral/templates/views/components/plugins/open-scheduled-monument-consent-workflow.htm
@@ -5,7 +5,7 @@
   <div class="row widget-wrapper">
     <div
       data-bind="component: {
-        name: 'resource-instance-select-widget',
+        name: 'resource-instance-multiselect-widget',
         params: {
           graphids: ['076f9381-7b00-11e9-8d6b-80000b44d1d9'],
           config: {


### PR DESCRIPTION
# PR - change the smc to allow multi select HA

## Description of the Issue
The SMC needs to allow multi select for the Heritage Assets and the query string needs to only show SMR's

**Related Task:** []()

---

## Changes Proposed
- Change HA selector to multi select
- Added search string to HA drop down to only look for HA's with an SMR number

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Add more models as needed)

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- (Add workflows as needed)

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- (Add reports as needed)

---
## Commands
```
make run
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- (Add tests as needed)

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
