### PR TITLE
Fix: 2261 Report Summary Resource Instance Select - Licence

### DIFF
--- a/coral/media/js/views/components/workflows/default-card-util.js
+++ b/coral/media/js/views/components/workflows/default-card-util.js
@@ -16,8 +16,6 @@ define([
     this.labels = params.labels || [];
     this.title = ko.observable(params?.title || '')
 
-    console.log("in the default util", this)
-
     if (this.form.componentData.parameters.prefilledNodes) {
       this.form.componentData.parameters.prefilledNodes?.forEach((prefill) => {
         Object.keys(this.form.tile().data).forEach((node) => {

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -48,7 +48,6 @@ APP_ROOT = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe(
 MIN_ARCHES_VERSION = arches.__version__
 MAX_ARCHES_VERSION = arches.__version__
 
-
 WEBPACK_LOADER = {
     "DEFAULT": {
         "STATS_FILE": os.path.join(APP_ROOT, 'webpack/webpack-stats.json'),
@@ -419,7 +418,7 @@ CACHES = {
 }
 
 # Hide nodes and cards in a report that have no data
-HIDE_EMPTY_NODES_IN_REPORT = False
+HIDE_EMPTY_NODES_IN_REPORT = True
 
 BYPASS_UNIQUE_CONSTRAINT_TILE_VALIDATION = False
 BYPASS_REQUIRED_VALUE_TILE_VALIDATION = False

--- a/coral/templates/views/components/widgets/resource-instance-select.htm
+++ b/coral/templates/views/components/widgets/resource-instance-select.htm
@@ -223,7 +223,7 @@
         name: 'resource-report-abstract',
         params: {
             resourceid: reportResourceId(),
-            summary: true,
+            summary: false,
         }
     }"></div>
     <!-- /ko -->


### PR DESCRIPTION
# PR - Report Summary Resource Instance Select - Licence

## Description of the Issue
The info button for the resource instance select was only showing one card. Updated to show the full report and hide the empty nodes

**Related Task:** [2261](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2261)

---

## Changes Proposed
- Change resource instance select summary to false
- Updated system settings to hide empty nodes in reports

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [x] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- All summary reports for instance select should be changed

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- Go into the add monument 
- Select a licence for the monument on step 2
- Press the info button for the selected licence
- Should show a full report and the empty nodes should be hidden
---

## Additional Notes
[Any additional information that might be helpful]
