### PR TITLE
fix: pin django toolbar to version 5.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerabilit
 sqlparse>=0.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 PyMuPDF
+django-debug-toolbar==5.2.0


### PR DESCRIPTION
## Description
An update to the Django Debug Toolbar was causing a crash in the build. This pins the toolbar version to 5.2.0 which was the last working instance
