### PR TITLE
feat(merge asset tracker): added custom report showing base and merge…

### DIFF
--- a/coral/media/js/views/components/reports/heritage-asset-merge.js
+++ b/coral/media/js/views/components/reports/heritage-asset-merge.js
@@ -1,0 +1,71 @@
+define([
+    'jquery',
+    'underscore',
+    'knockout',
+    'arches',
+    'utils/resource',
+    'utils/report',
+    'templates/views/components/reports/heritage-asset-merge.htm',
+    'views/components/reports/scenes/all',
+], function($, _, ko, arches, resourceUtils, reportUtils, heritageAssetMergeReportTemplate) {
+    return ko.components.register('heritage-asset-merge', {
+        viewModel: function(params) {
+            var self = this;
+            params.configKeys = ['tabs', 'activeTabIndex'];
+            this.configForm = params.configForm || false;
+            this.configType = params.configType || 'header';
+            this.report = params.report;
+
+            Object.assign(self, reportUtils);
+            self.sections = [
+                {id: 'all', title: 'Full Report'},
+            ];
+            self.reportMetadata = ko.observable(params.report?.report_json);
+            self.resource = ko.observable(self.reportMetadata()?.resource);
+            self.displayname = ko.observable(ko.unwrap(self.reportMetadata)?.displayname);
+            self.activeSection = ko.observable('all');
+
+            self.issueNodeGroups = ['d3ff3fe6-d62b-11ee-9454-0242ac180006'];
+
+            self.nameDataConfig = {
+                name: 'heritage asset Merge Tracker',
+                nameChildren: 'asset',
+                parent: 'parent asset'
+            };
+
+            self.nameCards = {};
+            self.descriptionCards = {};
+            self.summary = params.summary;
+            self.cards = {};
+
+            self.resource = ko.observable(self.resource());
+
+            self.fullReportConfig = {
+                id: 'heritage-asset',
+                label: 'Heritage Asset',
+                ignoreNodes: []
+            };
+
+            if(params.report.cards){
+                const cards = params.report.cards;
+
+                self.cards = self.createCardDictionary(cards);
+                
+                const baseResourceData = JSON.parse(self.cards?.['Base Resource Data']['params']['tiles'][3]['data']['07cf7760-f197-11ee-9b0c-0242ac170006']['en']['value']);
+                const mergeResourceData = JSON.parse(self.cards?.['Merged Resource Data']['params']['tiles'][4]['data']['3d1a1858-f197-11ee-9b0c-0242ac170006']['en']['value']);
+
+                const baseResourceDetails = 'Base Resource Details: ' +  baseResourceData['business_data']['resources'][0]['resourceinstance']['name'] + ' id: ' + baseResourceData['business_data']['resources'][0]['resourceinstance']['resourceinstanceid'];
+                const mergeResourceDetails = 'Merged Resource Details: ' +  mergeResourceData['business_data']['resources'][1]['resourceinstance']['name'] + ' id: ' + mergeResourceData['business_data']['resources'][1]['resourceinstance']['resourceinstanceid'];
+
+                self.descriptionCards = {
+                    descriptions: self.cards?.['descriptions'],
+                    baseResource: self.cards?.['Base Resource Data'],
+                    mergeResource: self.cards?.['Merged Resource Data'],
+                    baseResourceDetails: baseResourceDetails,
+                    mergeResourceDetails: mergeResourceDetails
+                };
+            }
+        },
+        template: heritageAssetMergeReportTemplate
+    });
+});

--- a/coral/pkg/graphs/resource_models/Merge Resource Tracker.json
+++ b/coral/pkg/graphs/resource_models/Merge Resource Tracker.json
@@ -1968,7 +1968,7 @@
             "subtitle": {
                 "en": "Used to track information required when merging two resources together."
             },
-            "template_id": "50000000-0000-0000-0000-000000000001",
+            "template_id": "e79672ec-8713-4c52-9e87-c90f6cee92cb",
             "version": ""
         }
     ],

