### PR TITLE
fix: fix issue with cm ref being pulled from ha

### DIFF
--- a/coral/pkg/graphs/resource_models/Heritage Asset.json
+++ b/coral/pkg/graphs/resource_models/Heritage Asset.json
@@ -707,6 +707,33 @@
                 },
                 {
                     "active": true,
+                    "cardid": "99428e41-72c6-430d-aebb-14aaa78a1727",
+                    "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
+                    "config": null,
+                    "constraints": [],
+                    "cssclass": null,
+                    "description": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "helpenabled": false,
+                    "helptext": {
+                        "en": ""
+                    },
+                    "helptitle": {
+                        "en": ""
+                    },
+                    "instructions": {
+                        "en": ""
+                    },
+                    "is_editable": false,
+                    "name": {
+                        "en": "CM Reference"
+                    },
+                    "nodegroup_id": "52f3230c-0051-4ff1-b0bb-eca887b1fba4",
+                    "sortorder": null,
+                    "visible": true
+                },
+                {
+                    "active": true,
                     "cardid": "4479a920-d7e2-11ee-a4a1-0242ac120006",
                     "component_id": "f05e4d3a-53c1-11e8-b0ea-784f435179ea",
                     "config": null,
@@ -12078,6 +12105,28 @@
                     "widget_id": "10000000-0000-0000-0000-000000000012"
                 },
                 {
+                    "card_id": "99428e41-72c6-430d-aebb-14aaa78a1727",
+                    "config": {
+                        "defaultValue": null,
+                        "i18n_properties": [
+                            "placeholder"
+                        ],
+                        "label": "CM Reference",
+                        "options": [],
+                        "placeholder": {
+                            "en": "Enter text"
+                        }
+                    },
+                    "id": "96411e3a-0673-4a1e-9316-2125b55c56d4",
+                    "label": {
+                        "en": "CM Reference"
+                    },
+                    "node_id": "52f3230c-0051-4ff1-b0bb-eca887b1fba4",
+                    "sortorder": null,
+                    "visible": true,
+                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                },
+                {
                     "card_id": "96656adc-d646-11ee-8b04-0242ac180006",
                     "config": {
                         "defaultValue": "0493601e-3491-40a7-a651-6fd8d9dbdce5",
@@ -16536,6 +16585,15 @@
                 },
                 {
                     "description": null,
+                    "domainnode_id": "d3ff3fe6-d62b-11ee-9454-0242ac180006",
+                    "edgeid": "8f83834d-0c3d-4e35-8bcd-bb279f405849",
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "name": null,
+                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "rangenode_id": "52f3230c-0051-4ff1-b0bb-eca887b1fba4"
+                },
+                {
+                    "description": null,
                     "domainnode_id": "49c65316-f5af-11ee-9f07-0242ac170006",
                     "edgeid": "49c687b4-f5af-11ee-9f07-0242ac170006",
                     "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
@@ -17784,15 +17842,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "rangenode_id": "efc9b6ba-3865-11ef-8bde-0242ac120006"
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "d3ff3fe6-d62b-11ee-9454-0242ac180006",
-                    "edgeid": "6c349a31-e4ed-456e-9bcf-354be3976834",
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
-                    "rangenode_id": "b5df3df2-4143-11f0-873e-2a478649f0ed"
                 },
                 {
                     "description": null,
@@ -19980,15 +20029,6 @@
                     "name": null,
                     "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
                     "rangenode_id": "f2f3970e-2d5a-11ef-bbfd-0242ac120006"
-                },
-                {
-                    "description": null,
-                    "domainnode_id": "b5df3df2-4143-11f0-873e-2a478649f0ed",
-                    "edgeid": "8d4cc445-b239-4829-b1e5-257ea4fa72d1",
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "name": null,
-                    "ontologyproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
-                    "rangenode_id": "e7840a04-4143-11f0-a73b-2a478649f0ed"
                 },
                 {
                     "description": null,
@@ -22397,6 +22437,12 @@
                     "cardinality": "1",
                     "legacygroupid": null,
                     "nodegroupid": "a0cb43ee-d62c-11ee-9454-0242ac180006",
+                    "parentnodegroup_id": "d3ff3fe6-d62b-11ee-9454-0242ac180006"
+                },
+                {
+                    "cardinality": "1",
+                    "legacygroupid": null,
+                    "nodegroupid": "52f3230c-0051-4ff1-b0bb-eca887b1fba4",
                     "parentnodegroup_id": "d3ff3fe6-d62b-11ee-9454-0242ac180006"
                 },
                 {
@@ -35744,6 +35790,27 @@
                     "sourcebranchpublication_id": null
                 },
                 {
+                    "alias": "cm_reference_n1",
+                    "config": {},
+                    "datatype": "string",
+                    "description": null,
+                    "exportable": false,
+                    "fieldname": null,
+                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
+                    "hascustomalias": false,
+                    "is_collector": true,
+                    "isrequired": false,
+                    "issearchable": true,
+                    "istopnode": false,
+                    "name": "CM Reference",
+                    "nodegroup_id": "52f3230c-0051-4ff1-b0bb-eca887b1fba4",
+                    "nodeid": "52f3230c-0051-4ff1-b0bb-eca887b1fba4",
+                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E55_Type",
+                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P2_has_type",
+                    "sortorder": 0,
+                    "sourcebranchpublication_id": null
+                },
+                {
                     "alias": "approved_by",
                     "config": {
                         "graphs": [
@@ -37434,29 +37501,6 @@
                     "sourcebranchpublication_id": null
                 },
                 {
-                    "alias": "cm_references_n1",
-                    "config": {
-                        "en": ""
-                    },
-                    "datatype": "semantic",
-                    "description": null,
-                    "exportable": false,
-                    "fieldname": null,
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "CM References",
-                    "nodegroup_id": "d3ff3fe6-d62b-11ee-9454-0242ac180006",
-                    "nodeid": "b5df3df2-4143-11f0-873e-2a478649f0ed",
-                    "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E73_Information_Object",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P67i_is_referred_to_by",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
-                {
                     "alias": "gar_approved_by_role_type",
                     "config": {
                         "rdmCollection": "0cdf5418-d21b-4d01-9760-8edad86ac4f0"
@@ -39050,29 +39094,6 @@
                     "nodegroup_id": "e71df5cc-3aad-11ef-a2d0-0242ac120003",
                     "nodeid": "e71df5cc-3aad-11ef-a2d0-0242ac120003",
                     "ontologyclass": "http://www.cidoc-crm.org/cidoc-crm/E62_String",
-                    "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
-                    "sortorder": 0,
-                    "sourcebranchpublication_id": null
-                },
-                {
-                    "alias": "cm_reference_n1",
-                    "config": {
-                        "en": ""
-                    },
-                    "datatype": "string",
-                    "description": null,
-                    "exportable": true,
-                    "fieldname": "CMRef",
-                    "graph_id": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
-                    "hascustomalias": false,
-                    "is_collector": false,
-                    "isrequired": false,
-                    "issearchable": true,
-                    "istopnode": false,
-                    "name": "CM reference",
-                    "nodegroup_id": "d3ff3fe6-d62b-11ee-9454-0242ac180006",
-                    "nodeid": "e7840a04-4143-11f0-a73b-2a478649f0ed",
-                    "ontologyclass": "http://www.w3.org/2000/01/rdf-schema#Literal",
                     "parentproperty": "http://www.cidoc-crm.org/cidoc-crm/P3_has_note",
                     "sortorder": 0,
                     "sourcebranchpublication_id": null

--- a/coral/plugins/issue-report-workflow.json
+++ b/coral/plugins/issue-report-workflow.json
@@ -142,7 +142,7 @@
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['resourceInstanceId']",
                   "parenttileid": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['issueReport']",
-                  "nodegroupid": "b5df3df2-4143-11f0-873e-2a478649f0ed",
+                  "nodegroupid": "52f3230c-0051-4ff1-b0bb-eca887b1fba4",
                   "semanticName": "CM References"
                 },
                 "tilesManaged": "one",


### PR DESCRIPTION
# PR - Fix CM reference being pulled from HA

## Description of the Issue
cm reference is being pulled from ha rather than being separate for the issue report workflow

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- Added CM reference to the issue reports in a HA

### Types of Changes
- [x] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [x] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- Heritage Asset

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- Issue report

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make run
make manage CMD="packages -o import_graphs -s coral/pkg/graphs/resource_models/Heritage\ \Asset.json"
make manage CMD="coral reload"
```

## Tests
- Navigate to issue report add cm ref
- CM ref should not be populated by the selected HA 
- CM ref should be under issue report in the HA report


---

## Additional Notes
[Any additional information that might be helpful]
