### PR TITLE
Hotfix/respond to enforcement

### DIFF
--- a/coral/plugins/open-workflow.json
+++ b/coral/plugins/open-workflow.json
@@ -8,8 +8,8 @@
     "show": false,
     "openableWorkflows": [
       {
-        "slug": "flag-for-enforcement-workflow",
-        "name": "Flag for Enforcement",
+        "slug": "respond-to-enforcement-workflow",
+        "name": "Respond to Enforcement",
         "graphIds": ["8c3a4ae7-2704-4f47-aa68-4da7f9fc6d84"],
         "description": "",
         "disableStartNew": true,

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -24,7 +24,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=13, patch=51)
+APP_VERSION = semantic_version.Version(major=7, minor=13, patch=52)
 
 GROUPINGS = {
     "groups": {


### PR DESCRIPTION
# PR - Open respond to enforcement

## Description of the Issue
Respond to enforcement did not open from the enforcement dashboard open page. The issue was with the slug not being present in the open workflow json

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- Update the Open-Workflow.json slug - convert flag for enforcement back to respond to enforcement

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