--- a/coral/reports/heritage_asset_merge.json
+++ b/coral/reports/heritage_asset_merge.json
@@ -1,0 +1,11 @@
+{
+    "name": "Heritage Asset Merge Template",
+    "component": "views/components/reports/heritage-asset-merge",
+    "defaultconfig": {
+        "uncompacted_reporting": true
+    },
+    "description": "Heritage Asset merge report",
+    "componentname": "heritage-asset-merge",
+    "templateid": "e79672ec-8713-4c52-9e87-c90f6cee92cb",
+    "preload_resource_data": true
+}

--- a/coral/templates/views/components/reports/heritage-asset-merge.htm
+++ b/coral/templates/views/components/reports/heritage-asset-merge.htm
@@ -1,0 +1,78 @@
+{% extends "views/report-templates/default.htm" %}
+{% load i18n %}
+
+{% block report %}
+    {% block report_title_bar %}
+    <!-- Custom Template Report Title Bar -->
+    <div class="relative">
+
+        <!-- Title Block -->
+        <div class="aher-report-toolbar">
+            <h1 class="aher-report-toolbar-title"><span class="aher-report-name">{% trans "Heritage Asset" %}:</span><span data-bind="text: displayname" class="aher-report-instance-name"></span></h1>
+        </div>
+
+    </div>
+    {% endblock report_title_bar %}
+
+    
+    {% block body %}
+    <!-- Link nav -->
+    <div class="aher-report-anchor-container">
+        <ol class="aher-report-anchors breadcrumb">
+            <!-- ko foreach: {data: sections, as: 'section'} -->
+            <li data-bind="click: function(){$parent.activeSection(section.id)}, css: {active: $parent.activeSection() === section.id}, text: section.title" class="aher-report-a"></li>
+            <!-- /ko -->
+        </ol>
+    </div>
+    <div class="aher-tabbed-report">
+        <div class="aher-tabbed-report-content">
+            <!-- Names Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/name',
+                    params: {
+                        data: resource,
+                        cards: nameCards,
+                        dataConfig: nameDataConfig
+                    }
+                }"></div>
+            </div>
+            <div class="aher-report-page">
+                <div class="aher-tabbed-report-content">
+                    <div data-bind="text: descriptionCards.baseResourceDetails"></div>
+                </div>
+            </div>
+            <div class="aher-report-page">
+                <div class="aher-tabbed-report-content">
+                    <div data-bind="text: descriptionCards.mergeResourceDetails"></div>
+                </div>
+            </div>
+            <!-- Description Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'description'">
+                <div data-bind="text: descriptionCards.baseResourceDetails"></div>
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/description',
+                    params: {
+                        data: resource,
+                        cards: descriptionCards,
+                        dataConfig: descriptionDataConfig
+                    }
+                }"></div>
+            </div>
+
+            <!-- All Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'all'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/all',
+                    params: {
+                        report: $data.report,
+                        showCards: true,
+                        showRelated: true,
+                        nodeGroups: null
+                    }
+                }"></div>
+            </div>
+        </div>
+    </div>            
+    {% endblock body %}
+{% endblock report %}


### PR DESCRIPTION
# PR - Make merge asset report page more useful

## Description of the Issue
Added custom report page for the merge asset tracker, it currently displays the original info along with base and merge ha title and resource id's


**Related Task:** []()

---

## Changes Proposed
- Added a new merge workflow report

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [x] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
[If any database models have been modified, added, or removed, list them below.]

- (Merge Asset tracker) Updated report ID

---

### Added Functions
[List any new functions or methods added, along with a brief description of their purpose.]

- (Add functions as needed)

---

### Added Concepts
[Describe any new concepts or terms introduced, and explain how they integrate with existing concepts.]

- (Concept Name: Concept ID)

---

### Workflows Updated
[Detail any changes to existing workflows or new workflows added.]

- (Add workflows as needed)

---

### Reports Updated
[List any reports that have been modified or added, and describe the changes.]

- Merge Workflow Report page

---
## Commands
```
make run
make manage CMD="report register -s ./coral-arches/coral/reports/heritage_asset_merge.json"
make manage CMD="packages -o import_graphs -s coral/pkg/graphs/resource_models/Merge\ \Resource\ \Tracker.json"
make webpack
```

## Tests
[List any tests that need to be run to verify the changes.]

- Merge HA's and check the report page and there should be Title and ID's for both Base and merged HA's 

---

## Additional Notes
[Add any additional context, notes, or information that might be relevant to reviewers or testers.]
