### PR TITLE
fix: removed organisation from select in consultation graph

### DIFF
--- a/coral/pkg/graphs/resource_models/Consultation.json
+++ b/coral/pkg/graphs/resource_models/Consultation.json
@@ -26773,10 +26773,6 @@
                         ],
                         "graphs": [
                             {
-                                "graphid": "d4a88461-5463-11e9-90d9-000d3ab1e588",
-                                "name": "Organization"
-                            },
-                            {
                                 "graphid": "22477f01-1a44-11e9-b0a9-000d3ab1e588",
                                 "name": "Person"
                             }


### PR DESCRIPTION
# PR - Applicant to show only person resource

## Description of the Issue
This PR removes organization from the resource select in the planning consultation workflow 

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2498
---

## Changes Proposed
- [List the changes you're proposing]
- [Be specific and concise]

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make manage CMD="packages -o import_graphs -s coral/pkg/graphs/resource_models/Consultation.json"
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
