### PR TITLE
fix: no longer refreshing wf when enter key pressed in text boxes

### DIFF
--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -156,10 +156,12 @@ define([
         };
 
         // ctrl+S to save any edited/dirty tiles in resource view 
+        // prevents workflow refresh if enter is pressed
         var keyListener = function(e) {
             if (e.ctrlKey && e.key === "s" || e.key === "Enter") {
                 e.preventDefault();
-                if (self?.tile?.dirty() == true && 
+                if (e.ctrlKey && e.key === "s" && 
+                    self?.tile?.dirty() == true && 
                     self?.tile?.parent?.isWritable === true) {
                         self.saveTile();
                 }


### PR DESCRIPTION
# PR - Fix Workflows refreshing when enter key is actioned in text boxes 

## Description of the Issue
Fix Workflows refreshing when enter key is actioned in text boxes

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/1676
---

## Changes Proposed
- Added key listener check for enter key and if detected action e.preventDefault()


### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make webpack
```

## Tests
- Hit enter in standard text fields in workflows and it should no longer refresh the workflow 

---

## Additional Notes
[Any additional information that might be helpful]
