### PR TITLE
perf(workflow): parallel fetches, pure computeds, dispose subs, drop reload on save

### DIFF
--- a/coral/media/js/views/components/workflows/workflow-component-abstract.js
+++ b/coral/media/js/views/components/workflows/workflow-component-abstract.js
@@ -88,12 +88,12 @@ function TileBasedComponent() {
         });
     };
 
-    this.initialize = function() {
+    this.initialize = async function() {
         if (self.componentData.tilesManaged === "one") {
             self.tile.subscribe(function(tile) {
                 if (!self.tiles()) {
                     self.tiles([tile]);
-                } 
+                }
             });
 
             self.tiles.subscribe(function(tiles) {
@@ -109,135 +109,142 @@ function TileBasedComponent() {
             });
         }
 
-        $.getJSON(( arches.urls.api_card + this.getCardResourceIdOrGraphId() ), function(data) {
-            var handlers = {
-                'after-update': [],
-                'tile-reset': []
-            };
-            var displayname = ko.observable(data.displayname);
-            var createLookup = function(list, idKey) {
-                return _.reduce(list, function(lookup, item) {
-                    lookup[item[idKey]] = item;
-                    return lookup;
-                }, {});
-            };
-
-            self.reviewer = data.userisreviewer;
-            self.provisionalTileViewModel = new ProvisionalTileViewModel({
-                tile: self.tile,
-                reviewer: data.userisreviewer
-            });
-
-            var graphModel = new GraphModel({
-                data: {
-                    nodes: data.nodes,
-                    nodegroups: data.nodegroups,
-                    edges: []
-                },
-                datatypes: data.datatypes
-            });
-
-            self.graphModel = graphModel;
-
-            self.topCards = _.filter(data.cards, function(card) {
-                var nodegroup = _.find(data.nodegroups, function(group) {
-                    return group.nodegroupid === card.nodegroup_id;
-                });
-                return !nodegroup || !nodegroup.parentnodegroup_id;
-            }).map(function(card) {
-                self.componentData.parameters.nodegroupid = self.componentData.parameters.nodegroupid || card.nodegroup_id;
-                return new CardViewModel({
-                    card: card,
-                    graphModel: graphModel,
-                    tile: null,
-                    resourceId: self.resourceId,
-                    displayname: displayname,
-                    handlers: handlers,
-                    cards: data.cards,
-                    tiles: data.tiles,
-                    provisionalTileViewModel: self.provisionalTileViewModel,
-                    cardwidgets: data.cardwidgets,
-                    userisreviewer: data.userisreviewer,
-                    loading: self.loading
-                });
-            });
-
-            var applyHiddenNodes = function(card) {
-                var hiddenNodes = self.componentData.parameters.hiddenNodes;
-                if (!card || !hiddenNodes) return;
-                var widgets = ko.unwrap(card.widgets);
-                if (!widgets) return;
-                widgets.forEach(function(widget) {
-                    if (hiddenNodes.indexOf(widget.node_id()) > -1) {
-                        widget.visible(false);
-                    }
-                });
-            };
-
-            self.card.subscribe(function(card) {
-                applyHiddenNodes(card);
-                /* Re-apply when widgets array mutates — parseNodes runs again
-                   on a throttled nodes subscription and can push widgets in
-                   after the initial hide pass. */
-                if (card && ko.isObservable(card.widgets)) {
-                    card.widgets.subscribe(function() {
-                        applyHiddenNodes(card);
-                    });
-                }
-            });
-
-            self.topCards.forEach(function(topCard) {
-                topCard.topCards = self.topCards;
-            });
-
-            self.widgetLookup = createLookup(
-                data.widgets,
-                'widgetid'
-            );
-            self.cardComponentLookup = createLookup(
-                data['card_components'],
-                'componentid'
-            );
-            self.nodeLookup = createLookup(
-                graphModel.get('nodes')(),
-                'nodeid'
-            );
-            self.on = function(eventName, handler) {
-                if (handlers[eventName]) {
-                    handlers[eventName].push(handler);
-                }
-            };
-
-            self.flattenTree(self.topCards, []).forEach(function(item) {
-                if (item.constructor.name === 'CardViewModel' && item.nodegroupid === ko.unwrap(self.componentData.parameters.nodegroupid)) {
-                    if (ko.unwrap(self.componentData.parameters.parenttileid) && item.parent && ko.unwrap(self.componentData.parameters.parenttileid) !== item.parent.tileid) {
-                        return;
-                    }
-                    if (self.customCardLabel) item.model.name(ko.unwrap(self.customCardLabel));
-                    self.card(item);
-                    if (ko.unwrap(self.componentData.parameters.tileid)) {
-                        ko.unwrap(item.tiles).forEach(function(tile) {
-                            if (tile.tileid === ko.unwrap(self.componentData.parameters.tileid)) {
-                                self.tile(tile);
-                            }
-                        });
-                    } else if (ko.unwrap(self.componentData.parameters.createTile) !== false) {
-                        self.tile(item.getNewTile());
-                    }
-                }
-            });
-
-            self.componentData.parameters.card = self.card();
-            self.componentData.parameters.tile = self.tile();
-            self.componentData.parameters.loading = self.loading;
-            self.componentData.parameters.provisionalTileViewModel = self.provisionalTileViewModel;
-            self.componentData.parameters.reviewer = data.userisreviewer;
-            self.componentData.parameters.dirty = self.dirty;
-            self.componentData.parameters.save = self.save;
-            self.componentData.parameters.tiles = self.tiles;
-
-            self.loading(false);
+        var data = await new Promise(function(resolve) {
+            $.getJSON(arches.urls.api_card + self.getCardResourceIdOrGraphId(), resolve);
         });
+
+        var handlers = {
+            'after-update': [],
+            'tile-reset': []
+        };
+        var displayname = ko.observable(data.displayname);
+        var createLookup = function(list, idKey) {
+            return _.reduce(list, function(lookup, item) {
+                lookup[item[idKey]] = item;
+                return lookup;
+            }, {});
+        };
+
+        self.reviewer = data.userisreviewer;
+        self.provisionalTileViewModel = new ProvisionalTileViewModel({
+            tile: self.tile,
+            reviewer: data.userisreviewer
+        });
+
+        var graphModel = new GraphModel({
+            data: {
+                nodes: data.nodes,
+                nodegroups: data.nodegroups,
+                edges: []
+            },
+            datatypes: data.datatypes
+        });
+
+        self.graphModel = graphModel;
+
+        self.topCards = _.filter(data.cards, function(card) {
+            var nodegroup = _.find(data.nodegroups, function(group) {
+                return group.nodegroupid === card.nodegroup_id;
+            });
+            return !nodegroup || !nodegroup.parentnodegroup_id;
+        }).map(function(card) {
+            self.componentData.parameters.nodegroupid = self.componentData.parameters.nodegroupid || card.nodegroup_id;
+            return new CardViewModel({
+                card: card,
+                graphModel: graphModel,
+                tile: null,
+                resourceId: self.resourceId,
+                displayname: displayname,
+                handlers: handlers,
+                cards: data.cards,
+                tiles: data.tiles,
+                provisionalTileViewModel: self.provisionalTileViewModel,
+                cardwidgets: data.cardwidgets,
+                userisreviewer: data.userisreviewer,
+                loading: self.loading
+            });
+        });
+
+        var applyHiddenNodes = function(card) {
+            var hiddenNodes = self.componentData.parameters.hiddenNodes;
+            if (!card || !hiddenNodes) return;
+            var widgets = ko.unwrap(card.widgets);
+            if (!widgets) return;
+            widgets.forEach(function(widget) {
+                if (hiddenNodes.indexOf(widget.node_id()) > -1) {
+                    widget.visible(false);
+                }
+            });
+        };
+
+        var widgetsSub = null;
+        self.card.subscribe(function(card) {
+            if (widgetsSub) {
+                widgetsSub.dispose();
+                widgetsSub = null;
+            }
+            applyHiddenNodes(card);
+            /* Re-apply when widgets array mutates — parseNodes runs again
+               on a throttled nodes subscription and can push widgets in
+               after the initial hide pass. */
+            if (card && ko.isObservable(card.widgets)) {
+                widgetsSub = card.widgets.subscribe(function() {
+                    applyHiddenNodes(card);
+                });
+            }
+        });
+
+        self.topCards.forEach(function(topCard) {
+            topCard.topCards = self.topCards;
+        });
+
+        self.widgetLookup = createLookup(
+            data.widgets,
+            'widgetid'
+        );
+        self.cardComponentLookup = createLookup(
+            data['card_components'],
+            'componentid'
+        );
+        self.nodeLookup = createLookup(
+            graphModel.get('nodes')(),
+            'nodeid'
+        );
+        self.on = function(eventName, handler) {
+            if (handlers[eventName]) {
+                handlers[eventName].push(handler);
+            }
+        };
+
+        self.flattenTree(self.topCards, []).forEach(function(item) {
+            if (item.constructor.name === 'CardViewModel' && item.nodegroupid === ko.unwrap(self.componentData.parameters.nodegroupid)) {
+                if (ko.unwrap(self.componentData.parameters.parenttileid) && item.parent && ko.unwrap(self.componentData.parameters.parenttileid) !== item.parent.tileid) {
+                    return;
+                }
+                if (self.customCardLabel) item.model.name(ko.unwrap(self.customCardLabel));
+                self.card(item);
+                if (ko.unwrap(self.componentData.parameters.tileid)) {
+                    ko.unwrap(item.tiles).forEach(function(tile) {
+                        if (tile.tileid === ko.unwrap(self.componentData.parameters.tileid)) {
+                            self.tile(tile);
+                        }
+                    });
+                } else if (ko.unwrap(self.componentData.parameters.createTile) !== false) {
+                    self.tile(item.getNewTile());
+                }
+            }
+        });
+
+        self.componentData.parameters.card = self.card();
+        self.componentData.parameters.tile = self.tile();
+        self.componentData.parameters.loading = self.loading;
+        self.componentData.parameters.provisionalTileViewModel = self.provisionalTileViewModel;
+        self.componentData.parameters.reviewer = data.userisreviewer;
+        self.componentData.parameters.dirty = self.dirty;
+        self.componentData.parameters.save = self.save;
+        self.componentData.parameters.tiles = self.tiles;
+
+        self.loading(false);
     };
 
     this.onSaveSuccess = function(savedData) {  // LEGACY -- DO NOT USE
@@ -297,88 +304,87 @@ function AbstractCardAdapter() {  // CURRENTLY IN DEVLEOPMENT, USE AT YOUR OWN R
     var self = this;
     this.cardinality = ko.observable();
 
-    this.initialize = function() {
+    this.initialize = async function() {
         self.loading(true);
 
-        $.getJSON(( arches.urls.api_nodegroup(self.componentData.parameters['nodegroupid']) ), function(nodegroupData) {
-            self.cardinality(nodegroupData.cardinality);
+        var nodegroupId = self.componentData.parameters['nodegroupid'];
+        var resourceInstanceId = self.componentData.parameters['resourceid'];
 
-            const resourceInstanceDataPromise = new Promise(function(resolve, _reject) {
-                const resourceInstanceId = self.componentData.parameters['resourceid'];
-
-                if (resourceInstanceId) {
-                    $.getJSON(
-                        ( arches.urls.resource + `/${resourceInstanceId}/tiles?nodeid=${self.componentData.parameters['nodegroupid']}`),
-                        function(data) {
-                            resolve(data);
-                        }
-                    );
-                }
-                else {
-                    resolve(null);
-                }
-            });
-
-            resourceInstanceDataPromise.then( function(data) {
-                if (self.cardinality() === '1') {
-                    if (data && data['tiles'].length) {
-                        self.componentData.parameters['tileid'] = data['tiles'][0]['tileid'];
-                        self.complete(true);
-                    }
-                    TileBasedComponent.apply(self);
-                }
-                else if (self.cardinality() === 'n') {
-                    MultipleTileBasedComponent.apply(self);
-                    if (data && data['tiles'].length) {
-                        self.complete(true);
-                    }
-
-                    self.card.subscribe(function(card) {
-                        if (!card.selected()) {
-                            card.selected(card.tiles().length);
-                        }
-                    });
-
-                    self.onSaveSuccess = function(savedData) {  // LEGACY -- DO NOT USE
-                        if (!(savedData instanceof Array)) { savedData = [savedData]; }
-
-                        let previouslySavedData = self.savedData();
-                        if (!previouslySavedData) {
-                            previouslySavedData = [];
-                        }
-
-                        self.savedData(
-                            previouslySavedData.concat(
-                                savedData.map(function(savedDatum) {
-                                    return {
-                                        tileData: savedDatum._tileData(),
-                                        tileId: savedDatum.tileid,
-                                        nodegroupId: savedDatum.nodegroup_id,
-                                        resourceInstanceId: savedDatum.resourceinstance_id,
-                                    };
-                                })
-                            )
-                        );
-
-                        self.value(self.savedData());
-
-                        self.componentData.parameters.dirty(false);
-                        self.card().getNewTile(true);  // `true` is forceNewTile
-                        self.card().selected(true);
-                        self.dirty(false);
-                        self.saving(false);
-                        self.complete(true);
-
-                        /**
-                         * TODO: this is a hack to get around previous data autofilling forms when creating a new tile in cardinality n cards
-                         * It should be removed when we're able to figure out how to prevent that logic
-                         * */ 
-                        window.location.reload();  
-                    };
-                }
-            });
-
+        var nodegroupDataPromise = new Promise(function(resolve) {
+            $.getJSON(arches.urls.api_nodegroup(nodegroupId), resolve);
         });
+
+        var resourceInstanceDataPromise = new Promise(function(resolve) {
+            if (resourceInstanceId) {
+                $.getJSON(
+                    arches.urls.resource + `/${resourceInstanceId}/tiles?nodeid=${nodegroupId}`,
+                    resolve
+                );
+            }
+            else {
+                resolve(null);
+            }
+        });
+
+        var [nodegroupData, data] = await Promise.all([nodegroupDataPromise, resourceInstanceDataPromise]);
+
+        self.cardinality(nodegroupData.cardinality);
+
+        if (self.cardinality() === '1') {
+            if (data && data['tiles'].length) {
+                self.componentData.parameters['tileid'] = data['tiles'][0]['tileid'];
+                self.complete(true);
+            }
+            TileBasedComponent.apply(self);
+        }
+        else if (self.cardinality() === 'n') {
+            MultipleTileBasedComponent.apply(self);
+            if (data && data['tiles'].length) {
+                self.complete(true);
+            }
+
+            self.card.subscribe(function(card) {
+                if (!card.selected()) {
+                    card.selected(card.tiles().length);
+                }
+            });
+
+            self.onSaveSuccess = function(savedData) {  // LEGACY -- DO NOT USE
+                if (!(savedData instanceof Array)) { savedData = [savedData]; }
+
+                let previouslySavedData = self.savedData();
+                if (!previouslySavedData) {
+                    previouslySavedData = [];
+                }
+
+                self.savedData(
+                    previouslySavedData.concat(
+                        savedData.map(function(savedDatum) {
+                            return {
+                                tileData: savedDatum._tileData(),
+                                tileId: savedDatum.tileid,
+                                nodegroupId: savedDatum.nodegroup_id,
+                                resourceInstanceId: savedDatum.resourceinstance_id,
+                            };
+                        })
+                    )
+                );
+
+                self.value(self.savedData());
+
+                self.componentData.parameters.dirty(false);
+                self.card().selected(true);
+                self.dirty(false);
+                self.saving(false);
+                self.complete(true);
+
+                /* Reset local state so the next add starts on a clean tile
+                   without prefilled values (replaces previous full-page reload). */
+                self.tile(self.card().getNewTile(true));
+                self.previouslyPersistedComponentData = undefined;
+                self.tiles([]);
+            };
+        }
     };
 
     this.initialize();
@@ -394,12 +400,12 @@ function MultipleTileBasedComponent(title) {
 
     this.itemName = ko.observable(ko.unwrap(title) ? ko.unwrap(title) : 'Items');
 
-    this.hasDirtyTiles = ko.computed(function() {
+    this.hasDirtyTiles = ko.pureComputed(function() {
         var tiles = self.tiles();
         var hasDirtyTiles = false;
 
-        if (!tiles) { 
-            hasDirtyTiles = true; 
+        if (!tiles) {
+            hasDirtyTiles = true;
         }
         else if (self.savedData() ) {
             if (self.savedData().length !== tiles.length) {
@@ -440,8 +446,12 @@ function MultipleTileBasedComponent(title) {
                 }
             });
         }
-        self.multiTileUpdated(hasDirtyTiles);
         return hasDirtyTiles;
+    });
+
+    self.multiTileUpdated(this.hasDirtyTiles());
+    this.hasDirtyTiles.subscribe(function(val) {
+        self.multiTileUpdated(val);
     });
 
     this.initialize = function() {
@@ -753,7 +763,7 @@ function WorkflowComponentAbstract(params) {
     });
 
     this.multiTileUpdated = ko.observable();
-    this.hasUnsavedData = ko.computed(function() {
+    this.hasUnsavedData = ko.pureComputed(function() {
         var hasUnsavedData = false;
 
         if (self.componentData.tilesManaged === "many") {


### PR DESCRIPTION
## Summary

Targets `coral/media/js/views/components/workflows/workflow-component-abstract.js` to speed up workflow step loading, stop subscription leaks across step transitions, and replace a full-page reload on save with explicit local state reset.

User-visible improvement: workflow steps render measurably faster (one fewer round-trip-serialised fetch per `card` step) and saving a cardinality-n tile no longer triggers a hard page reload.

## Changes (four, audited individually)

### 1. Parallelise initial fetches

- `AbstractCardAdapter.initialize` previously fired `api_nodegroup`, then inside the callback fired `resource/<id>/tiles`, serialising two network calls that have no data dependency on each other. Both fetches are now wrapped as promises and awaited together with `Promise.all([...])`.
- `TileBasedComponent.initialize` is now `async` with the `api_card` `$.getJSON` converted to an awaited promise. This flattens the previous deeply nested callback (the function body shifted left by one indent level) and lets future fetches be added to a `Promise.all` cleanly.
- All side effects from the original callbacks (graph model construction, top-card hydration, parameter wiring, `self.loading(false)`) are preserved verbatim in their original order — just hoisted out of the callback into the post-`await` block.

### 2. `pure: true` on dirty-check computeds

- `hasDirtyTiles` is now `ko.pureComputed`. The previous trailing `self.multiTileUpdated(hasDirtyTiles)` side effect is moved to an explicit `hasDirtyTiles.subscribe(...)` immediately after the computed is defined. The current value is also pushed via `self.multiTileUpdated(hasDirtyTiles())` once at construction so the initial state matches the prior behaviour (knockout subscriptions do not deliver an initial value).
- `hasUnsavedData` is now `ko.pureComputed` (it had no side effects, just observable reads).

Pure computeds suspend evaluation when they have no subscribers; both are subscribed (internally via the new `multiTileUpdated` subscriber, or externally from `workflow-step.js` and `workflow.htm`), so they remain awake in the cases that matter and skip work otherwise.

### 3. Dispose nested subscriptions

- In `TileBasedComponent.initialize`, `self.card.subscribe` creates `card.widgets.subscribe` inside its body. The widgets-subscribe handle is now captured in a closure-scoped `widgetsSub` and disposed before the next one is created when `self.card` changes. Previously, switching cards leaked one widgets-subscribe per change.
- The two self-disposing subscribes in `MultipleTileBasedComponent.initialize` (`multiTileInitSubscription`, `multiTilePersistedDataSubscription`) and the self-disposing `savingSubscription` were already correct and are unchanged.

### 4. Remove `window.location.reload()` on cardinality-n save

In `AbstractCardAdapter.onSaveSuccess`:

- Removed `window.location.reload();` and its TODO comment.
- Replaced with explicit local state reset, mirroring the new-tile pattern already used at `MultipleTileBasedComponent` line ~470 / `addOrUpdateTile`:
  ```
  self.tile(self.card().getNewTile(true));
  self.previouslyPersistedComponentData = undefined;
  self.tiles([]);
  ```
- The pre-existing `self.card().getNewTile(true);` call that discarded its return value has been removed in favour of the assignment to `self.tile`.

**Reviewer note: please manually test this path.** The original `location.reload()` was put in as a hack to prevent prefilled form data after saving an additional tile in a cardinality-n card. If the reset is incomplete, autofill will reappear in the editor after adding the first tile. Suggested smoke test: open a workflow step backed by a cardinality-n card, add a tile, save it, then start adding the next tile — the editor should be empty.

## Test plan

- [ ] Smoke test workflow steps that use `TileBasedComponent` (cardinality 1 or `tilesManaged: "one"`): step still loads, data still loads, hidden nodes still hidden after `card.widgets` mutates.
- [ ] Smoke test workflow steps that use `MultipleTileBasedComponent` (`tilesManaged: "many"`): add/remove tiles, save, reload step — saved tiles still appear; dirty-state-driven UI (e.g. save button enable) still toggles correctly.
- [ ] **Smoke test `AbstractCardAdapter` cardinality-n path: add tile, save, immediately start adding next tile — verify no prefilled values from the previously saved tile appear in the editor.**
- [ ] Verify hidden-nodes behaviour from fb90ff38 still works after switching `self.card` to a different card (widgetsSub now disposes between switches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)