### PR TITLE
fix: full report now showing on first tab for archive source

### DIFF
--- a/coral/media/js/views/components/reports/archive-source.js
+++ b/coral/media/js/views/components/reports/archive-source.js
@@ -19,12 +19,12 @@ define([
 
             Object.assign(self, reportUtils);
             self.sections = [
+                {id: 'all', title: 'Full Report'},
                 {id: 'name', title: 'Names and Identifiers'},
                 {id: 'description', title: 'Descriptions and Citations'},
                 {id: 'images', title: 'Images'},
                 {id: 'archive', title: 'Archive Holding'},
                 {id: 'resources', title: 'Associated Resources'},
-                {id: 'all', title: 'Full Report'},
                 {id: 'json', title: 'JSON'},
             ];
             self.reportMetadata = ko.observable(params.report?.report_json);

--- a/coral/templates/views/components/reports/archive-source.htm
+++ b/coral/templates/views/components/reports/archive-source.htm
@@ -26,6 +26,15 @@
     </div>
     <div class="aher-tabbed-report">
         <div class="aher-tabbed-report-content">
+             <!-- All Tab -->
+            <div class="aher-report-page" data-bind="if: activeSection() === 'all'">
+                <div data-bind="component: {
+                    name: 'views/components/reports/scenes/all',
+                    params: {
+                        report: $data.report
+                    }
+                }"></div>
+            </div>
             <!-- Names Tab -->
             <div class="aher-report-page" data-bind="if: activeSection() === 'name'">
                 <div data-bind="component: {
@@ -119,15 +128,6 @@
                         data: resource,
                         cards: resourcesCards,
                         dataConfig: resourceDataConfig
-                    }
-                }"></div>
-            </div>
-            <!-- All Tab -->
-            <div class="aher-report-page" data-bind="if: activeSection() === 'all'">
-                <div data-bind="component: {
-                    name: 'views/components/reports/scenes/all',
-                    params: {
-                        report: $data.report
                     }
                 }"></div>
             </div>


### PR DESCRIPTION
# PR - Full report should show on first tab for archive source report 

## Description of the Issue
This pr will make sure that the full report is displayed on the first tab in the archive source report

**Related Task:** [Link to task/issue]
https://tree.taiga.io/project/viktoriabon-coral-phase-2/issue/3049
---

## Changes Proposed
- Changed the index for tab items in the archive source report js comp
- Changed the HTM order for full report 

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [x] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
