### PR TITLE
fix: fixed merge asset tracker report page not displaying details

### DIFF
--- a/coral/media/js/views/components/reports/heritage-asset-merge.js
+++ b/coral/media/js/views/components/reports/heritage-asset-merge.js
@@ -54,18 +54,26 @@ define([
 
                 self.cards = self.createCardDictionary(cards);
                 
-                const baseResourceData = JSON.parse(self.cards?.['Base Resource Data']['params']['tiles'].find(tile =>
+                const baseResourceData = self.cards?.['Base Resource Data']['params']['tiles'].find(tile =>
                     tile.data && tile.data['07cf7760-f197-11ee-9b0c-0242ac170006']
-                )['data']['07cf7760-f197-11ee-9b0c-0242ac170006']['en']['value']);
+                );
 
-                const mergeResourceData = JSON.parse(self.cards?.['Merged Resource Data']['params']['tiles'].find(tile =>
+                const mergeResourceData = self.cards?.['Merged Resource Data']['params']['tiles'].find(tile =>
                     tile.data && tile.data['3d1a1858-f197-11ee-9b0c-0242ac170006']
-                )['data']['3d1a1858-f197-11ee-9b0c-0242ac170006']['en']['value']);
+                );
 
                 if (baseResourceData && mergeResourceData) {
-                    baseResourceDetails('Base Resource Details: ' +  baseResourceData['business_data']['resources'][0]['resourceinstance']['name'] + ' id: ' + baseResourceData['business_data']['resources'][0]['resourceinstance']['resourceinstanceid']);
-                    mergeResourceDetails('Merged Resource Details: ' +  mergeResourceData['business_data']['resources'][1]['resourceinstance']['name'] + ' id: ' + mergeResourceData['business_data']['resources'][1]['resourceinstance']['resourceinstanceid']);
-                };
+                    const baseNameStr = JSON.parse(baseResourceData['data']['07cf7760-f197-11ee-9b0c-0242ac170006']['en']['value'])['business_data']['resources'][0]['resourceinstance']['name'];
+                    const baseIdString = JSON.parse(baseResourceData['data']['07cf7760-f197-11ee-9b0c-0242ac170006']['en']['value'])['business_data']['resources'][0]['resourceinstance']['resourceinstanceid'];
+
+                    const mergeNameStr = JSON.parse(mergeResourceData['data']['3d1a1858-f197-11ee-9b0c-0242ac170006']['en']['value'])['business_data']['resources'][1]['resourceinstance']['name'];
+                    const mergeIdString = JSON.parse(mergeResourceData['data']['3d1a1858-f197-11ee-9b0c-0242ac170006']['en']['value'])['business_data']['resources'][1]['resourceinstance']['resourceinstanceid'];
+
+                    if (baseNameStr && mergeNameStr && baseIdString && mergeIdString) {
+                        baseResourceDetails(`${baseNameStr} id: ${baseIdString}`);
+                        mergeResourceDetails(`${mergeNameStr} id: ${mergeIdString}`);
+                    }
+                }
 
                 self.descriptionCards = {
                     descriptions: self.cards?.['descriptions'],

--- a/coral/templates/views/components/reports/heritage-asset-merge.htm
+++ b/coral/templates/views/components/reports/heritage-asset-merge.htm
@@ -37,12 +37,18 @@
                     }
                 }"></div>
             </div>
-            <div class="aher-report-page">
+            <div class="rp-card-section" style="padding-bottom: 0; margin: 0 10px;">
+                <div class="h5 rp-tile-title">
+                    <span class="rp-tile-title" >Base Report Details</span>
+                </div>
                 <div class="aher-tabbed-report-content">
                     <div data-bind="text: descriptionCards.baseResourceDetails"></div>
                 </div>
             </div>
-            <div class="aher-report-page">
+            <div class="rp-card-section" style="padding-bottom: 0; margin: 0 10px;">
+                <div class="h5 rp-tile-title">
+                    <span class="rp-tile-title" >Merged Report Details</span>
+                </div>
                 <div class="aher-tabbed-report-content">
                     <div data-bind="text: descriptionCards.mergeResourceDetails"></div>
                 </div>


### PR DESCRIPTION
# PR - Fix merge asset tracker report page not displaying details

## Description of the Issue
Merge asset tracker page wasn't displaying details correctly

**Related Task:** https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2595

---

## Changes Proposed
- [List the changes you're proposing]
- [Be specific and concise]

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make run
make webpack
```

## Tests
- Navigate to a merge asset tracker report and it should display all details correctly 

---

## Additional Notes
[Any additional information that might be helpful]
