### PR TITLE
fix: added activity and consultation graphs back to resource list node

### DIFF
--- a/coral/pkg/graphs/resource_models/Enforcement.json
+++ b/coral/pkg/graphs/resource_models/Enforcement.json
@@ -3473,6 +3473,18 @@
                         ],
                         "graphs": [
                             {
+                                "graphid": "8d41e49e-a250-11e9-9eab-00224800b26d",
+                                "name": "Consultation"
+                            },
+                            {
+                                "graphid": "b9e0701e-5463-11e9-b5f5-000d3ab1e588",
+                                "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "name": "Activity",
+                                "relationshipCollection": "00000000-0000-0000-0000-000000000005",
+                                "relationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
+                                "useOntologyRelationship": false
+                            },
+                            {
                                 "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                                 "inverseRelationshipConcept": "ac41d9be-79db-4256-b368-2f4559cfbe55",
                                 "name": "Heritage Asset",


### PR DESCRIPTION
# PR - Update Select resources node in enforcement workflow 

## Description of the Issue
Several graphs were missing from the Select resources node resource instance select, this pr adds them back

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/1694
---

## Changes Proposed
- Add Activity and Consultation to the associated resources for an enforcement

### Types of Changes
- [x] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- Enforcement

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Flag for Enforcement)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make run
make manage CMD="packages -o import_graphs -s coral/pkg/graphs/resource_models/Enforcement.json"
```

## Tests
- Create new flag for enforcement
- Navigate through workflow as normal
- For the Select resources in the enforcement details tab you should be able to add HA, Consultations and Activities

---

## Additional Notes
[Any additional information that might be helpful]
