### PR TITLE
Feat: Add Designation Description Option 'Notes'

### DIFF
--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -248,15 +248,17 @@ class ScanForDataRisks():
     for node in list(tile_json['data'].keys()):
       if node in [concept["node_id"] for concept in updated_concepts]:
           try:
-            if self.mapping:
+            if self.mapping and not self.default_mapping:
               mapping = next(value for key, value in self.mapping.items() if key == node)
             else:
-              answer = input(f"No mapping has been provided for {node}. Do you want to continue with the default mapping setting the value to null? [y/N]: ")
-              if answer.lower() == 'y':
-                if self.mapping is None:
-                    self.mapping = {}
-                self.mapping[node] = { 'default': None }
-                mapping = { 'default': None }
+              if self.default_mapping is not True:
+                answer = input(f"No mapping has been provided for {node}. Do you want to continue with the default mapping setting the value to null? [y/N]: ")
+                if answer.lower() == 'y':
+                  self.default_mapping = True
+              if self.mapping is None:
+                  self.mapping = {}
+              self.mapping[node] = { 'default': None }
+              mapping = { 'default': None }
           except Exception as e:
             raise ValueError(f"No mapping could be found in the file for the node {node}") from e
           TransformData().concept_to_concept(tile_json, node, mapping)
@@ -335,6 +337,7 @@ class ScanForDataRisks():
     self.graphid = self.incoming_json['graph'][0]['graphid']
     self.graph = Graph.objects.get(pk=self.graphid)
     self.mapping = mapping
+    self.default_mapping = False
     if self.mapping:
        with open(mapping, 'r') as file:
             self.mapping = json.load(file)

--- a/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset Revision.json
@@ -34552,6 +34552,13 @@
                                 "text": {
                                     "en": "Evaluation"
                                 }
+                            },
+                            {
+                                "id": "dc9e7656-b618-4184-8959-9bc04cf8c55a",
+                                "selected": false,
+                                "text": {
+                                    "en": "Notes"
+                                }
                             }
                         ]
                     },

--- a/coral/pkg/graphs/resource_models/Heritage Asset.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset.json
@@ -23631,6 +23631,13 @@
                                 "text": {
                                     "en": "Evaluation"
                                 }
+                            },
+                            {
+                                "id": "dc9e7656-b618-4184-8959-9bc04cf8c55a",
+                                "selected": false,
+                                "text": {
+                                    "en": "Notes"
+                                }
                             }
                         ]
                     },


### PR DESCRIPTION
# PR - Add Designation Description Option 'Notes'

## Description of the Issue
The domain value list for 'Designation Description' needed 'Notes' adding to it.
When trying to migrate the model using the migration tool, there were issues when using the default mapping option. This was also fixed

**Related Task:** N/A

---

## Changes Proposed
- Added notes to the HA and HA revision model for designation description
- Added a default mapping flag to the migration tool to allow all nodes to use default mapping when selected

### Types of Changes
- [x] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- Heritage Asset - Added Notes to the domain drop down - Designation Description
- Heritage Asset Revision - Added Notes to the domain drop down - Designation Description

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
