### PR TITLE
fix: added time zone details in coral settings.py

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -26,6 +26,9 @@ except ImportError:
 APP_NAME = 'coral'
 APP_VERSION = semantic_version.Version(major=7, minor=14, patch=52)
 
+TIME_ZONE = "Europe/London"
+USE_TZ = True
+
 GROUPINGS = {
     "groups": {
         "allowed_relationships": {


### PR DESCRIPTION
# PR - Notification times out by an hour

## Description of the Issue
This PR should fix the incorrect time zone and times being displayed in the notification panel

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2503
---

## Changes Proposed
- [List the changes you're proposing]
- [Be specific and concise]

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make run
```

## Tests
- Trigger a notification and make sure the time displayed is correct

---

## Additional Notes
[Any additional information that might be helpful]
