### PR TITLE
chore: remove duplicate csp import from settings.py

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -16,7 +16,6 @@ import semantic_version
 from django.utils.translation import gettext_lazy as _
 from datetime import datetime, timedelta
 from csp.constants import SELF, NONE
-from csp.constants import SELF, NONE, NONCE
 
 try:
     from arches.settings import *


### PR DESCRIPTION
# PR - remove duplicate csp import from settings.py

## Description of the Issue
removes duplicate csp import from settings.py

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- remove duplicate csp import from settings.py

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

---

### Model Changes
- (Add details here if this change type is checked)

---

### Added Functions
- (Add details here if this change type is checked)

---

### Added Concepts
- (Add details here if this change type is checked)

---

### Workflows Updated
- (Add details here if this change type is checked)

---

### Reports Updated
- (Add details here if this change type is checked)

---

### Added/Updated Dependencies
- (Add details here if this change type is checked)

---

### Features Added
- (Add details here if this change type is checked)

---

### Bug Fix
- (Add details here if this change type is checked)

---

## Commands
```
# Add any commands that should be run to test these changes
```

## Tests
- [Describe the tests you've added or run]
- [Include steps to verify the changes]

---

## Additional Notes
[Any additional information that might be helpful]
