### PR TITLE
fix(Organization): change county data type to a concept

### DIFF
--- a/coral/pkg/graphs/resource_models/Organization.json
+++ b/coral/pkg/graphs/resource_models/Organization.json
@@ -2246,7 +2246,7 @@
                     "node_id": "9e791cfe-eff3-11eb-9c35-a87eeabdefba",
                     "sortorder": 27,
                     "visible": true,
-                    "widget_id": "10000000-0000-0000-0000-000000000001"
+                    "widget_id": "10000000-0000-0000-0000-000000000002"
                 },
                 {
                     "card_id": "af3b0118-29a9-11eb-8e7b-f875a44e0e11",
@@ -8714,8 +8714,10 @@
                 },
                 {
                     "alias": "county_value",
-                    "config": {},
-                    "datatype": "string",
+                    "config": {
+                        "rdmCollection": "763ba635-3800-324a-8d54-c1427bcaa5aa"
+                    },
+                    "datatype": "concept",
                     "description": null,
                     "exportable": true,
                     "fieldname": "County",


### PR DESCRIPTION
# PR - change county data type to a concept

## Description of the Issue
Organization county datatype was still set as a string

**Related Task:** [2607](https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2607)

---

## Changes Proposed
- Change county type in Organization model to a concept

### Types of Changes
- [x] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- Organization

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- Create a new organization
- County should be a drop down of counties

---

## Additional Notes
[Any additional information that might be helpful]
