### PR TITLE
fix: 3122 show site name on the excavation site visit workflow

### DIFF
--- a/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-licence-details.js
+++ b/coral/media/js/views/components/workflows/excavation-site-visit-workflow/get-selected-licence-details.js
@@ -13,8 +13,7 @@ define([
     this.SELECTED_LICENCE_NODEGROUP_AND_NODE = '879fc326-02f6-11ef-927a-0242ac150006';
 
     this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE = 'ea059ab7-83d7-11ea-a3c4-f875a44e0e11';
-    this.SITE_NAME_NODEGROUP_AND_NODE = 'a9f53f00-48b6-11ee-85af-0242ac140007';
-
+    this.LICENCE_ASSOCIATED_ACTIVITY = 'a9f53f00-48b6-11ee-85af-0242ac140007';
 
     this.CM_REFERENCE_NODEGROUP = 'b84fa9c6-bad2-11ee-b3f2-0242ac180006';
     this.CM_REFERENCE_NODE = 'b84fb182-bad2-11ee-b3f2-0242ac180006';
@@ -36,7 +35,7 @@ define([
     this.siteName = ko.observable();
     this.licensee = ko.observable();
     this.licenceNumber = ko.observable();
-
+    this.relatedActivityId = null;
     this.form
       .card()
       ?.widgets()
@@ -77,6 +76,9 @@ define([
         if (tile.nodegroup === this.CM_REFERENCE_NODEGROUP) {
           this.cmNumber(tile.data[this.CM_REFERENCE_NODE]?.en?.value || 'N/A');
         }
+        if(tile.nodegroup === this.LICENCE_ASSOCIATED_ACTIVITY) {
+          this.relatedActivityId = tile.data[this.LICENCE_ASSOCIATED_ACTIVITY][0].resourceId
+        }
 
         if (tile.nodegroup === this.CONTACTS_NODEGROUP) {
           for (const dv of tile.display_values) {
@@ -89,7 +91,6 @@ define([
     };
 
     this.findLicence = async function (siteResourceId) {
-
       const tiles = await this.fetchTileData(siteResourceId)
       for (const tile of tiles) {
         if (tile.nodegroup === this.ACTIVITY_NAME_NODEGROUP) {
@@ -109,8 +110,9 @@ define([
       for (const tile of tiles) {
         if (tile.nodegroup === this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE) {
           const preFilled = tile.data[this.ASSOCIATED_ACITITY_NODEGROUP_AND_NODE]
-          this.selectedResource(preFilled[0].resourceId)
-          this.getDetails(preFilled[0].resourceId)
+          await this.selectedResource(preFilled[0].resourceId)
+          await this.getDetails(preFilled[0].resourceId)
+          await this.findLicence(this.relatedActivityId)
         }
       }
     }


### PR DESCRIPTION
# PR -show site name on the excavation site visit workflow

## Description of the Issue
In the Site Visit workflow. The box displaying the information about the Licence was not showing the site name

**Related Task:** [3122](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/3122)

---

## Changes Proposed
- Updated the get-selected-licence.js to call the method to fetch the licence info

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
