### PR TITLE
Feat: 1409 Hide the resource manager to users

### DIFF
--- a/coral/permissions/casbin.py
+++ b/coral/permissions/casbin.py
@@ -146,6 +146,9 @@ class CasbinPermissionFramework(ArchesStandardPermissionFramework):
         print("RECALC", 2)
         for django_group in DjangoGroup.objects.all():
             print(django_group.name)
+            # Remove access to the resource editor for users
+            if django_group.name == 'Resource Editor': 
+                continue
             group_key = self._subj_to_str(django_group)
             self._enforcer.add_named_grouping_policy("g", group_key, f"dgn:{django_group.name}")
             # The default permissions are (still) all perms, if the nodegroup perms set is empty


### PR DESCRIPTION
# PR - Hide the resource manager to users

## Description of the Issue
Users shouldn't be able to see the resource manager as we want the workflows to be used to create the resources.
This will remove permissions for editing for the user, which will remove the icon but also removes the edit button on the search card. 

An alternative is we just hide the button in the side bar, updating the htm file, this would still give access to the edit page for the user

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- [List the changes you're proposing]
- [Be specific and concise]

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
