### PR TITLE
Fix: 3079 3085 Evaluation Meeting and Issue Report tabs

### DIFF
--- a/coral/media/js/viewmodels/workflow.js
+++ b/coral/media/js/viewmodels/workflow.js
@@ -490,8 +490,6 @@ define([
         this.next = async function(){
             var activeStep = self.activeStep();
 
-            console.log("ACTIVE STEP", self.activeStep().complete(), self.activeStep() && self.activeStep().required())
-
             if (activeStep.stepInjectionConfig) {
                 await self.updateStepPath();
             }

--- a/coral/media/js/viewmodels/workflow.js
+++ b/coral/media/js/viewmodels/workflow.js
@@ -86,6 +86,8 @@ define([
             });
         };
 
+        
+
         this.updatePan = function(val){
             if (this.pan() !== val) {
                 this.pan(val);
@@ -272,6 +274,9 @@ define([
 
             /* furthest completed step index */ 
             self.steps().forEach(function(step) {
+                if(step.title === 'Map'){
+                    return;
+                }
                 if (ko.unwrap(step.complete)) {
                     startIdx = step._index;
                 }
@@ -484,6 +489,8 @@ define([
 
         this.next = async function(){
             var activeStep = self.activeStep();
+
+            console.log("ACTIVE STEP", self.activeStep().complete(), self.activeStep() && self.activeStep().required())
 
             if (activeStep.stepInjectionConfig) {
                 await self.updateStepPath();

--- a/coral/media/js/viewmodels/workflow.js
+++ b/coral/media/js/viewmodels/workflow.js
@@ -274,7 +274,7 @@ define([
 
             /* furthest completed step index */ 
             self.steps().forEach(function(step) {
-                if(step.title === 'Map'){
+                if(step.ignoreComplete){
                     return;
                 }
                 if (ko.unwrap(step.complete)) {

--- a/coral/plugins/evaluation-meeting-workflow.json
+++ b/coral/plugins/evaluation-meeting-workflow.json
@@ -195,6 +195,7 @@
         "name": "1663b9a5-39c3-4518-b85d-12bc24076610",
         "title": "Location Details",
         "required": false,
+        "ignoreComplete": true,
         "layoutSections": [
           {
             "componentConfigs": [

--- a/coral/plugins/issue-report-workflow.json
+++ b/coral/plugins/issue-report-workflow.json
@@ -327,6 +327,7 @@
         "name": "13817e0a-4240-48d6-8e26-03b03b40fbac",
         "title": "Map",
         "required": false,
+        "ignoreComplete": true,
         "layoutSections": [
           {
             "componentConfigs": [


### PR DESCRIPTION
# PR - Issue Report Tabs

## Description of the Issue
When opening an issue report and evaluation meeting all tabs were enabled. It was due to the fact that issue report and evaluation meeting are nodegroups in the HA model. If the HA model had the map tile saved, it would reference this in the issue report and assume it had been completed. Subsequently if location details was present (it is a required tile) then evaluation meeting had the same issue. This will add an additional arg that can be put in the workflow config 'ignoreComplete' which will allow the workflow to skip the step from setting the workflow as completed passed the required nodes

**Related Task:** 
[3079](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/3079)
[3085](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/3085)

---

## Changes Proposed
- Add a check in the workflow furthestValidIndex to see if the step should be skipped
- Updated the Issue report workflow to add the 'ignoreComplete'
- Update the Evaluation meeting worklfow to add 'ignoreComplete'

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [x] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- Issue Report
- Evaluation Meeting

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- Make a HA and save a point on the map
- Open an issue report for the HA
- Should have everything but the first 2 tabs disabled

---

## Additional Notes
[Any additional information that might be helpful]
