### PR TITLE
fix: check application type data on load to set hierarchy type

### DIFF
--- a/coral/media/js/views/components/workflows/assign-consultation-workflow/show-hierarchy-change.js
+++ b/coral/media/js/views/components/workflows/assign-consultation-workflow/show-hierarchy-change.js
@@ -42,7 +42,7 @@ define([
       }
     }, this);
 
-    if (this.STATUTORY_VALUES.includes(this.tile.data['54de6acc-8895-11ea-9067-f875a44e0e11']())) {
+    if (this.tile.data['54de6acc-8895-11ea-9067-f875a44e0e11']()) {
       if (this.STATUTORY_VALUES.includes(this.tile.data['54de6acc-8895-11ea-9067-f875a44e0e11']())) {
         this.selectedHierarchy('d06d5de0-2881-4d71-89b1-522ebad3088d');
       } else {

--- a/coral/pkg/graphs/resource_models/Consultation.json
+++ b/coral/pkg/graphs/resource_models/Consultation.json
@@ -1269,7 +1269,7 @@
                     },
                     "nodegroup_id": "54de6acc-8895-11ea-9067-f875a44e0e11",
                     "sortorder": 5,
-                    "visible": false
+                    "visible": true
                 },
                 {
                     "active": true,


### PR DESCRIPTION
# PR - check application type data on load to set hierarchy type

## Description of the Issue
The application data was checking if the selection was in the STATUTORY_VALUES on load and setting a default selection text if not. This changes to check for a value or default text and then perform the check for hierarchy type.
The Application type was also not showing in the report section of the instance

**Related Task:** [2783](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2783)
[2943](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2943)

---

## Changes Proposed
- update check against application type in the show-hierarchy-change
- make the application type card visible in the resource instance

### Types of Changes
- [x] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- Consultation - Made Application Type card visible

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make manage CMD="migrate_safely -o migrate -m Consultation"
```

## Tests
- Start a planning consultation
- Navigate to assignment details
- Hierarchy type should show selection text
- Choose Full in application type
- Hierarchy type should change to Statutory
- Save and move to next step and then step back to assessment details
- Hierarchy type should still be Statutory
- Choose advertisement
- Hierarchy type should change to Non Statutory
- Save and navigate back to the step
- Should still say Non Statutory
- Delete Application text and repeat the above process
- Should show the selection text
- Go to the resource instance and open the report page
- Should see the application type listed in the full report

---

## Additional Notes
[Any additional information that might be helpful]
