### PR TITLE
perf(open_workflow): prefetch tile relations, move state to instance, drop debug print

### DIFF
--- a/coral/views/open_workflow.py
+++ b/coral/views/open_workflow.py
@@ -11,21 +11,26 @@ logger = logging.getLogger(__name__)
 
 
 class OpenWorkflow(View):
-    workflow_step_data = {}
-    workflow_component_data = {}
-    step_mapping = []
-    step_config = []
-    grouped_tiles = {}
-    nodes = {}
-    nodegroups = {}
     setup_workflows = {
         "licensing-workflow": "setup_licensing_workflow",
         "hb-planning-consultation-response-workflow": "setup_planning_consultation",
         "hm-planning-consultation-response-workflow": "setup_planning_consultation",
         "heritage-asset-designation-workflow": "setup_designation",
     }
-    workflow_slug = None
-    resource_id = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.workflow_step_data = {}
+        self.workflow_component_data = {}
+        self.step_mapping = []
+        self.step_config = []
+        self.grouped_tiles = {}
+        self.nodes = {}
+        self.nodegroups = {}
+        self.additional_saved_values = {}
+        self.open_config = {}
+        self.workflow_slug = None
+        self.resource_id = None
 
     def get_plugin(self, plugin_slug):
         plugin = None
@@ -350,20 +355,6 @@ class OpenWorkflow(View):
         )
 
     def post(self, request):
-        # For some reason I need to reset the class defaults every time
-        # a request is sent. It will persist the data and add it onto the
-        # next workflow generation?
-        self.workflow_step_data = {}
-        self.workflow_component_data = {}
-        self.step_mapping = []
-        self.step_config = []
-        self.grouped_tiles = {}
-        self.additional_saved_values = {}
-        self.open_config = {}
-        self.nodes = {}
-        self.nodegroups = {}
-        self.resource_id = None
-
         data = json.loads(request.body.decode("utf-8"))
         step_config = data.get("stepConfig")
         self.resource_id = data.get("resourceId")
@@ -383,7 +374,7 @@ class OpenWorkflow(View):
         # Get all the resources tiles
 
         self.resource = self.get_resource(self.resource_id)
-        resource_tiles = Tile.objects.filter(resourceinstance=self.resource)
+        resource_tiles = Tile.objects.filter(resourceinstance=self.resource).prefetch_related('nodegroup', 'parenttile', 'parenttile__nodegroup', 'resourceinstance')
 
         # Loop through tiles and add them to the component data lookup
 
@@ -456,7 +447,6 @@ class OpenWorkflow(View):
                 # if the cardinality allows for multiple how do we
                 # decide which tile is the one that should be displayed
                 tile = tiles[0]
-                print('tile before into comp data: ', tile)
                 component_data = {
                     "nodegroupId": nodegroup_id,
                     "resourceInstanceId": self.resource_id,


### PR DESCRIPTION
## Summary
- Adds `prefetch_related('nodegroup', 'parenttile', 'parenttile__nodegroup', 'resourceinstance')` to the resource tile query in `OpenWorkflow.post()` to eliminate the N+1 ORM round-trips during the "many tiles" serialisation loop (lines accessing `tile.nodegroup.nodegroupid`, `tile.parenttile.tileid`, `tile.parenttile.nodegroup.nodegroupid` via `group_tiles`, and `tile.resourceinstance.resourceinstanceid` per tile).
- Converts mutable class-level state (`workflow_step_data`, `workflow_component_data`, `step_mapping`, `step_config`, `grouped_tiles`, `nodes`, `nodegroups`, `additional_saved_values`, `open_config`, `workflow_slug`, `resource_id`) into instance state via a new `__init__`. The immutable `setup_workflows` config dict remains a class attribute. This fixes the latent concurrency race that the prior author noted in the inline comment ("For some reason I need to reset the class defaults every time a request is sent. It will persist the data and add it onto the next workflow generation?") at the top of `post()` — that workaround is no longer needed and has been removed.
- Removes a stray `print('tile before into comp data: ', tile)` debug line left over from development.

User-visible impact: faster workflow open/advance, especially on resources with many tiles, and removal of cross-request state bleed.

Note: the optional `get_or_create` batching in `setup_licensing_workflow` / `setup_designation` was not pursued — those would need substantial refactoring (different `resourceinstance` targets and conditional creation logic) and were deferred per scope guidance.

## Test plan
- [ ] Open a workflow on a resource with many tiles and verify it loads faster than before
- [ ] Open multiple workflows in succession and confirm no state leaks between requests
- [ ] Advance and back through workflow steps to confirm component data is still rendered correctly
- [ ] Smoke-test the licensing, planning consultation, and heritage asset designation workflows (the `setup_workflows` paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)