### PR TITLE
fix(workflow): dispose initial-step subscriptions to prevent leak

### DIFF
--- a/coral/media/js/views/components/workflows/workflow-builder-initial-step.js
+++ b/coral/media/js/views/components/workflows/workflow-builder-initial-step.js
@@ -13,7 +13,7 @@ function viewModel(params) {
 
   _.extend(self, params.form);
   self.parentTiles = ko.observable(params.form.savedData()?.parentTiles || {});
-  self.tile().dirty.subscribe(function (val) {
+  const dirtySubscription = self.tile().dirty.subscribe(function (val) {
     self.dirty(val);
   });
   self.params = params
@@ -36,13 +36,25 @@ function viewModel(params) {
     });
   };
 
+  let widgetsSubscription;
   const card = params.form.card();
   if (card) {
     applyWidgetCustomisations(card.widgets());
     if (ko.isObservable(card.widgets)) {
-      card.widgets.subscribe(applyWidgetCustomisations);
+      widgetsSubscription = card.widgets.subscribe(applyWidgetCustomisations);
     }
   }
+
+  let disposed = false;
+  this.dispose = function () {
+    if (disposed) return;
+    disposed = true;
+    dirtySubscription.dispose();
+    if (widgetsSubscription) {
+      widgetsSubscription.dispose();
+    }
+  };
+
   params.form.save = async () => {
     const txnId = uuid.generate();
     try {


### PR DESCRIPTION
## Summary
- Capture and dispose the `tile.dirty` and `card.widgets` knockout subscriptions in `workflow-builder-initial-step`'s viewModel so they're released when the component is removed.
- Knockout invokes `viewModel.dispose()` automatically on component teardown; the new `dispose` is idempotent and tolerant of subscriptions that were never created (when no `card` is present).
- Prevents accumulation of dangling subscriptions across workflow step transitions that was slowing workflow step loading.

## Test plan
- [ ] Open a workflow that mounts/unmounts initial-step components repeatedly and confirm step load time stays consistent.
- [ ] Verify hidden nodes and label customisations still apply correctly on initial-step render.
- [ ] Confirm `tile.dirty` -> `form.dirty` propagation still works while the component is active.

Generated with Claude Code