### PR TITLE
fix: 2421 Decode the html strings in the summary step

### DIFF
--- a/coral/media/js/views/components/workflows/summary-step.js
+++ b/coral/media/js/views/components/workflows/summary-step.js
@@ -24,6 +24,13 @@ define([
     this.resourceData = ko.observable();
     this.relatedResources = ko.observableArray();
 
+    this.decodeHtmlEntities = (text) => {
+      if (!text || typeof text !== 'string') return text;
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = text;
+      return tempDiv.textContent || tempDiv.innerText || '';
+    };
+
     this.getResourceData = function () {
       window
         .fetch(this.urls.api_resources(this.resourceid) + '?format=json&compact=false')
@@ -215,14 +222,14 @@ define([
             formatted[tile.nodegroup]['data'][display.nodeid] = {
               nodeId: display.nodeid,
               label: display.label,
-              displayValue: display.value,
+              displayValue: this.decodeHtmlEntities(display.value),
               value: tile.data[display.nodeid]
             };
           } else {
             formatted[tile.nodegroup][cardinalityIdx]['data'][display.nodeid] = {
               nodeId: display.nodeid,
               label: display.label,
-              displayValue: display.value,
+              displayValue: this.decodeHtmlEntities(display.value),
               value: tile.data[display.nodeid]
             };
           }


### PR DESCRIPTION
# PR - Decode the html strings in the summary step

## Description of the Issue
The summary step was showing encoded strings. This adds a helper function to decode these

**Related Task:** [2421](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2421)

---

## Changes Proposed
- Added helper function to the summary step

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- Open an enforcement
- Fill in the reason for enforcement and use ' " £ signs in the text
- Save and continue to the summary
- Should see the text as you typed it

---

## Additional Notes
[Any additional information that might be helpful]
