### PR TITLE
Feat: 2065 Add colour indicators when the password criteria is met on signup

### DIFF
--- a/coral/media/css/project.css
+++ b/coral/media/css/project.css
@@ -1,5 +1,6 @@
 @import url(report_templates.css);
 @import url(dashboard.css);
+@import url(signup.css);
 
 .workflow-panel.navbarclosed {
     min-width: 50px;
@@ -1108,3 +1109,5 @@ span.rp-tile-title {
 .mh-75vh { max-height: 75vh; }
 .mh-full { max-height: 100vh; }
 .mh-500 { max-height: 500px; }
+
+.mt-1 { margin-top: 0.5rem }

--- a/coral/media/css/signup.css
+++ b/coral/media/css/signup.css
@@ -1,0 +1,23 @@
+.password-rule {
+    color: #dc3545;
+    transition: color 0.3s ease;
+}
+.password-rule.valid {
+    color: #28a745;
+}
+.password-rule.valid i {
+    color: #28a745;
+}
+.password-rule i {
+    color: #dc3545;
+}
+.form-control.invalid {
+    border: 2px solid #dc3545;
+}
+.form-control.valid {
+    border: 2px solid #28a745;
+}
+.btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/coral/static/js/signup.js
+++ b/coral/static/js/signup.js
@@ -1,0 +1,70 @@
+function SignupViewModel() {
+    const password1Input = document.getElementById('password1');
+    const password2Input = document.getElementById('password2');
+    
+    const passwordRules = {
+        length: false,
+        lowercase: false,
+        uppercase: false,
+        number: false,
+        special: false,
+        match: false
+    };
+    
+    function validatePassword() {
+        const password = password1Input.value;
+        
+        passwordRules.uppercase = /[A-Z]/.test(password);
+        passwordRules.lowercase = /[a-z]/.test(password);
+        passwordRules.number = /[0-9]/.test(password);
+        passwordRules.special = /[^A-Za-z0-9]/.test(password);
+        passwordRules.length = password.length >= 9;
+        
+        // Update DOM classes
+        document.getElementById('rule-0').classList.toggle('valid', passwordRules.lowercase || passwordRules.uppercase)
+        document.getElementById('rule-1').classList.toggle('valid', passwordRules.special);
+        document.getElementById('rule-2').classList.toggle('valid', passwordRules.number);
+        document.getElementById('rule-3').classList.toggle('valid', passwordRules.uppercase && passwordRules.lowercase);
+        document.getElementById('rule-4').classList.toggle('valid', passwordRules.length);
+        
+        // Add red border if any rule fails
+        const allRulesValid = passwordRules.length && passwordRules.lowercase && passwordRules.uppercase && passwordRules.number && passwordRules.special;
+        password1Input.classList.toggle('invalid', password.length > 0 && !allRulesValid);
+        password1Input.classList.toggle('valid', password.length > 0 && allRulesValid);
+        
+        validatePasswordMatch();
+    }
+    
+    function validatePasswordMatch() {
+        const password = password1Input.value;
+        const confirmPassword = password2Input.value;
+        const confirmMessage = document.getElementById('rule-confirm');
+        
+        passwordRules.match = password === confirmPassword && password.length > 0;
+
+        if(passwordRules.match){
+            confirmMessage.querySelector('span').textContent = 'Your passwords match';
+            document.getElementById('rule-confirm').classList.toggle('valid', true);
+            password2Input.classList.toggle('invalid', false);
+            password2Input.classList.toggle('valid', true);
+        }
+        else{
+            confirmMessage.querySelector('span').textContent = 'Passwords do not match';
+            document.getElementById('rule-confirm').classList.toggle('valid', false);
+            password2Input.classList.toggle('invalid', confirmPassword.length > 0);
+            password2Input.classList.toggle('valid', false);
+        }
+
+        const signupBtn = document.getElementById('signup-btn');
+
+        const allRulesValid = passwordRules.length && passwordRules.lowercase && passwordRules.uppercase && passwordRules.number && passwordRules.special && passwordRules.match;
+        signupBtn.disabled = !allRulesValid;        
+    }
+    
+    password1Input.addEventListener('input', validatePassword);
+    password2Input.addEventListener('input', validatePasswordMatch);
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    SignupViewModel();
+});

--- a/coral/templates/signup.htm
+++ b/coral/templates/signup.htm
@@ -99,23 +99,23 @@
                                             <div style="color:darkred">{{ error|escape }}</div>
                                         {% endfor %}
                                         {% endif %}
+                                        {% if not form.password2.errors %}
+                                            <li class="password-rule mt-1" id="rule-confirm"><i class="ion-checkmark-circled"></i><span>Passwords do not match</span></li>
+                                        {% endif%}
                                     </div>
     
                                     <div class="form-group">
                                         <div class="arches-signin-btn" style="padding-bottom: 0px;">
                                             {% if showform %}
-                                            <button class="btn btn-primary btn-lg btn-block" type="submit">{% trans "Signup" %}</button>
+                                            <button class="btn btn-primary btn-lg btn-block" id="signup-btn" type="submit" disabled>{% trans "Signup" %}</button>
                                             {% endif %}
                                         </div>
                                     </div>
     
                                     <div class="password-rules" style="text-align: start;">
-                                        {% trans 'Your password must:' %}
-                                        <ul class="list-unstyled">
-                                            {% for message in validation_help %}
-                                            <li class="password-rule"><i class="ion-checkmark-circled"></i><span>{{ message }}</span></li>
-                                            {% endfor %}
-                                        </ul>
+                                        {% for message in validation_help %}
+                                            <li class="password-rule" id="rule-{{ forloop.counter0 }}"><i class="ion-checkmark-circled"></i><span>{{ message }}</span></li>
+                                        {% endfor %}
                                     </div>
     
                                     {% if enable_captcha %}
@@ -144,4 +144,5 @@
 
 </div>
 
+<script src="{% static 'js/signup.js' %}"></script>
 {% endblock body %}


### PR DESCRIPTION
# PR - Add colour indicators when the password criteria is met on signup

## Description of the Issue
On signup there were no indicators to highlight what was incorrect with your password. This adds green and red indicators to each category to highlight if your password in incorrect

**Related Task:** [2065](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2065)

---

## Changes Proposed
- Updated the signup.htm to use a js script
- Created a static js script to validate the password before submitting
- Added CSS classes for validation

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [x] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
