### PR TITLE
fix: fixed typo in license workflow notification banner

### DIFF
--- a/coral/media/js/views/components/workflows/licensing-workflow/fetch-generated-licence-number.js
+++ b/coral/media/js/views/components/workflows/licensing-workflow/fetch-generated-licence-number.js
@@ -165,7 +165,7 @@ define([
         new AlertViewModel(
           'ep-alert-blue',
           `Application status is "Granted". Licence Number: ${licenceNumber}. Click "Ok" to continue.`,
-          `This application's status has been moved to "Granted". With that a licence number has been genereated that will now be used to identify this application. Example 'Excavation Licence ${licenceNumber}', please use this to find the file in the future. The old application ID will still work on the search page.`,
+          `This application's status has been moved to "Granted". With that a licence number has been generated that will now be used to identify this application. Example 'Excavation Licence ${licenceNumber}', please use this to find the file in the future. The old application ID will still work on the search page.`,
           null,
           () => {
             params.form.complete(true);


### PR DESCRIPTION
# PR - fix typo in license workflow notification banner

## Description of the Issue
fixed typo in license workflow notification banner

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- Updated a typo in the Licence, open workflow description

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [x] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- Licence Workflow

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make webpack
```

## Tests
- Go to license workflow and generate a license, the banner should have no typos
---

## Additional Notes
[Any additional information that might be helpful]
