### PR TITLE
fix: fixed director many select not clearing

### DIFF
--- a/coral/media/js/views/components/widgets/check-open-applications.js
+++ b/coral/media/js/views/components/widgets/check-open-applications.js
@@ -28,10 +28,6 @@ define([
 
     this.limit = ko.observable(params.config().limit);
 
-    if(this.totalLicences() === 0) {
-      this.currentState(null);
-    }
-
     this.limit.subscribe((value) => {
       this.config({
         ...this.config(),

--- a/coral/media/js/views/components/widgets/check-open-applications.js
+++ b/coral/media/js/views/components/widgets/check-open-applications.js
@@ -28,6 +28,10 @@ define([
 
     this.limit = ko.observable(params.config().limit);
 
+    if(this.totalLicences() === 0) {
+      this.currentState(null);
+    }
+
     this.limit.subscribe((value) => {
       this.config({
         ...this.config(),
@@ -126,6 +130,14 @@ define([
       }, true);
 
     this.value.subscribe(async (value) => {
+      if (!value || value.length === 0) {
+        this.applicationData(null);
+        this.totalOpenApplications(null);
+        this.totalLicences(null);
+        this.currentState(null);
+        return;
+      }
+
       await this.loadApplicationData(value);
     }, this);
 


### PR DESCRIPTION
# PR - fix: fixed director many select not clearing

## Description of the Issue
Last Nominated Excavation Director many select not clearing after all were deleted, this PR will fix that issue. The license message pop ups will now clear 

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2338
---

## Changes Proposed
- remove info message when check application is null

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- add null check to the check open application

---

## Commands
```
make run
make webpack
```

## Tests
- Navigate to Licensing workflow and go to application details 
- select many directors and ensure after all are deleted all the message pop ups are removed also 

---

## Additional Notes
[Any additional information that might be helpful]
