### PR TITLE
fix: add escape function to notify enforcement

### DIFF
--- a/coral/functions/notify_enforcement.py
+++ b/coral/functions/notify_enforcement.py
@@ -37,6 +37,9 @@ details = {
 
 class NotifyEnforcement(BaseFunction):
     def post_save(self, tile, request, context):
+        if context and context.get('escape_function', False):
+            return
+        
         resource_instance_id = str(tile.resourceinstance.resourceinstanceid)
 
         existing_notification = models.Notification.objects.filter(

--- a/coral/media/js/views/components/workflows/enforcement-workflow/enforcement-summary-step.js
+++ b/coral/media/js/views/components/workflows/enforcement-workflow/enforcement-summary-step.js
@@ -61,6 +61,11 @@ define([
         nodegroupId: 'ac823b90-b555-11ee-805b-0242ac120006',
         renderNodeIds: ['c9711ef6-b555-11ee-baf6-0242ac120006']
       },
+      cMRef: {
+        label: 'CM Reference',
+        nodegroupId: '25e2611c-b557-11ee-805b-0242ac120006',
+        renderNodeIds: ['25e26afe-b557-11ee-805b-0242ac120006']
+      },
       crimeRef: {
         label: 'Crime References',
         nodegroupId: '0674ff12-b5e6-11ee-a372-0242ac120006',


### PR DESCRIPTION
# PR - add escape function to notify enforcement and cm ref to enforcement summary

## Description of the Issue
The notify enforcement did not have the check to escape the function for imports and CM ref was not showing on the Enforcement summary page

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- add escape_function context to notify_enforcement

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- Create an enforcement
- Head to the dashboard
- Open the respond to enforcement by clicking open
- Add a cm ref
- Should be visible on the summary step

---

## Additional Notes
[Any additional information that might be helpful]
