### PR TITLE
Fix: 2782 - Update Consultation Display Name

### DIFF
--- a/coral/functions/update_planning_name_function.py
+++ b/coral/functions/update_planning_name_function.py
@@ -90,8 +90,8 @@ class UpdatePlanningNameFunction(BaseFunction):
             resource_id_value = self.get_localised_string_value(
                 system_reference_tile, SYSTEM_REFERENCE_RESOURCE_NODE_ID
             )
+
             if resource_id_value.startswith('extrados'):
-                print("DEBUG PLANNING NAME UPDATE: ", resource_id_value)
                 def generateID (prefix="CON", length=6):
                     base62chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
                     current_date = date.today()
@@ -131,10 +131,8 @@ class UpdatePlanningNameFunction(BaseFunction):
             display_name_tile.data[DISPLAY_NAME_NODE_ID] = (
                 self.value_as_localised_string(planning_ref_value)
             )
-            display_name_tile.save()
-            return
-
-        display_name_tile.data[DISPLAY_NAME_NODE_ID] = self.value_as_localised_string(
-            resource_id_value
-        )
+        else:
+            display_name_tile.data[DISPLAY_NAME_NODE_ID] = self.value_as_localised_string(
+                resource_id_value
+            )
         display_name_tile.save()


### PR DESCRIPTION
# PR - Update Consultation Display Name

## Description of the Issue
The display name for a planning consultation was not updating when all the tiles were filled in.

**Related Task:** [2782](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2782)

---

## Changes Proposed
- Add else statement to update planning name function to stop the reference number being used

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- Start a planning consultation
- Fill in everything on the application details page
- Find the resource in the search
- Should have the planning reference as the display name

---

## Additional Notes
[Any additional information that might be helpful]
