### PR TITLE
Fix: 2818 PDF Merge Files not showing for Users

### DIFF
--- a/coral/pkg/business_data/Logical Sets.json
+++ b/coral/pkg/business_data/Logical Sets.json
@@ -1,1 +1,1899 @@
-{"business_data": {"resources": [{"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "Heritage Assets LogSet"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "Heritage Assets LogSet", "principaluser_id": null, "resourceinstanceid": "3b2cbb70-e49b-4c1d-8281-3b852404c5bf", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "Heritage Assets LogSet"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "3b2cbb70-e49b-4c1d-8281-3b852404c5bf", "sortorder": 0, "tileid": "4fa237bc-42cf-4051-9857-ca0ea011792b"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\":\"076f9381-7b00-11e9-8d6b-80000b44d1d9\",\"name\":\"Heritage Asset\",\"inverted\":false}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "3b2cbb70-e49b-4c1d-8281-3b852404c5bf", "sortorder": 0, "tileid": "76c1ddd0-e62b-48e0-b9eb-d845d13dd794"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "State Care Condition Survey LogSet"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "State Care Condition Survey LogSet", "principaluser_id": null, "resourceinstanceid": "48bca122-19af-4fd1-8649-114f3319b4e5", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"en": {"direction": "ltr", "value": "State Care Condition Survey LogSet"}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "48bca122-19af-4fd1-8649-114f3319b4e5", "sortorder": 0, "tileid": "1a5eeddc-59c6-4f99-9f19-1530bdd84f55"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Heritage Asset Revisions"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Heritage Asset Revisions", "principaluser_id": null, "resourceinstanceid": "c0088cf0-d4e8-4c9d-8f76-793b2cc5cd70", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Heritage Asset Revisions"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "c0088cf0-d4e8-4c9d-8f76-793b2cc5cd70", "sortorder": 0, "tileid": "e0f38c99-c2be-4f24-b016-7eb9550160df"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"9e59e355-07f0-4b13-86c8-7aa12c04a5e3\"%3A{\"val\"%3A\"f\"}}%2C{\"op\"%3A\"or\"%2C\"9e59e355-07f0-4b13-86c8-7aa12c04a5e3\"%3A{\"val\"%3A\"null\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "c0088cf0-d4e8-4c9d-8f76-793b2cc5cd70", "sortorder": 0, "tileid": "d79750c1-bc03-47f0-a4ce-018c1d1c2bc6"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Consultations LogSet"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Consultations LogSet", "principaluser_id": null, "resourceinstanceid": "6affd23b-da12-425e-b0cd-2007a20a065b", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Consultations LogSet"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "6affd23b-da12-425e-b0cd-2007a20a065b", "sortorder": 0, "tileid": "d070a5c8-cf94-4199-87a4-2b6561752635"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "6affd23b-da12-425e-b0cd-2007a20a065b", "sortorder": 0, "tileid": "78da6248-00a1-46ec-a6c4-2e653c1aabd3"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Heritage Assets"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Heritage Assets", "principaluser_id": null, "resourceinstanceid": "70704858-c507-49c5-b6fc-47de4bc0b33c", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"98bd23cd-0923-4d5b-8c84-4269e92887d2\"%3A{\"val\"%3A\"f\"}}%2C{\"op\"%3A\"or\"%2C\"98bd23cd-0923-4d5b-8c84-4269e92887d2\"%3A{\"val\"%3A\"null\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "70704858-c507-49c5-b6fc-47de4bc0b33c", "sortorder": 0, "tileid": "bf94ea74-b8f7-46f1-9db3-2e198a985e74"}, {"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Heritage Assets"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "70704858-c507-49c5-b6fc-47de4bc0b33c", "sortorder": 0, "tileid": "6eabceeb-a57a-4379-977e-f5d7be889e56"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All FMW Inspections"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All FMW Inspections", "principaluser_id": null, "resourceinstanceid": "e1a4c1e0-ff42-41cb-a274-45dba13943ed", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All FMW Inspections"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "e1a4c1e0-ff42-41cb-a274-45dba13943ed", "sortorder": 0, "tileid": "19c6c11e-989a-46d8-bd67-ef771a1d3759"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"FMW\"}%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "e1a4c1e0-ff42-41cb-a274-45dba13943ed", "sortorder": 0, "tileid": "08b57a54-a160-4ed2-8fc4-64951db264df"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Bibliographic Sources"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Bibliographic Sources", "principaluser_id": null, "resourceinstanceid": "510c7387-2623-4971-9777-840172c6fc20", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"en": {"direction": "ltr", "value": "All Bibliographic Sources"}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "510c7387-2623-4971-9777-840172c6fc20", "sortorder": 0, "tileid": "eb6a58a9-16ff-418b-b4d8-2497b39a25d1"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\"%3A\"24d7b54f-5464-11e9-a86b-000d3ab1e588\"%2C\"name\"%3A\"Bibliographic Source\"%2C\"inverted\"%3Afalse}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "510c7387-2623-4971-9777-840172c6fc20", "sortorder": 0, "tileid": "97f4d347-c7df-4463-8e23-f8a647ec8760"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Organizations"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Organizations", "principaluser_id": null, "resourceinstanceid": "71b35126-054c-4c14-8482-a8f08f7ad727", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Organizations"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "71b35126-054c-4c14-8482-a8f08f7ad727", "sortorder": 0, "tileid": "56c67f9c-ff63-43bc-a123-e01552ac6b2a"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\"%3A\"d4a88461-5463-11e9-90d9-000d3ab1e588\"%2C\"name\"%3A\"Organization\"%2C\"inverted\"%3Afalse}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "71b35126-054c-4c14-8482-a8f08f7ad727", "sortorder": 0, "tileid": "c993d31f-60d3-4dcc-816f-4353ae32cae9"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Evaluation Meetings"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Evaluation Meetings", "principaluser_id": null, "resourceinstanceid": "7f2d60f3-27db-4a02-b476-6cbe07aeed5e", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"EVM\"}%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "7f2d60f3-27db-4a02-b476-6cbe07aeed5e", "sortorder": 0, "tileid": "5fb2d137-ae64-4980-99f3-6aef717e9b76"}, {"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Evaluation Meetings"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "7f2d60f3-27db-4a02-b476-6cbe07aeed5e", "sortorder": 0, "tileid": "d598f903-cc6c-4a13-904b-77bda6047dbc"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Persons"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Persons", "principaluser_id": null, "resourceinstanceid": "dae2fe3b-1a35-479a-bf05-c861f6bea919", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Persons"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "dae2fe3b-1a35-479a-bf05-c861f6bea919", "sortorder": 0, "tileid": "81001476-8ee6-4fe1-98ed-6e175f9b1f17"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\"%3A\"22477f01-1a44-11e9-b0a9-000d3ab1e588\"%2C\"name\"%3A\"Person\"%2C\"inverted\"%3Afalse}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "dae2fe3b-1a35-479a-bf05-c861f6bea919", "sortorder": 0, "tileid": "ac4cb08e-3b2d-4c1c-b2ef-06ef634d992e"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Archive Sources"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Archive Sources", "principaluser_id": null, "resourceinstanceid": "297d32af-0f80-44ff-a205-36699735bb72", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\"%3A\"b07cfa6f-894d-11ea-82aa-f875a44e0e11\"%2C\"name\"%3A\"Archive Source\"%2C\"inverted\"%3Afalse}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "297d32af-0f80-44ff-a205-36699735bb72", "sortorder": 0, "tileid": "9727c361-8bfd-43ea-bf58-f718b94e1a0c"}, {"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Archive Sources"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "297d32af-0f80-44ff-a205-36699735bb72", "sortorder": 0, "tileid": "16bfb2a2-c339-4fea-92e5-984320968f27"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "HM Consultations LogSet"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "HM Consultations LogSet", "principaluser_id": null, "resourceinstanceid": "4edddd68-d59c-4173-9be4-208d4be36ad8", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "HM Consultations LogSet"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "4edddd68-d59c-4173-9be4-208d4be36ad8", "sortorder": 0, "tileid": "796f79bc-9332-4d6f-ac31-37e61b62a9e6"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}},{\"op\":\"and\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"94817212-3888-4b5c-90ad-a35ebd2445d5\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}},{\"op\":\"or\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"7d2b266f-f76d-4d25-87f5-b67ff1e1350f\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "4edddd68-d59c-4173-9be4-208d4be36ad8", "sortorder": 0, "tileid": "b793ca56-2cf3-44a9-9417-9970619978bf"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Excavation Licences"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Excavation Licences", "principaluser_id": null, "resourceinstanceid": "4a1ccf22-a490-4073-8054-54e19fcfc5fe", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Excavation Licences"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "4a1ccf22-a490-4073-8054-54e19fcfc5fe", "sortorder": 0, "tileid": "2092af48-f5bc-4426-b3ee-73f93ad92eff"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"991c49b2-48b6-11ee-85af-0242ac140007\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"EL\"}%2C\"991c5326-48b6-11ee-85af-0242ac140007\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"991c4340-48b6-11ee-85af-0242ac140007\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "4a1ccf22-a490-4073-8054-54e19fcfc5fe", "sortorder": 0, "tileid": "d31d1e36-fe6b-4033-bd16-d6c3be9855f8"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "Thatched Resources"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "Thatched Resources", "principaluser_id": null, "resourceinstanceid": "9c796ee3-1728-412f-9f8d-a7a9210d7e70", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "term-filter=[{\"context\"%3A\"3f3775a1-1bed-315a-8f4b-32c0fb22eece\"%2C\"context_label\"%3A\"Material <By Form>\"%2C\"id\"%3A\"concept54f56140-1c3a-3bc9-96f6-41c95fb26b7dMaterial <By Form>\"%2C\"text\"%3A\"Thatch\"%2C\"type\"%3A\"concept\"%2C\"value\"%3A\"54f56140-1c3a-3bc9-96f6-41c95fb26b7d\"%2C\"inverted\"%3Afalse%2C\"selected\"%3Atrue}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "9c796ee3-1728-412f-9f8d-a7a9210d7e70", "sortorder": 0, "tileid": "e0f15a7a-a66d-4837-85b6-2f7b4ed114e4"}, {"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "Thatched Resources"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "9c796ee3-1728-412f-9f8d-a7a9210d7e70", "sortorder": 0, "tileid": "53c7ad1f-8651-4478-b5b8-4ef2803c9d3e"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "Enforcement LogSet"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "Enforcement LogSet", "principaluser_id": null, "resourceinstanceid": "5bb86c22-f674-4a11-9307-577cabc4055a", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "Enforcement LogSet"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "5bb86c22-f674-4a11-9307-577cabc4055a", "sortorder": 0, "tileid": "c4ff5cdc-3f7b-40df-983e-eedc639e7bf0"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\":\"8c3a4ae7-2704-4f47-aa68-4da7f9fc6d84\",\"name\":\"Enforcement\",\"inverted\":false}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "5bb86c22-f674-4a11-9307-577cabc4055a", "sortorder": 0, "tileid": "871c15ec-6e99-4988-b856-ed23a673789e"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Excavation Activities"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Excavation Activities", "principaluser_id": null, "resourceinstanceid": "5c6cac44-5d0d-45a1-aac5-84c8997fc69a", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Excavation Activities"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "5c6cac44-5d0d-45a1-aac5-84c8997fc69a", "sortorder": 0, "tileid": "51c4dc60-6cba-4af7-97a6-83fae26594f3"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"e7d69603-9939-11ea-9e7f-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"EL\"}%2C\"e7d69604-9939-11ea-baef-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"e7d69602-9939-11ea-b514-f875a44e0e11\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "5c6cac44-5d0d-45a1-aac5-84c8997fc69a", "sortorder": 0, "tileid": "50161c85-4e89-4628-8e43-3cbc97a2cc77"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Agriculture and Forestry Consultations"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Agriculture and Forestry Consultations", "principaluser_id": null, "resourceinstanceid": "a5a1893d-9fce-4a0b-8d93-6d400ad1d5ec", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Agriculture and Forestry Consultations"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "a5a1893d-9fce-4a0b-8d93-6d400ad1d5ec", "sortorder": 0, "tileid": "de9e0a74-6548-4897-ba97-add4932c61c6"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=%5B%7B\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"AFC\"%7D%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"%7D%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A%7B\"op\"%3A\"eq\"%2C\"val\"%3A\"\"%7D%7D%5D"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "a5a1893d-9fce-4a0b-8d93-6d400ad1d5ec", "sortorder": 0, "tileid": "9a5daa52-8ccc-44c6-acac-53c066daf663"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "Test HA"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "Test HA", "principaluser_id": null, "resourceinstanceid": "76d7c120-c98c-4adf-ad46-b25b7e6bf39b", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "Test HA"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "76d7c120-c98c-4adf-ad46-b25b7e6bf39b", "sortorder": 0, "tileid": "330742d2-90e4-48de-9a93-cf679735426d"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=%5B%7B\"op\"%3A\"and\"%2C\"98bd23cd-0923-4d5b-8c84-4269e92887d2\"%3A%7B\"val\"%3A\"null\"%7D%7D%5D"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "76d7c120-c98c-4adf-ad46-b25b7e6bf39b", "sortorder": 0, "tileid": "d7ff6ad6-9f11-451e-b6aa-51a8119a39bc"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All DAERA Consultations"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All DAERA Consultations", "principaluser_id": null, "resourceinstanceid": "f2e6b3c0-35f0-4943-a838-131c05fbc97f", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All DAERA Consultations"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "f2e6b3c0-35f0-4943-a838-131c05fbc97f", "sortorder": 0, "tileid": "cc14df03-a560-4bb3-a9fa-0f9ca7b79016"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=%5B%7B\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"AIL\"%7D%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"%7D%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A%7B\"op\"%3A\"eq\"%2C\"val\"%3A\"\"%7D%7D%5D"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "f2e6b3c0-35f0-4943-a838-131c05fbc97f", "sortorder": 0, "tileid": "72594db7-816c-414c-962a-b1854856ec14"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "HB Consultations LogSet"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "HB Consultations LogSet", "principaluser_id": null, "resourceinstanceid": "b37faedc-27d7-4a44-9b62-cfa32e8b60fb", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "HB Consultations LogSet"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "b37faedc-27d7-4a44-9b62-cfa32e8b60fb", "sortorder": 0, "tileid": "af72a32e-8495-40ac-9399-089283e3dcd3"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}},{\"op\":\"and\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"12041c21-6f30-4772-b3dc-9a9a745a7a3f\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}},{\"op\":\"or\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"7d2b266f-f76d-4d25-87f5-b67ff1e1350f\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "b37faedc-27d7-4a44-9b62-cfa32e8b60fb", "sortorder": 0, "tileid": "c01d4898-00f5-4390-b2a3-a6dbb6364621"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Risk Assessments"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Risk Assessments", "principaluser_id": 1, "resourceinstanceid": "eac17998-f4ba-40d0-ad29-414f1cc11a28", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\":\"and\",\"91533656-2a5e-11f0-b5c0-62d3208fcf53\":{\"op\":\"not_null\",\"lang\":\"en\",\"val\":\"\"},\"91533c78-2a5e-11f0-b5c0-62d3208fcf53\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"9153321e-2a5e-11f0-b5c0-62d3208fcf53\":{\"op\":\"eq\",\"val\":\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "eac17998-f4ba-40d0-ad29-414f1cc11a28", "sortorder": 0, "tileid": "08124e07-f2ac-4315-ba81-fbb57eda3d49"}, {"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Risk Assessments"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "eac17998-f4ba-40d0-ad29-414f1cc11a28", "sortorder": 0, "tileid": "5b9b9b56-b353-4d6c-948f-97923a848bbd"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Planning Consultations"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Planning Consultations", "principaluser_id": 34, "resourceinstanceid": "0fa88714-e0ac-47c5-b13c-eeca0358bc59", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Planning Consultations"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "0fa88714-e0ac-47c5-b13c-eeca0358bc59", "sortorder": 0, "tileid": "e810f2a0-bf92-4c41-8e87-10c9eff36bbf"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "0fa88714-e0ac-47c5-b13c-eeca0358bc59", "sortorder": 0, "tileid": "64ece45b-3400-41cc-8f74-67f8094dca4c"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All SMC Consultations"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All SMC Consultations", "principaluser_id": 34, "resourceinstanceid": "5119c2c7-73a6-4172-82e8-801aa3420773", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All SMC Consultations"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "5119c2c7-73a6-4172-82e8-801aa3420773", "sortorder": 0, "tileid": "5904a6b6-668b-45c0-ad0e-a6d572e4c7a8"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"SMC\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "5119c2c7-73a6-4172-82e8-801aa3420773", "sortorder": 0, "tileid": "bc3fd860-f66b-4942-a99a-730fab06a2f5"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Curatorial Inspecitions"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Curatorial Inspecitions", "principaluser_id": 34, "resourceinstanceid": "1b252aa2-64a0-48d5-a8f4-0998fff041a3", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Curatorial Inspecitions"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "1b252aa2-64a0-48d5-a8f4-0998fff041a3", "sortorder": 0, "tileid": "336854dc-022f-4663-99fa-aa9ac526ca13"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CIN\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "1b252aa2-64a0-48d5-a8f4-0998fff041a3", "sortorder": 0, "tileid": "f3a29fe4-c301-4154-adb6-e53540d25b74"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "All Ranger Inspection Reports"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "All Ranger Inspection Reports", "principaluser_id": null, "resourceinstanceid": "d134dbe4-6bd5-4a9f-a9bf-9ceca224fa78", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "All Ranger Inspection Reports"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "d134dbe4-6bd5-4a9f-a9bf-9ceca224fa78", "sortorder": 0, "tileid": "ef03bc63-0c5e-4e2f-b1cc-30e0937c3d26"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\"%3A\"eded3b45-42d1-4bb7-938e-2bc69ad82dab\"%2C\"name\"%3A\"Ranger Inspection Report\"%2C\"inverted\"%3Afalse}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "d134dbe4-6bd5-4a9f-a9bf-9ceca224fa78", "sortorder": 0, "tileid": "28949c78-2f14-48da-b0af-5a13c2e7c039"}]}, {"resourceinstance": {"descriptors": {"en": {"description": "Undefined", "map_popup": "Undefined", "name": "Public Assets"}}, "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006", "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006", "legacyid": null, "name": "Public Assets", "principaluser_id": null, "resourceinstanceid": "333a779f-5f40-4f0c-992e-2084fb0ee6aa", "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"}, "tiles": [{"data": {"5b8b46b0-9687-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "Public Assets"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "333a779f-5f40-4f0c-992e-2084fb0ee6aa", "sortorder": 0, "tileid": "fb133f60-810f-428f-bebf-6dca4d7371ab"}, {"data": {"2f94332c-9688-11ee-8782-0242ac140006": {"de": {"direction": "ltr", "value": ""}, "el": {"direction": "ltr", "value": ""}, "en": {"direction": "ltr", "value": "resource-type-filter=[{\"graphid\":\"076f9381-7b00-11e9-8d6b-80000b44d1d9\",\"name\":\"Heritage Asset\",\"inverted\":false}]"}, "en-US": {"direction": "ltr", "value": ""}, "en-us": {"direction": "ltr", "value": ""}, "fr": {"direction": "ltr", "value": ""}, "pt": {"direction": "ltr", "value": ""}, "ru": {"direction": "ltr", "value": ""}, "zh": {"direction": "ltr", "value": ""}}}, "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006", "parenttile_id": null, "provisionaledits": null, "resourceinstance_id": "333a779f-5f40-4f0c-992e-2084fb0ee6aa", "sortorder": 0, "tileid": "09184d4e-f5ed-46c8-b644-e64ae78463d8"}]}]}}
+{
+  "business_data": {
+    "resources": [
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "Heritage Assets LogSet"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "Heritage Assets LogSet",
+          "principaluser_id": null,
+          "resourceinstanceid": "3b2cbb70-e49b-4c1d-8281-3b852404c5bf",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "Heritage Assets LogSet" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "3b2cbb70-e49b-4c1d-8281-3b852404c5bf",
+            "sortorder": 0,
+            "tileid": "4fa237bc-42cf-4051-9857-ca0ea011792b"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\":\"076f9381-7b00-11e9-8d6b-80000b44d1d9\",\"name\":\"Heritage Asset\",\"inverted\":false}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "3b2cbb70-e49b-4c1d-8281-3b852404c5bf",
+            "sortorder": 0,
+            "tileid": "76c1ddd0-e62b-48e0-b9eb-d845d13dd794"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "State Care Condition Survey LogSet"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "State Care Condition Survey LogSet",
+          "principaluser_id": null,
+          "resourceinstanceid": "48bca122-19af-4fd1-8649-114f3319b4e5",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "en": {
+                  "direction": "ltr",
+                  "value": "State Care Condition Survey LogSet"
+                }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "48bca122-19af-4fd1-8649-114f3319b4e5",
+            "sortorder": 0,
+            "tileid": "1a5eeddc-59c6-4f99-9f19-1530bdd84f55"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Heritage Asset Revisions"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Heritage Asset Revisions",
+          "principaluser_id": null,
+          "resourceinstanceid": "c0088cf0-d4e8-4c9d-8f76-793b2cc5cd70",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Heritage Asset Revisions"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "c0088cf0-d4e8-4c9d-8f76-793b2cc5cd70",
+            "sortorder": 0,
+            "tileid": "e0f38c99-c2be-4f24-b016-7eb9550160df"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"9e59e355-07f0-4b13-86c8-7aa12c04a5e3\"%3A{\"val\"%3A\"f\"}}%2C{\"op\"%3A\"or\"%2C\"9e59e355-07f0-4b13-86c8-7aa12c04a5e3\"%3A{\"val\"%3A\"null\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "c0088cf0-d4e8-4c9d-8f76-793b2cc5cd70",
+            "sortorder": 0,
+            "tileid": "d79750c1-bc03-47f0-a4ce-018c1d1c2bc6"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Consultations LogSet"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Consultations LogSet",
+          "principaluser_id": null,
+          "resourceinstanceid": "6affd23b-da12-425e-b0cd-2007a20a065b",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Consultations LogSet"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "6affd23b-da12-425e-b0cd-2007a20a065b",
+            "sortorder": 0,
+            "tileid": "d070a5c8-cf94-4199-87a4-2b6561752635"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "6affd23b-da12-425e-b0cd-2007a20a065b",
+            "sortorder": 0,
+            "tileid": "78da6248-00a1-46ec-a6c4-2e653c1aabd3"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Heritage Assets"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Heritage Assets",
+          "principaluser_id": null,
+          "resourceinstanceid": "70704858-c507-49c5-b6fc-47de4bc0b33c",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"98bd23cd-0923-4d5b-8c84-4269e92887d2\"%3A{\"val\"%3A\"f\"}}%2C{\"op\"%3A\"or\"%2C\"98bd23cd-0923-4d5b-8c84-4269e92887d2\"%3A{\"val\"%3A\"null\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "70704858-c507-49c5-b6fc-47de4bc0b33c",
+            "sortorder": 0,
+            "tileid": "bf94ea74-b8f7-46f1-9db3-2e198a985e74"
+          },
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All Heritage Assets" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "70704858-c507-49c5-b6fc-47de4bc0b33c",
+            "sortorder": 0,
+            "tileid": "6eabceeb-a57a-4379-977e-f5d7be889e56"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All FMW Inspections"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All FMW Inspections",
+          "principaluser_id": null,
+          "resourceinstanceid": "e1a4c1e0-ff42-41cb-a274-45dba13943ed",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All FMW Inspections" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "e1a4c1e0-ff42-41cb-a274-45dba13943ed",
+            "sortorder": 0,
+            "tileid": "19c6c11e-989a-46d8-bd67-ef771a1d3759"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"FMW\"}%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "e1a4c1e0-ff42-41cb-a274-45dba13943ed",
+            "sortorder": 0,
+            "tileid": "08b57a54-a160-4ed2-8fc4-64951db264df"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Bibliographic Sources"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Bibliographic Sources",
+          "principaluser_id": null,
+          "resourceinstanceid": "510c7387-2623-4971-9777-840172c6fc20",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Bibliographic Sources"
+                }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "510c7387-2623-4971-9777-840172c6fc20",
+            "sortorder": 0,
+            "tileid": "eb6a58a9-16ff-418b-b4d8-2497b39a25d1"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\"%3A\"24d7b54f-5464-11e9-a86b-000d3ab1e588\"%2C\"name\"%3A\"Bibliographic Source\"%2C\"inverted\"%3Afalse}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "510c7387-2623-4971-9777-840172c6fc20",
+            "sortorder": 0,
+            "tileid": "97f4d347-c7df-4463-8e23-f8a647ec8760"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Organizations"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Organizations",
+          "principaluser_id": null,
+          "resourceinstanceid": "71b35126-054c-4c14-8482-a8f08f7ad727",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All Organizations" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "71b35126-054c-4c14-8482-a8f08f7ad727",
+            "sortorder": 0,
+            "tileid": "56c67f9c-ff63-43bc-a123-e01552ac6b2a"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\"%3A\"d4a88461-5463-11e9-90d9-000d3ab1e588\"%2C\"name\"%3A\"Organization\"%2C\"inverted\"%3Afalse}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "71b35126-054c-4c14-8482-a8f08f7ad727",
+            "sortorder": 0,
+            "tileid": "c993d31f-60d3-4dcc-816f-4353ae32cae9"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Evaluation Meetings"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Evaluation Meetings",
+          "principaluser_id": null,
+          "resourceinstanceid": "7f2d60f3-27db-4a02-b476-6cbe07aeed5e",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"EVM\"}%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "7f2d60f3-27db-4a02-b476-6cbe07aeed5e",
+            "sortorder": 0,
+            "tileid": "5fb2d137-ae64-4980-99f3-6aef717e9b76"
+          },
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Evaluation Meetings"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "7f2d60f3-27db-4a02-b476-6cbe07aeed5e",
+            "sortorder": 0,
+            "tileid": "d598f903-cc6c-4a13-904b-77bda6047dbc"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Persons"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Persons",
+          "principaluser_id": null,
+          "resourceinstanceid": "dae2fe3b-1a35-479a-bf05-c861f6bea919",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All Persons" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "dae2fe3b-1a35-479a-bf05-c861f6bea919",
+            "sortorder": 0,
+            "tileid": "81001476-8ee6-4fe1-98ed-6e175f9b1f17"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\"%3A\"22477f01-1a44-11e9-b0a9-000d3ab1e588\"%2C\"name\"%3A\"Person\"%2C\"inverted\"%3Afalse}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "dae2fe3b-1a35-479a-bf05-c861f6bea919",
+            "sortorder": 0,
+            "tileid": "ac4cb08e-3b2d-4c1c-b2ef-06ef634d992e"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Archive Sources"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Archive Sources",
+          "principaluser_id": null,
+          "resourceinstanceid": "297d32af-0f80-44ff-a205-36699735bb72",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\"%3A\"b07cfa6f-894d-11ea-82aa-f875a44e0e11\"%2C\"name\"%3A\"Archive Source\"%2C\"inverted\"%3Afalse}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "297d32af-0f80-44ff-a205-36699735bb72",
+            "sortorder": 0,
+            "tileid": "9727c361-8bfd-43ea-bf58-f718b94e1a0c"
+          },
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All Archive Sources" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "297d32af-0f80-44ff-a205-36699735bb72",
+            "sortorder": 0,
+            "tileid": "16bfb2a2-c339-4fea-92e5-984320968f27"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "HM Consultations LogSet"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "HM Consultations LogSet",
+          "principaluser_id": null,
+          "resourceinstanceid": "4edddd68-d59c-4173-9be4-208d4be36ad8",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "HM Consultations LogSet"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "4edddd68-d59c-4173-9be4-208d4be36ad8",
+            "sortorder": 0,
+            "tileid": "796f79bc-9332-4d6f-ac31-37e61b62a9e6"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}},{\"op\":\"and\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"94817212-3888-4b5c-90ad-a35ebd2445d5\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}},{\"op\":\"or\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"7d2b266f-f76d-4d25-87f5-b67ff1e1350f\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "4edddd68-d59c-4173-9be4-208d4be36ad8",
+            "sortorder": 0,
+            "tileid": "b793ca56-2cf3-44a9-9417-9970619978bf"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Excavation Licences"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Excavation Licences",
+          "principaluser_id": null,
+          "resourceinstanceid": "4a1ccf22-a490-4073-8054-54e19fcfc5fe",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Excavation Licences"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "4a1ccf22-a490-4073-8054-54e19fcfc5fe",
+            "sortorder": 0,
+            "tileid": "2092af48-f5bc-4426-b3ee-73f93ad92eff"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"991c49b2-48b6-11ee-85af-0242ac140007\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"EL\"}%2C\"991c5326-48b6-11ee-85af-0242ac140007\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"991c4340-48b6-11ee-85af-0242ac140007\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "4a1ccf22-a490-4073-8054-54e19fcfc5fe",
+            "sortorder": 0,
+            "tileid": "d31d1e36-fe6b-4033-bd16-d6c3be9855f8"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "Thatched Resources"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "Thatched Resources",
+          "principaluser_id": null,
+          "resourceinstanceid": "9c796ee3-1728-412f-9f8d-a7a9210d7e70",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "term-filter=[{\"context\"%3A\"3f3775a1-1bed-315a-8f4b-32c0fb22eece\"%2C\"context_label\"%3A\"Material <By Form>\"%2C\"id\"%3A\"concept54f56140-1c3a-3bc9-96f6-41c95fb26b7dMaterial <By Form>\"%2C\"text\"%3A\"Thatch\"%2C\"type\"%3A\"concept\"%2C\"value\"%3A\"54f56140-1c3a-3bc9-96f6-41c95fb26b7d\"%2C\"inverted\"%3Afalse%2C\"selected\"%3Atrue}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "9c796ee3-1728-412f-9f8d-a7a9210d7e70",
+            "sortorder": 0,
+            "tileid": "e0f15a7a-a66d-4837-85b6-2f7b4ed114e4"
+          },
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "Thatched Resources" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "9c796ee3-1728-412f-9f8d-a7a9210d7e70",
+            "sortorder": 0,
+            "tileid": "53c7ad1f-8651-4478-b5b8-4ef2803c9d3e"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "Enforcement LogSet"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "Enforcement LogSet",
+          "principaluser_id": null,
+          "resourceinstanceid": "5bb86c22-f674-4a11-9307-577cabc4055a",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "Enforcement LogSet" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "5bb86c22-f674-4a11-9307-577cabc4055a",
+            "sortorder": 0,
+            "tileid": "c4ff5cdc-3f7b-40df-983e-eedc639e7bf0"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\":\"8c3a4ae7-2704-4f47-aa68-4da7f9fc6d84\",\"name\":\"Enforcement\",\"inverted\":false}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "5bb86c22-f674-4a11-9307-577cabc4055a",
+            "sortorder": 0,
+            "tileid": "871c15ec-6e99-4988-b856-ed23a673789e"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Excavation Activities"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Excavation Activities",
+          "principaluser_id": null,
+          "resourceinstanceid": "5c6cac44-5d0d-45a1-aac5-84c8997fc69a",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Excavation Activities"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "5c6cac44-5d0d-45a1-aac5-84c8997fc69a",
+            "sortorder": 0,
+            "tileid": "51c4dc60-6cba-4af7-97a6-83fae26594f3"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\"%3A\"and\"%2C\"e7d69603-9939-11ea-9e7f-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"EL\"}%2C\"e7d69604-9939-11ea-baef-f875a44e0e11\"%3A{\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"}%2C\"e7d69602-9939-11ea-b514-f875a44e0e11\"%3A{\"op\"%3A\"eq\"%2C\"val\"%3A\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "5c6cac44-5d0d-45a1-aac5-84c8997fc69a",
+            "sortorder": 0,
+            "tileid": "50161c85-4e89-4628-8e43-3cbc97a2cc77"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Agriculture and Forestry Consultations"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Agriculture and Forestry Consultations",
+          "principaluser_id": null,
+          "resourceinstanceid": "a5a1893d-9fce-4a0b-8d93-6d400ad1d5ec",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Agriculture and Forestry Consultations"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "a5a1893d-9fce-4a0b-8d93-6d400ad1d5ec",
+            "sortorder": 0,
+            "tileid": "de9e0a74-6548-4897-ba97-add4932c61c6"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=%5B%7B\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"AFC\"%7D%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"%7D%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A%7B\"op\"%3A\"eq\"%2C\"val\"%3A\"\"%7D%7D%5D"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "a5a1893d-9fce-4a0b-8d93-6d400ad1d5ec",
+            "sortorder": 0,
+            "tileid": "9a5daa52-8ccc-44c6-acac-53c066daf663"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "Test HA"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "Test HA",
+          "principaluser_id": null,
+          "resourceinstanceid": "76d7c120-c98c-4adf-ad46-b25b7e6bf39b",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "Test HA" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "76d7c120-c98c-4adf-ad46-b25b7e6bf39b",
+            "sortorder": 0,
+            "tileid": "330742d2-90e4-48de-9a93-cf679735426d"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=%5B%7B\"op\"%3A\"and\"%2C\"98bd23cd-0923-4d5b-8c84-4269e92887d2\"%3A%7B\"val\"%3A\"null\"%7D%7D%5D"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "76d7c120-c98c-4adf-ad46-b25b7e6bf39b",
+            "sortorder": 0,
+            "tileid": "d7ff6ad6-9f11-451e-b6aa-51a8119a39bc"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All DAERA Consultations"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All DAERA Consultations",
+          "principaluser_id": null,
+          "resourceinstanceid": "f2e6b3c0-35f0-4943-a838-131c05fbc97f",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All DAERA Consultations"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "f2e6b3c0-35f0-4943-a838-131c05fbc97f",
+            "sortorder": 0,
+            "tileid": "cc14df03-a560-4bb3-a9fa-0f9ca7b79016"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=%5B%7B\"op\"%3A\"and\"%2C\"b37552be-9527-11ea-9213-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"AIL\"%7D%2C\"b37552bf-9527-11ea-9c87-f875a44e0e11\"%3A%7B\"op\"%3A\"~\"%2C\"lang\"%3A\"en\"%2C\"val\"%3A\"\"%7D%2C\"b37552bd-9527-11ea-97f4-f875a44e0e11\"%3A%7B\"op\"%3A\"eq\"%2C\"val\"%3A\"\"%7D%7D%5D"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "f2e6b3c0-35f0-4943-a838-131c05fbc97f",
+            "sortorder": 0,
+            "tileid": "72594db7-816c-414c-962a-b1854856ec14"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "HB Consultations LogSet"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "HB Consultations LogSet",
+          "principaluser_id": null,
+          "resourceinstanceid": "b37faedc-27d7-4a44-9b62-cfa32e8b60fb",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "HB Consultations LogSet"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "b37faedc-27d7-4a44-9b62-cfa32e8b60fb",
+            "sortorder": 0,
+            "tileid": "af72a32e-8495-40ac-9399-089283e3dcd3"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}},{\"op\":\"and\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"12041c21-6f30-4772-b3dc-9a9a745a7a3f\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}},{\"op\":\"or\",\"e2585f8a-51a3-11eb-a7be-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"7d2b266f-f76d-4d25-87f5-b67ff1e1350f\"},\"8322f9f6-69b5-11ee-93a1-0242ac120002\":{\"op\":\"\",\"val\":\"\"},\"c4413ac8-69b6-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"06adec44-69b7-11ee-908a-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"19eef70c-69b8-11ee-8431-0242ac120002\":{\"op\":\"eq\",\"val\":\"\"},\"bfd39106-51a3-11eb-9104-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "b37faedc-27d7-4a44-9b62-cfa32e8b60fb",
+            "sortorder": 0,
+            "tileid": "c01d4898-00f5-4390-b2a3-a6dbb6364621"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Risk Assessments"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Risk Assessments",
+          "principaluser_id": 1,
+          "resourceinstanceid": "eac17998-f4ba-40d0-ad29-414f1cc11a28",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"91533656-2a5e-11f0-b5c0-62d3208fcf53\":{\"op\":\"not_null\",\"lang\":\"en\",\"val\":\"\"},\"91533c78-2a5e-11f0-b5c0-62d3208fcf53\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"9153321e-2a5e-11f0-b5c0-62d3208fcf53\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "eac17998-f4ba-40d0-ad29-414f1cc11a28",
+            "sortorder": 0,
+            "tileid": "08124e07-f2ac-4315-ba81-fbb57eda3d49"
+          },
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All Risk Assessments" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "eac17998-f4ba-40d0-ad29-414f1cc11a28",
+            "sortorder": 0,
+            "tileid": "5b9b9b56-b353-4d6c-948f-97923a848bbd"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Planning Consultations"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Planning Consultations",
+          "principaluser_id": 34,
+          "resourceinstanceid": "0fa88714-e0ac-47c5-b13c-eeca0358bc59",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Planning Consultations"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "0fa88714-e0ac-47c5-b13c-eeca0358bc59",
+            "sortorder": 0,
+            "tileid": "e810f2a0-bf92-4c41-8e87-10c9eff36bbf"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CON\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "0fa88714-e0ac-47c5-b13c-eeca0358bc59",
+            "sortorder": 0,
+            "tileid": "64ece45b-3400-41cc-8f74-67f8094dca4c"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All SMC Consultations"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All SMC Consultations",
+          "principaluser_id": 34,
+          "resourceinstanceid": "5119c2c7-73a6-4172-82e8-801aa3420773",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All SMC Consultations" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "5119c2c7-73a6-4172-82e8-801aa3420773",
+            "sortorder": 0,
+            "tileid": "5904a6b6-668b-45c0-ad0e-a6d572e4c7a8"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"SMC\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "5119c2c7-73a6-4172-82e8-801aa3420773",
+            "sortorder": 0,
+            "tileid": "bc3fd860-f66b-4942-a99a-730fab06a2f5"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Curatorial Inspecitions"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Curatorial Inspecitions",
+          "principaluser_id": 34,
+          "resourceinstanceid": "1b252aa2-64a0-48d5-a8f4-0998fff041a3",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Curatorial Inspecitions"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "1b252aa2-64a0-48d5-a8f4-0998fff041a3",
+            "sortorder": 0,
+            "tileid": "336854dc-022f-4663-99fa-aa9ac526ca13"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"b37552be-9527-11ea-9213-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"CIN\"},\"b37552bf-9527-11ea-9c87-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"\"},\"b37552bd-9527-11ea-97f4-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "1b252aa2-64a0-48d5-a8f4-0998fff041a3",
+            "sortorder": 0,
+            "tileid": "f3a29fe4-c301-4154-adb6-e53540d25b74"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Ranger Inspection Reports"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Ranger Inspection Reports",
+          "principaluser_id": null,
+          "resourceinstanceid": "d134dbe4-6bd5-4a9f-a9bf-9ceca224fa78",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "All Ranger Inspection Reports"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "d134dbe4-6bd5-4a9f-a9bf-9ceca224fa78",
+            "sortorder": 0,
+            "tileid": "ef03bc63-0c5e-4e2f-b1cc-30e0937c3d26"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\"%3A\"eded3b45-42d1-4bb7-938e-2bc69ad82dab\"%2C\"name\"%3A\"Ranger Inspection Report\"%2C\"inverted\"%3Afalse}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "d134dbe4-6bd5-4a9f-a9bf-9ceca224fa78",
+            "sortorder": 0,
+            "tileid": "28949c78-2f14-48da-b0af-5a13c2e7c039"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "Public Assets"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "Public Assets",
+          "principaluser_id": null,
+          "resourceinstanceid": "333a779f-5f40-4f0c-992e-2084fb0ee6aa",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "Public Assets" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "333a779f-5f40-4f0c-992e-2084fb0ee6aa",
+            "sortorder": 0,
+            "tileid": "fb133f60-810f-428f-bebf-6dca4d7371ab"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "resource-type-filter=[{\"graphid\":\"076f9381-7b00-11e9-8d6b-80000b44d1d9\",\"name\":\"Heritage Asset\",\"inverted\":false}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "333a779f-5f40-4f0c-992e-2084fb0ee6aa",
+            "sortorder": 0,
+            "tileid": "09184d4e-f5ed-46c8-b644-e64ae78463d8"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "All Digital Objects"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "All Digital Objects",
+          "principaluser_id": 1,
+          "resourceinstanceid": "43739fb9-d235-4e63-b2e5-9c2ea4bf3cb5",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": { "direction": "ltr", "value": "All Digital Objects" },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "43739fb9-d235-4e63-b2e5-9c2ea4bf3cb5",
+            "sortorder": 0,
+            "tileid": "9299a951-8b66-48a0-a141-f0b1592fc460"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"c61ab16c-9513-11ea-89a4-f875a44e0e11\":{\"op\":\"not_null\",\"lang\":\"en\",\"val\":\"\"},\"c61ab166-9513-11ea-a44c-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"},\"c61ab167-9513-11ea-9d50-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "43739fb9-d235-4e63-b2e5-9c2ea4bf3cb5",
+            "sortorder": 0,
+            "tileid": "bf3daf2f-6fdb-4fac-aa37-b04fe18ffa98"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "HM Response Digital Objects"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "HM Response Digital Objects",
+          "principaluser_id": 1,
+          "resourceinstanceid": "edc6e955-4804-429f-af3e-6dfa73e2ecfc",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "HM Response Digital Objects"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "edc6e955-4804-429f-af3e-6dfa73e2ecfc",
+            "sortorder": 0,
+            "tileid": "b08fc632-d6c5-458f-9b92-db0a62a44334"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"c61ab16c-9513-11ea-89a4-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"HM Response\"},\"c61ab166-9513-11ea-a44c-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"},\"c61ab167-9513-11ea-9d50-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "edc6e955-4804-429f-af3e-6dfa73e2ecfc",
+            "sortorder": 0,
+            "tileid": "8024b39d-bd3d-41d6-8083-e95b20eb0b5a"
+          }
+        ]
+      },
+      {
+        "resourceinstance": {
+          "descriptors": {
+            "en": {
+              "description": "Undefined",
+              "map_popup": "Undefined",
+              "name": "HB Response Digital Objects"
+            }
+          },
+          "graph_id": "5b8b4084-9687-11ee-8782-0242ac140006",
+          "graph_publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006",
+          "legacyid": null,
+          "name": "HB Response Digital Objects",
+          "principaluser_id": 1,
+          "resourceinstanceid": "b7408bed-4678-41ca-acf2-ead3512c8b5c",
+          "publication_id": "6d9d83c6-9688-11ee-a81e-0242ac140006"
+        },
+        "tiles": [
+          {
+            "data": {
+              "5b8b46b0-9687-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "HB Response Digital Objects"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "5b8b43ae-9687-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "b7408bed-4678-41ca-acf2-ead3512c8b5c",
+            "sortorder": 0,
+            "tileid": "977a79b6-b414-49c7-a8c3-d1f0d39399bd"
+          },
+          {
+            "data": {
+              "2f94332c-9688-11ee-8782-0242ac140006": {
+                "de": { "direction": "ltr", "value": "" },
+                "el": { "direction": "ltr", "value": "" },
+                "en": {
+                  "direction": "ltr",
+                  "value": "advanced-search=[{\"op\":\"and\",\"c61ab16c-9513-11ea-89a4-f875a44e0e11\":{\"op\":\"~\",\"lang\":\"en\",\"val\":\"HB Response\"},\"c61ab166-9513-11ea-a44c-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"},\"c61ab167-9513-11ea-9d50-f875a44e0e11\":{\"op\":\"eq\",\"val\":\"\"}}]"
+                },
+                "en-US": { "direction": "ltr", "value": "" },
+                "en-us": { "direction": "ltr", "value": "" },
+                "fr": { "direction": "ltr", "value": "" },
+                "pt": { "direction": "ltr", "value": "" },
+                "ru": { "direction": "ltr", "value": "" },
+                "zh": { "direction": "ltr", "value": "" }
+              }
+            },
+            "nodegroup_id": "2f94332c-9688-11ee-8782-0242ac140006",
+            "parenttile_id": null,
+            "provisionaledits": null,
+            "resourceinstance_id": "b7408bed-4678-41ca-acf2-ead3512c8b5c",
+            "sortorder": 0,
+            "tileid": "0c3633f9-7364-4d09-8334-5ad4d67066b9"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# PR - PDF Merge Files not showing for Users

## Description of the Issue
The PDF files were not being listed in the PDF merger step for the planning resource when logged in as a user. This was related to the permissions not being able to access the Related Resources of a resource instance.

**Related Task:** [2818](https://tree.taiga.io/project/viktoriabon-coral-phase-2/us/2818)

---

## Changes Proposed
- Updated casbin to check against the user permissions as well as the Django Group permissions
- Added additional logical sets for the digital objects
- Updated the planning groups with the new logical sets (saved in the S3 bucket)

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [x] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- Logical sets data set has been updated to include
    - All digital objects
    - HM Response Digital Objects
    - HB Response Digital Objects 
- Casbin permissions check against user permissions
- Extra function added to check for permissions against graph access 

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make manage CMD="packages -o import_business_data -s coral/pkg/business_data/Logical\ Sets.json"
make manage CMD="migrate_safely -o rehydrate_members -s path_to_downloaded_groups
```

## Tests
- Download the latest Group and hydrate with your current members
- Create a planning consultation and assign to both groups HM and HB
- Fill out a response and uploaded a pdf file for both responses
- Log in as a planning team admin user
- Navigate to the created consultation
- Go to the Response step at the end which merges the pdf's
- Check that you can see the name of both files
- Additional check is to click on related resources for the consultation
- Should see the response files linked

---

## Additional Notes
[Any additional information that might be helpful]
