### PR TITLE
fix: designation type now displays in info tab

### DIFF
--- a/coral/media/js/views/components/workflows/fmw-workflow/get-selected-monument-details.js
+++ b/coral/media/js/views/components/workflows/fmw-workflow/get-selected-monument-details.js
@@ -17,7 +17,7 @@ define([
     this.SMR_NUMBER_NODE = '158e1ed2-3aae-11ef-a2d0-0242ac120003';
 
     this.DESIGNATIONS_NODEGROUP = '6af2a0cb-efc5-11eb-8436-a87eeabdefba';
-    this.DESIGNATIONS_TYPE_NODE = '6af2a0ce-efc5-11eb-88d1-a87eeabdefba';
+    this.DESIGNATIONS_TYPE_NODE = '74ef37e0-37b5-11ef-9263-0242ac150006';
 
     this.MONUMENT_NAMES_NODEGROUP = '676d47f9-9c1c-11ea-9aa0-f875a44e0e11';
     this.MONUMENT_NAMES_NODE = '676d47ff-9c1c-11ea-b07f-f875a44e0e11';
@@ -193,6 +193,8 @@ define([
         }
       }
       await Promise.all(additionalPromises);
+
+      console.log('designation type ', designationType());
         
     this.cards({...this.cards(), [resourceId]: {
               designationType : designationType(),


### PR DESCRIPTION
# PR - Fix designation type not displaying in info panel

## Description of the Issue
This pr will fix the designation type not displaying in info panel

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/3088
---

## Changes Proposed
- Update the get-selected-monument-details js comp with the correct designation type node id

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make webpack
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
