### PR TITLE
fix: disable name field in issue report wf

### DIFF
--- a/coral/plugins/issue-report-workflow.json
+++ b/coral/plugins/issue-report-workflow.json
@@ -90,6 +90,11 @@
                 "parameters": {
                   "graphid": "076f9381-7b00-11e9-8d6b-80000b44d1d9",
                   "resourceid": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['resourceInstanceId']",
+                  "nodeOptions": {
+                    "676d47ff-9c1c-11ea-b07f-f875a44e0e11": {
+                      "disabled": true
+                    }
+                  },
                   "hiddenNodes": [
                     "676d47fd-9c1c-11ea-9d73-f875a44e0e11",
                     "676d47fc-9c1c-11ea-b5b0-f875a44e0e11"


### PR DESCRIPTION
# PR - Disable name field in issue report wf

## Description of the Issue
This PR will disable the HA name field in the issue report workflow

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/3080
---

## Changes Proposed
- [List the changes you're proposing]
- [Be specific and concise]

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- Navigate to the issue report workflow
- Follow through to the Record of the Issue workflow step
- Make sure the name field is disabled 

---

## Additional Notes
[Any additional information that might be helpful]
