### PR TITLE
fix: Migration Tool Many Select Conversion

### DIFF
--- a/coral/management/commands/migrate_safely.py
+++ b/coral/management/commands/migrate_safely.py
@@ -1,4 +1,5 @@
 import os, glob
+from typing import List
 import uuid
 from arches.app.models.graph import Graph
 from arches.app.models.models import FunctionXGraph
@@ -500,7 +501,8 @@ class TransformData():
         print(f"An error occurred: {e}")
 
   def allow_many(self, tile_json, nodeid):
-    if tile_json['data'][nodeid]:
+    value = tile_json['data'][nodeid]
+    if value and not isinstance(value, List):
       tile_json['data'][nodeid] = [tile_json['data'][nodeid]]
     return tile_json
   


### PR DESCRIPTION
# PR - Migration Tool Many Select Conversion

## Description of the Issue
When a resource instance was converting to a list, it was adding an extra [ ] to the value. A resource instance is already a list so this threw an error

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- In migrate tool allow many, add a check if the node value is already a list

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
