### PR TITLE
fix: disabled delete in ha select

### DIFF
--- a/coral/plugins/state-care-condition-survey-workflow.json
+++ b/coral/plugins/state-care-condition-survey-workflow.json
@@ -25,6 +25,7 @@
                     "07428674-5020-11ef-b77e-0242ac120006": {
                       "disabled": true,
                       "allowInstanceCreation": false,
+                      "disableDelete": true,
                       "config": {
                         "disabled": true,
                         "label": "SMR Number"


### PR DESCRIPTION
# PR - disabled delete in ha select in State Care Condition Survey workflow

## Description of the Issue
This will remove the delete functionality from the resource instance select for the HA in the State Care Condition Survey workflow

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- Update State Care Workflow to disable delete

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [x] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- State Care Condition Survey

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make manage CMD="coral reload"
```

## Tests
- Navigate to State Care Condition Survey workflow and ensure that you can't delete the HA

---

## Additional Notes
[Any additional information that might be helpful]
