### PR TITLE
fix: hidden undo button from add ha wf finish steps

### DIFF
--- a/coral/plugins/add-building-workflow.json
+++ b/coral/plugins/add-building-workflow.json
@@ -427,7 +427,8 @@
             ]
           }
         ],
-        "workflowstepclass": "workflow-form-component"
+        "workflowstepclass": "workflow-form-component",
+        "hiddenWorkflowButtons": ["undo"]
       }
     ],
     "initWorkflow": {

--- a/coral/plugins/add-garden-workflow.json
+++ b/coral/plugins/add-garden-workflow.json
@@ -416,7 +416,8 @@
             ]
           }
         ],
-        "workflowstepclass": "workflow-form-component"
+        "workflowstepclass": "workflow-form-component",
+        "hiddenWorkflowButtons": ["undo"]
       }
     ],
     "initWorkflow": {

--- a/coral/plugins/add-ihr-workflow.json
+++ b/coral/plugins/add-ihr-workflow.json
@@ -458,7 +458,7 @@
           }
         ],
         "workflowstepclass": "workflow-form-component",
-        "hiddenWorkflowButtons": []
+        "hiddenWorkflowButtons": ["undo"]
       }
     ],
     "initWorkflow": {

--- a/coral/plugins/add-monument-workflow.json
+++ b/coral/plugins/add-monument-workflow.json
@@ -499,7 +499,8 @@
             ]
           }
         ],
-        "workflowstepclass": "workflow-form-component"
+        "workflowstepclass": "workflow-form-component",
+        "hiddenWorkflowButtons": ["undo"]
       }
     ],
     "initWorkflow": {


### PR DESCRIPTION
# PR -hide undo button from add ha wf finish steps

## Description of the Issue
Undo button can cause tile validation errors if used in the finish step in add ha workflows so this pr hides that button from the user

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/2673
---

## Changes Proposed
- Hide undo button from the user in the finish step of add HA workflows

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
make manage CMD="coral reload"
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
