### PR TITLE
RELEASE - sprint 35 - v7.15.53

### DIFF
--- a/CHANGELOG_sprint_35.md
+++ b/CHANGELOG_sprint_35.md
@@ -15,6 +15,9 @@
 - Create a separate download function to fetch the blob of the file
 - Changed the uploader download button to always download the file
 - Update the context if function to work correctly
+- Update the many tile titles for all HA workflows
+- Update the many tile titles for HA Designation
+- Update the many tile titles for Licensing
 
 ## Pull Requests
 
@@ -26,4 +29,7 @@
 
 **fix: disable cm ref node in issue report workflow**
 [783](https://github.com/flaxandteal/coral-arches/pull/783) by @StuCM
+
+**fix: updated many select labels**
+[780](https://github.com/flaxandteal/coral-arches/pull/780) by @babou212
 

--- a/CHANGELOG_sprint_35.md
+++ b/CHANGELOG_sprint_35.md
@@ -18,6 +18,7 @@
 - Update the many tile titles for all HA workflows
 - Update the many tile titles for HA Designation
 - Update the many tile titles for Licensing
+- Added key listener check for enter key and if detected action e.preventDefault
 
 ## Pull Requests
 
@@ -32,4 +33,7 @@
 
 **fix: updated many select labels**
 [780](https://github.com/flaxandteal/coral-arches/pull/780) by @babou212
+
+**fix: no longer refreshing wf when enter key pressed in text boxes**
+[785](https://github.com/flaxandteal/coral-arches/pull/785) by @babou212
 

--- a/CHANGELOG_sprint_35.md
+++ b/CHANGELOG_sprint_35.md
@@ -1,0 +1,22 @@
+### Types of Changes
+- [ ] Model Changes
+- [ ] Added Functions
+- [ ] Added Concepts
+- [ ] Workflows Updated
+- [ ] Reports Updated
+- [ ] Added/Updated Dependencies
+- [x] Features Added
+- [x] Bug Fix
+
+### Proposed Changes
+- Added a download button to the report page to allow for the file to be downloaded
+- Updated CSP to allow for the thumbnail image to be viewed in the report
+- Create a custom file.js and file.htm to make these changes
+- Create a separate download function to fetch the blob of the file
+- Changed the uploader download button to always download the file
+
+## Pull Requests
+
+**Fix/3138 File Uploader Files**
+[782](https://github.com/flaxandteal/coral-arches/pull/782) by @StuCM
+

--- a/CHANGELOG_sprint_35.md
+++ b/CHANGELOG_sprint_35.md
@@ -19,6 +19,8 @@
 - Update the many tile titles for HA Designation
 - Update the many tile titles for Licensing
 - Added key listener check for enter key and if detected action e.preventDefault
+- Switched Monument type node in get-ha-details comp for HA type node
+- Switched Monument type node in get-ha-smc-details comp for HA type node
 
 ## Pull Requests
 
@@ -36,4 +38,7 @@
 
 **fix: no longer refreshing wf when enter key pressed in text boxes**
 [785](https://github.com/flaxandteal/coral-arches/pull/785) by @babou212
+
+**fix: switched monument type node for HA type node**
+[784](https://github.com/flaxandteal/coral-arches/pull/784) by @babou212
 

--- a/CHANGELOG_sprint_35.md
+++ b/CHANGELOG_sprint_35.md
@@ -24,3 +24,6 @@
 **Fix: Context Update Statement**
 [779](https://github.com/flaxandteal/coral-arches/pull/779) by @StuCM
 
+**fix: disable cm ref node in issue report workflow**
+[783](https://github.com/flaxandteal/coral-arches/pull/783) by @StuCM
+

--- a/CHANGELOG_sprint_35.md
+++ b/CHANGELOG_sprint_35.md
@@ -14,9 +14,13 @@
 - Create a custom file.js and file.htm to make these changes
 - Create a separate download function to fetch the blob of the file
 - Changed the uploader download button to always download the file
+- Update the context if function to work correctly
 
 ## Pull Requests
 
 **Fix/3138 File Uploader Files**
 [782](https://github.com/flaxandteal/coral-arches/pull/782) by @StuCM
+
+**Fix: Context Update Statement**
+[779](https://github.com/flaxandteal/coral-arches/pull/779) by @StuCM
 

--- a/coral/functions/update_report_classification_type.py
+++ b/coral/functions/update_report_classification_type.py
@@ -38,7 +38,7 @@ class UpdateReportClassificationType(BaseFunction):
 
             context : represents the context in which this function has been called.
         """
-        if context and not context['escape_function']:
+        if context and context.get('escape_function', False):
             return
 
 

--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -157,7 +157,7 @@ define([
 
         // ctrl+S to save any edited/dirty tiles in resource view 
         var keyListener = function(e) {
-            if (e.ctrlKey && e.key === "s") {
+            if (e.ctrlKey && e.key === "s" || e.key === "Enter") {
                 e.preventDefault();
                 if (self?.tile?.dirty() == true && 
                     self?.tile?.parent?.isWritable === true) {

--- a/coral/media/js/viewmodels/card-component.js
+++ b/coral/media/js/viewmodels/card-component.js
@@ -156,10 +156,12 @@ define([
         };
 
         // ctrl+S to save any edited/dirty tiles in resource view 
+        // prevents workflow refresh if enter is pressed
         var keyListener = function(e) {
             if (e.ctrlKey && e.key === "s" || e.key === "Enter") {
                 e.preventDefault();
-                if (self?.tile?.dirty() == true && 
+                if (e.ctrlKey && e.key === "s" && 
+                    self?.tile?.dirty() == true && 
                     self?.tile?.parent?.isWritable === true) {
                         self.saveTile();
                 }

--- a/coral/media/js/views/components/plugins/licensing-workflow.js
+++ b/coral/media/js/views/components/plugins/licensing-workflow.js
@@ -798,7 +798,7 @@ define([
                   componentName: 'transfer-of-licence',
                   uniqueInstanceName: 'transfer-of-licence',
                   tilesManaged: 'many',
-                  manyTitle: 'Transfers',
+                  manyTitle: 'Transfer of Licence',
                   parameters: {
                     title: 'Transfer of Licence',
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',
@@ -891,6 +891,7 @@ define([
                   componentName: 'default-card-util',
                   uniqueInstanceName: 'extension-of-licence',
                   tilesManaged: 'many',
+                  manyTitle: 'Extension of Licence',
                   parameters: {
                     title: 'Extension of Licence',
                     graphid: 'cc5da227-24e7-4088-bb83-a564c4331efd',

--- a/coral/media/js/views/components/widgets/file.js
+++ b/coral/media/js/views/components/widgets/file.js
@@ -1,0 +1,47 @@
+define([
+    'jquery',
+    'knockout',
+    'underscore',
+    'dropzone',
+    'uuid',
+    'viewmodels/file-widget',
+    'templates/views/components/widgets/file.htm',
+    'bindings/dropzone',
+], function($, ko, _, Dropzone, uuid, FileWidgetViewModel, fileWidgetTemplate) {
+    /**
+     * registers a file-widget component for use in forms
+     * @function external:"ko.components".file-widget
+     * @param {object} params
+     * @param {string} params.value - the value being managed
+     * @param {function} params.config - observable containing config object
+     * @param {string} params.config().acceptedFiles - accept attribute value for file input
+     * @param {string} params.config().maxFilesize - maximum allowed file size in MB
+     */
+
+    const viewModel = function(params) {
+        params.configKeys = ['acceptedFiles', 'maxFilesize'];
+         
+        FileWidgetViewModel.apply(this, [params]);
+
+        this.downloadFile = function(fileUrl, fileName) {
+            const url = this.getFileUrl(fileUrl);
+            if (!url) return true;
+            fetch(url)
+                .then(response => response.blob())
+                .then(blob => {
+                    const link = document.createElement('a');
+                    link.href = window.URL.createObjectURL(blob);
+                    link.download = ko.unwrap(fileName);
+                    document.body.appendChild(link);
+                    link.click();
+                    document.body.removeChild(link);
+                })
+                .catch(error => console.error('Error downloading file:', error));
+        };
+    };
+
+    return ko.components.register('file-widget', {
+        viewModel: viewModel,
+        template: fileWidgetTemplate,
+    });
+});

--- a/coral/media/js/views/components/workflows/heritage-asset-designation-workflow/ha-summary.js
+++ b/coral/media/js/views/components/workflows/heritage-asset-designation-workflow/ha-summary.js
@@ -40,8 +40,8 @@ define([
       },
       monumentType: {
         label: 'Monument Type',
-        nodegroupId: '8b94df3e-233f-11ef-89fe-0242ac1a0006',
-        renderNodeIds: [{nodeId: '8b94df3e-233f-11ef-89fe-0242ac1a0006', label: 'Type'}]
+        nodegroupId: 'aca05d09-b52d-4ee7-ab17-f31134131a1c',
+        renderNodeIds: [{nodeId: 'abf06e3f-1044-4e28-86de-724726adce4c', label: 'Type'}]
       },
       historicalPeriod: {
         label: 'Historical Period',

--- a/coral/media/js/views/components/workflows/risk-assessment-workflow/get-ha-details.js
+++ b/coral/media/js/views/components/workflows/risk-assessment-workflow/get-ha-details.js
@@ -40,7 +40,9 @@ define([
       this.RECOMMENDED_DESIGNATION_NODE = "74ef37e0-37b5-11ef-9263-0242ac150006"
       this.SCHEDULED_MONUMENT_CONCEPT = "40462188-3aa9-cdaf-8b1d-3ed8dfa57df9"
 
-      this.MONUMENT_TYPE_NODEGROUP = "0b5b3430-233f-11ef-89fe-0242ac1a0006";
+      // Switched out for Heritage Asset Type node under constrcution phases nodegroup
+      // Monument Type seems to be a duplicate node 
+      this.MONUMENT_TYPE_NODEGROUP = "77e90834-efdc-11eb-b2b9-a87eeabdefba";
       
       this.haRefStrings = {
         '158e1ed2-3aae-11ef-a2d0-0242ac120003': 'SMR Number',

--- a/coral/media/js/views/components/workflows/risk-assessment-workflow/get-ha-smc-details.js
+++ b/coral/media/js/views/components/workflows/risk-assessment-workflow/get-ha-smc-details.js
@@ -36,7 +36,9 @@ define([
 
         this.COUNCIL = "447973ce-d7e2-11ee-a4a1-0242ac120006";
 
-        this.MONUMENT_TYPE_NODEGROUP = "0b5b3430-233f-11ef-89fe-0242ac1a0006";
+        // Switched out for Heritage Asset Type node under constrcution phases nodegroup
+        // Monument Type seems to be a duplicate node 
+        this.MONUMENT_TYPE_NODEGROUP = "77e90834-efdc-11eb-b2b9-a87eeabdefba";
 
         this.haRefStrings = {
             "158e1ed2-3aae-11ef-a2d0-0242ac120003": "SMR Number",

--- a/coral/plugins/add-building-workflow.json
+++ b/coral/plugins/add-building-workflow.json
@@ -126,6 +126,7 @@
                 }
               },
                 "tilesManaged": "many",
+                "manyTitle": "Citations",
                 "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"
               },

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -134,6 +134,7 @@
                     }
                 }
                 },
+                "manyTitle": "Citations",
                 "tilesManaged": "many",
                 "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"

--- a/coral/plugins/add-ihr-workflow.json
+++ b/coral/plugins/add-ihr-workflow.json
@@ -131,6 +131,7 @@
                     }
                 }
                 },
+                "manyTitle": "Citations",
                 "tilesManaged": "many",
                 "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -153,6 +153,7 @@
                     }
                 }
                 },
+                "manyTitle": "Citations",
                 "tilesManaged": "many",
                 "componentName": "default-card",
                 "uniqueInstanceName": "e0da378f-ea20-44d7-8d8a-05b46f8d54c0"

--- a/coral/plugins/heritage-asset-designation-workflow.json
+++ b/coral/plugins/heritage-asset-designation-workflow.json
@@ -225,6 +225,7 @@
                     }
                   }
                 },
+                "manyTitle": "Designation Descriptions",
                 "tilesManaged": "many",
                 "componentName": "default-card",
                 "uniqueInstanceName": "4ae2af75-3829-4633-9b69-618f89691195"

--- a/coral/plugins/issue-report-workflow.json
+++ b/coral/plugins/issue-report-workflow.json
@@ -148,7 +148,12 @@
                   "resourceid": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['resourceInstanceId']",
                   "parenttileid": "['initial-step-step']['d96cc87e-6de5-4b33-90db-ea324af7a66d'][0]['resourceid']['issueReport']",
                   "nodegroupid": "52f3230c-0051-4ff1-b0bb-eca887b1fba4",
-                  "semanticName": "CM References"
+                  "semanticName": "CM References",
+                  "nodeOptions": {
+                    "52f3230c-0051-4ff1-b0bb-eca887b1fba4": {
+                      "disabled": true
+                    }
+                  }
                 },
                 "tilesManaged": "one",
                 "componentName": "default-card",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -24,7 +24,7 @@ except ImportError:
     pass
 
 APP_NAME = 'coral'
-APP_VERSION = semantic_version.Version(major=7, minor=15, patch=52)
+APP_VERSION = semantic_version.Version(major=7, minor=15, patch=53)
 
 TIME_ZONE = "Europe/London"
 USE_TZ = True

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -243,7 +243,7 @@ CONTENT_SECURITY_POLICY = {
     "DIRECTIVES": {
         "default-src": [NONE],
         "script-src": [SELF, "'unsafe-inline'", "'unsafe-eval'", "cdnjs.cloudflare.com", "api.mapbox.com", "events.mapbox.com", "mo.ev.openindustry.in", "storage.googleapis.com"],
-        "img-src": [SELF, "blob:", "data:"],
+        "img-src": [SELF, "blob:", "data:", "mo.ev.openindustry.in"],
         "font-src": [SELF, "blob:", "cdnjs.cloudflare.com", "fonts.gstatic.com", "fonts.googleapis.com"],
         "style-src": [SELF, "'unsafe-inline'", "cdnjs.cloudflare.com", "fonts.googleapis.com", "api.mapbox.com"],
         "connect-src": [SELF, "cdnjs.cloudflare.com", "api.mapbox.com", "events.mapbox.com", "mo.ev.openindustry.in", "storage.googleapis.com"],

--- a/coral/templates/views/components/widgets/file.htm
+++ b/coral/templates/views/components/widgets/file.htm
@@ -1,0 +1,291 @@
+{% extends "views/components/widgets/base.htm" %}
+{% load template_tags %}
+{% load i18n %}
+
+{% block form %}
+<div class="row widget-wrapper" data-bind="class: nodeCssClasses">
+    <div class="form-group">
+        <span class="control-label widget-input-label" for="" data-bind="text:label"></span>
+        <!-- ko if: node -->
+        <i data-bind="css: {'ion-asterisk widget-label-required': node.isrequired}"></i>
+        <!-- /ko -->
+        <div class="col-xs-12 dropzone" data-bind="dropzone: dropzoneOptions">
+            <div class="file-select-window" data-bind="visible: filesJSON().length === 0">
+                <div class="bord-top pad-ver file-select">
+                    <div style="padding: 5px">
+                        <div class="file-select-h2 h2">
+                            <span data-bind="text: $root.translations.uploadDocuments"></span>
+                        </div>
+                        <div class="card-component-panel-h3 h3">
+                            <span data-bind="text: $root.translations.dragAndDropFilesOnPanel"></span>
+                        </div>
+                    </div>
+                    <button type="button" class="btn btn-lg btn-file-select fileinput-button dz-clickable" data-bind="css: uniqueidClass, disable: disabled">
+                        <i class="fa fa-file"></i>
+                        <span data-bind="text: $root.translations.selectFiles"></span>
+                    </button>
+                    <br>
+                    <div style="padding: 10px">
+                        <span data-bind="text: $root.translations.addingDocumentsOptional"></span>
+                        <br>
+                        <span data-bind="text: $root.translations.maxFileSizeWarning"></span>
+                        <span data-bind="text: maxFilesize() + 'MB.'"></span>
+                    </div>
+
+                    <!-- <div class="btn-group pull-right">
+                        <button id="dz-remove-btn" class="btn btn-danger cancel" type="reset" data-bind="click: reset">
+                            <i class="ion ion-close"></i>
+                        </button>
+                    </div> -->
+                </div>
+                <div class="file-upload-footer">
+                    <span>
+                        <span data-bind="text: $root.translations.allowedDocumentFormats"></span>
+                        <span data-bind="text: (acceptedFiles() || $root.translations.any) + '. '"></span>
+                    </span>
+                </div>
+            </div>
+            <div data-bind="visible: filesJSON().length > 0">
+                <!-- note that data-bind=visible must be in place (instead of ko if:) as DZ instantiates only once;
+                    elements with its class name must exist at time of init -->
+                <div class="card-component-panel-h4 h4">
+                    <span data-bind="text: $root.translations.uploadedFiles"></span>
+                </div>
+                <div class="file-upload-options">
+                    <div class="file-upload-options-grow list-filter">
+                    <!--ko if: filesJSON().length > 1-->
+
+                        <input
+                            data-bind="
+                                attr: {placeholder: $root.translations.findAFile + '...', 'aria-label': $root.translations.findAFile},
+                                textInput: filter
+                            "
+                            type="text"
+                            class="file-upload-filter"
+                        >
+                        <!-- Clear Search -->
+                        <span tabindex="0" aria-label="{% trans "Clear filter" %}" class="clear-node-search" data-bind="onEnterkeyClick, onSpaceClick, visible: filter().length > 0, click: function() { filter(''); }"><i class="fa fa-times-circle"></i></span>
+                        <!-- /ko -->
+
+                        <div style="margin-top: 7px;">
+                            <!-- ko if: filter() -->
+                            <span style="margin:0 35px;" data-bind="text: filteredList().length +' '+ $root.translations.outOf +' '+ filesJSON().length +' '+ $root.translations.filesMatchFilter"></span>
+                            <!-- /ko -->
+                            <!-- ko if: (!filter() || filter() == "") -->
+                            <span style="margin:0 5px;" data-bind="text: filesJSON().length +' '+ $root.translations.filesUploaded"></span>
+                            <!-- /ko -->
+                        </div>
+                    </div>
+                    <div >
+                        <button type="button" class="btn btn-file-upload-reset dropzone fileinput-button dz-clickable" data-bind="css: uniqueidClass">
+                            <span data-bind="text: $root.translations.addMoreFiles"></span>
+                        </button>
+                        <button type="button" class="btn btn-file-upload-reset dropzone fileinput-button dz-clickable" data-bind="click: reset">
+                            <span data-bind="text: $root.translations.deleteAllFiles"></span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="dz-previews" data-bind="css: uniqueidClass">
+                <!-- ko foreach: pagedList(filter() ? filteredList() : filesJSON()) -->
+                <div class="file-upload-card">
+                    <div class="media-body">
+                        <div class="media-block">
+                            <div class="media-left">
+                                <span><i class="fa fa-file fa-lg"></i></span>
+                            </div>
+                            <div class="media-body file-upload-card-detail">
+                                <div class="media-left">
+                                    <span class="text-main mar-no text-overflow" data-bind="text: name"></span>
+                                    <!-- ko if: $data.error -->
+                                    <span class="dz-error text-danger text-sm" data-bind="text: $root.translations.error"></span>
+                                    <!-- /ko -->
+                                    <span class="text-sm">
+                                        <a data-bind="attr: {href: ko.unwrap(url) ? $parent.getFileUrl(url) : content, download: name, 'aria-label': ($root.translations.download).concat(' ', name)}, click: () => $parent.downloadFile(url, name), clickBubble: false">
+                                            <span data-bind="text: ko.unwrap(url) ? $root.translations.download : $root.translations.unsaved"></span>
+                                        </a>
+                                    </span>
+                                </div>
+                                <div class="file-upload-card-detail-right">
+                                    <div class="media-right" data-bind="click: $parent.removeFile">
+                                        <button class="btn btn-xs btn-danger btn-file-cancel" data-bind="attr: {'aria-label': ($root.translations.delete).concat(' ', name)}"><i class="ion ion-close"></i></button>
+                                    </div>
+                                    <div class="file-size-label">
+                                        <span class="text-sm" data-bind="html: $parent.formatSize($data)"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    {% block file-metadata %}
+                    <div class="row">
+                        <div class="file-metadata">
+                            <label data-bind="text: $root.translations.alternativeText"></label>
+                            <a href="#" data-toggle="tooltip" data-bind="attr: {title: $root.translations.altTextHelp}">
+                                <i class="fa fa-question-circle" aria-hidden="true" style="padding-left: 3px;"></i>
+                            </a>
+                            <input
+                                type="text"
+                                class="form-control"
+                                data-bind="textInput: $data.altText[$parent.activeLanguage].value, attr: {'aria-label': $root.translations.alternativeText}"
+                            />
+                        </div>
+                    </div>
+                    <div class="row"
+                        data-toggle="collapse"
+                        style="cursor: pointer"
+                        data-bind="attr: {'data-target': '.file-metadata-additional-' + $parent.unique_id + $index()},
+                            click: $parent.toggleDropdown($index())"
+                    >
+                        <div class="file-metadata">
+                            <i class="fa" aria-hidden="true" data-bind="class: $parent.metadataDrawerCollapsedStatus()[$index()] ? 'fa-chevron-right' : 'fa-chevron-down'"></i>
+                            <span data-bind="text: $root.translations.additionalMetadata"></span>
+                        </div>
+                    </div>
+                    <div class="row collapse" data-bind="class: 'file-metadata-additional-' + $parent.unique_id + $index()">
+                        <div class="file-metadata col-sm-6">
+                            <label data-bind="text: $root.translations.title"></label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                data-bind="textInput: $data.title[$parent.activeLanguage].value, attr: {'aria-label': $root.translations.title}"
+                            />
+                        </div>
+                        <div class="file-metadata col-sm-6">
+                            <label data-bind="text: $root.translations.attribution"></label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                data-bind="textInput: $data.attribution[$parent.activeLanguage].value, attr: {'aria-label': $root.translations.attribution}"
+                            />
+                        </div>
+                        <div class="file-metadata">
+                            <label data-bind="text: $root.translations.description"></label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                data-bind="textInput: $data.description[$parent.activeLanguage].value, attr: {'aria-label': $root.translations.description}"
+                                style="resize: vertical;"
+                            />
+                        </div>
+                    </div>
+                    {% endblock file-metadata %}
+                </div>
+                <!-- /ko -->
+            </div>
+            <div data-bind="style: {visibility: pageCtReached()}">
+                <select type="button" class="btn btn-file-upload-limit" data-bind="value: pageCt" aria-label="{% trans 'Number of Files Shown' %}">
+                    <option value="5" data-bind="text: $root.translations.showFirstFiveFiles"></option>
+                    <option value="10" data-bind="text: $root.translations.showFirstTenFiles"></option>
+                    <option value="25" data-bind="text: $root.translations.showFirstTwentyFiveFiles"></option>
+                    <option value="100" data-bind="text: $root.translations.showAllFiles"></option>
+                </select>
+            </div>
+        </div>
+    </div>
+</div>
+
+<template id="file-widget-dz-preview"><span></span></template>
+{% endblock form %}
+
+{% block config_form %}
+<div class="control-label">
+    <span data-bind="text: node.config.imagesOnly
+        ? $root.translations.acceptedFileTypesImagesOnly : $root.translations.acceptedFileTypes"></span>
+</div>
+<div class="col-xs-12 pad-no crud-widget-container">
+    <input
+        class="form-control input-md widget-input"
+        data-bind="
+            attr: {placeholder: node.config.imagesOnly
+                ? $root.translations.exampleImageTypes : $root.translations.exampleFileTypes,
+            'aria-label': node.config.imagesOnly
+                ? $root.translations.acceptedFileTypesImagesOnly : $root.translations.acceptedFileTypes},
+            textInput: acceptedFiles
+        "
+    >
+</div>
+
+<div class="control-label">
+    <span data-bind="text: $root.translations.maxFileSize"></span>
+</div>
+<div class="col-xs-12 pad-no crud-widget-container">
+    <input
+        type="number"
+        class="form-control input-md widget-input"
+        data-bind="
+            attr: {placeholder: $root.translations.maxFileSize, 'aria-label': $root.translations.maxFileSize},
+            value: maxFilesize
+        "
+    >
+</div>
+
+{% endblock config_form %}
+
+{% block report %}
+
+<!-- ko if: uploadedFiles().length === 0 -->
+<dt data-bind="text: label"></dt>
+<dd data-bind="class: nodeCssClasses">
+    <span data-bind="text: $root.translations.none"></span>
+</dd>
+<!-- /ko -->
+
+<!-- ko foreach: reportFiles() -->
+<dt class="first" data-bind="text: $parent.label, class: $parent.nodeCssClasses"></dt>
+<dd class="first" data-bind="class: $parent.nodeCssClasses" style="border-top: 1px lightgray; border-top-style: solid;"></dt>
+    <a data-bind="attr: {href: $parent.getFileUrl(url)}" target="_blank">
+        <i class="ion ion-forward"></i>
+        <span data-bind="text: name"></span>
+        <img class="img-responsive" data-bind="attr: {src:$parent.getFileUrl(url)+'?thumbnail=true',
+            alt: $data.altText[$parent.activeLanguage].value ?? name}">
+    </a>
+    <button class="btn btn-download" data-bind="click: function() { $parent.downloadFile(url, name) }">
+        <i class="fa fa-download"></i> Download
+    </button>
+</dd>
+<!-- ko if: title[$parent.activeLanguage].value -->
+<dt data-bind="text: $root.translations.title"></dt>
+<dd data-bind="text: title[$parent.activeLanguage].value"></dd>
+<!-- /ko -->
+<!-- ko if: attribution[$parent.activeLanguage].value -->
+<dt data-bind="text: $root.translations.attribution"></dt>
+<dd data-bind="text: attribution[$parent.activeLanguage].value"></dd>
+<!-- /ko -->
+<!-- ko if: description[$parent.activeLanguage].value -->
+<dt data-bind="text: $root.translations.description"></dt>
+<dd data-bind="text: description[$parent.activeLanguage].value"></dd>
+<!-- /ko -->
+<!-- /ko -->
+
+<!-- ko foreach: reportImages() -->
+<dt class="first" data-bind="text: $parent.label, class: $parent.nodeCssClasses"></dt>
+<dd class="first" data-bind="class: $parent.nodeCssClasses">
+    <div class="rp-image-grid-item">
+        <a target="_blank" data-bind="attr: {href: $parent.getFileUrl(url)}">
+            <img class="img-responsive" data-bind="attr: {src:$parent.getFileUrl(url)+'?thumbnail=true',
+            alt: $data.altText[$parent.activeLanguage].value ?? name}">
+        </a>
+        <button class="btn btn-download" data-bind="click: function() { $parent.downloadFile(url, name) }">
+            <i class="fa fa-download"></i> Download
+        </button>
+    </div>
+</dd>
+<!-- ko if: title[$parent.activeLanguage].value -->
+<dt data-bind="text: $root.translations.title"></dt>
+<dd data-bind="text: title[$parent.activeLanguage].value"></dd>
+<!-- /ko -->
+<!-- ko if: attribution[$parent.activeLanguage].value -->
+<dt data-bind="text: $root.translations.attribution"></dt>
+<dd data-bind="text: attribution[$parent.activeLanguage].value"></dd>
+<!-- /ko -->
+<!-- ko if: description[$parent.activeLanguage].value -->
+<dt data-bind="text: $root.translations.description"></dt>
+<dd data-bind="text: description[$parent.activeLanguage].value"></dd>
+<!-- /ko -->
+<!-- /ko -->
+{% endblock report %}
+
+{% block display_value %}
+<span data-bind="text: Number.isInteger(displayValue()) ? displayValue() + $root.translations.filesUploaded : displayValue(), class: nodeCssClasses"></span>
+{% endblock display_value %}


### PR DESCRIPTION
### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [x] Features Added
- [x] Bug Fix

### Proposed Changes
- Added a download button to the report page to allow for the file to be downloaded
- Updated CSP to allow for the thumbnail image to be viewed in the report
- Create a custom file.js and file.htm to make these changes
- Create a separate download function to fetch the blob of the file
- Changed the uploader download button to always download the file
- Update the context if function to work correctly
- Update the many tile titles for all HA workflows
- Update the many tile titles for HA Designation
- Update the many tile titles for Licensing
- Added key listener check for enter key and if detected action e.preventDefault
- Switched Monument type node in get-ha-details comp for HA type node
- Switched Monument type node in get-ha-smc-details comp for HA type node

## Pull Requests

**Fix/3138 File Uploader Files**
[782](https://github.com/flaxandteal/coral-arches/pull/782) by @StuCM

**Fix: Context Update Statement**
[779](https://github.com/flaxandteal/coral-arches/pull/779) by @StuCM

**fix: disable cm ref node in issue report workflow**
[783](https://github.com/flaxandteal/coral-arches/pull/783) by @StuCM

**fix: updated many select labels**
[780](https://github.com/flaxandteal/coral-arches/pull/780) by @babou212

**fix: no longer refreshing wf when enter key pressed in text boxes**
[785](https://github.com/flaxandteal/coral-arches/pull/785) by @babou212

**fix: switched monument type node for HA type node**
[784](https://github.com/flaxandteal/coral-arches/pull/784) by @babou212

