### PR TITLE
fix: fixed typo in relate ha workflow

### DIFF
--- a/coral/media/js/views/components/plugins/relate-two-monuments-workflow.js
+++ b/coral/media/js/views/components/plugins/relate-two-monuments-workflow.js
@@ -17,7 +17,7 @@ define([
           workflowstepclass: 'workflow-form-component',
           informationboxdata: {
             heading: 'Target Heritage Asset',
-            text: 'The monument selected here will be the Heritage Asset that is related to. The Heritage Asset selected on the second page will appear on this Heritage Asset.'
+            text: 'The monument selected here will be the Heritage Asset that it is related to. The Heritage Asset selected on the second page will appear on this Heritage Asset.'
           },
           layoutSections: [
             {


### PR DESCRIPTION
# PR - fix typo in relate ha workflow

## Description of the Issue
[Provide a brief description of the issue this PR addresses]

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2497
---

## Changes Proposed
- Fix typo in related HA workflow description

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [x] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- Related HA

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (relate-two-monuments-workflow)

---

### Bug Fix
- Update description in related HA

---

## Commands
```
make run 
make webpack
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
