### PR TITLE
fix: added building name and barony to eval wf location details

### DIFF
--- a/coral/plugins/evaluation-meeting-workflow.json
+++ b/coral/plugins/evaluation-meeting-workflow.json
@@ -209,6 +209,8 @@
                   "semanticName": "Show Location Nodes",
                   "title": "Heritage Asset",
                   "showNodes": [
+                    ["Building Name", "location_data.addresses.0.building_name.building_name_value"],
+                    ["Barony", "location_data.addresses.0.localities_administrative_areas.area_names.area_name"],
                     ["Street", "location_data.addresses.0.street.street_value"],
                     ["Town or City", "location_data.addresses.0.town_or_city.town_or_city_value"],
                     ["County", "location_data.addresses.0.county.county_value"],


### PR DESCRIPTION
# PR - added building name and barony to eval wf location details

## Description of the Issue
dded building name and barony to eval wf location details

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/3087
---

## Changes Proposed
- [List the changes you're proposing]
- [Be specific and concise]

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make manage CMD="coral reload"
```

## Tests
- Navigate to eval workflow and make sure all location details appear

---

## Additional Notes
[Any additional information that might be helpful]
