### PR TITLE
perf(workflow): lazy-load step component modules

### DIFF
--- a/coral/media/js/views/components/plugins/workflow-builder-loader.js
+++ b/coral/media/js/views/components/plugins/workflow-builder-loader.js
@@ -2,43 +2,133 @@ import ko from 'knockout';
 import arches from 'arches';
 import OpenableWorkflow from 'viewmodels/openable-workflow';
 import workflowTemplate from 'templates/views/components/plugins/default-workflow.htm';
-import defaultCardUtil from 'views/components/workflows/default-card-util';
-import workflowBuilderInitialStep from 'views/components/workflows/workflow-builder-initial-step';
-import showHierarchyChange from 'views/components/workflows/assign-consultation-workflow/show-hierarchy-change';
-import enforcementSummaryStep from 'views/components/workflows/enforcement-workflow/enforcement-summary-step';
-import relatedDocumentUpload from 'views/components/workflows/related-document-upload';
-import fileTemplate from 'views/components/workflows/file-template';
-import getSelectedMonumentDetails from 'views/components/workflows/fmw-workflow/get-selected-monument-details';
-import getSelectedLicenceDetails from 'views/components/workflows/excavation-site-visit-workflow/get-selected-licence-details';
-import calculateCompositeScore from 'views/components/workflows/fmw-workflow/calculate-composite-score';
-import generateHaNumber from 'views/components/workflows/generate-ha-number';
-import generateSmrNumber from 'views/components/workflows/generate-smr-number';
-import generateGardenNumber from 'views/components/workflows/generate-garden-number';
-import generateHbNumber from 'views/components/workflows/generate-hb-number';
-import haSummary from 'views/components/workflows/heritage-asset-designation-workflow/ha-summary';
-import approvalSummary from 'views/components/workflows/heritage-asset-designation-workflow/approval-summary';
-import startRemapAndMerge from 'views/components/workflows/heritage-asset-designation-workflow/start-remap-and-merge';
-import pcSummary from 'views/components/workflows/assign-consultation-workflow/pc-summary';
-import relatedHeritageAssetMap from 'views/components/workflows/assign-consultation-workflow/related-heritage-asset-map';
-import fetchLatestTile from 'views/components/workflows/fetch-latest-tile';
-import showNodes from 'views/components/workflows/show-nodes';
-import updateDates from 'views/components/workflows/update-dates';
-import generateAfcNumber from 'views/components/workflows/agriculture-and-forestry-consultation-workflow/generate-afc-number';
-import updateDeadline from 'views/components/workflows/update-deadline';
-import generateAilNumber from 'views/components/workflows/daera-workflow/generate-ail-number';
-import getSelectedMonumentDetailsWithCount from 'views/components/workflows/get-selected-monument-details-with-count';
-import getHaDetails from 'views/components/workflows/risk-assessment-workflow/get-ha-details';
-import getHaSmcDetails from 'views/components/workflows/risk-assessment-workflow/get-ha-smc-details';
-import getCalculatedRisk from 'views/components/workflows/risk-assessment-workflow/get-calculated-risk';
+
+/*
+ * Eagerly load components required by every workflow:
+ *   - workflow-builder-initial-step renders the first step of every workflow
+ *   - default-card-util backs the common "default-card-util" componentName
+ *     used by most stepConfig layouts
+ * Loading these lazily would force a chunk fetch on the critical path of
+ * opening any workflow, defeating the perf gain from splitting the rest.
+ */
+import 'views/components/workflows/default-card-util';
+import 'views/components/workflows/workflow-builder-initial-step';
+
+/*
+ * Lazy step-component loaders. Each entry is a function returning the
+ * webpack dynamic import() for the module whose side-effect is
+ * ko.components.register('<key>', ...). Components are loaded on demand
+ * when a workflow's stepConfig references them, so opening a workflow no
+ * longer pays the cost of parsing/registering every step component in
+ * the project.
+ *
+ * IMPORTANT: webpack only code-splits dynamic import() calls whose
+ * specifier is a literal string. Keep these inline — do not refactor
+ * the paths into variables.
+ */
+const lazyStepComponentLoaders = {
+  'show-hierarchy-change': () =>
+    import('views/components/workflows/assign-consultation-workflow/show-hierarchy-change'),
+  'enforcement-summary-step': () =>
+    import('views/components/workflows/enforcement-workflow/enforcement-summary-step'),
+  'related-document-upload': () =>
+    import('views/components/workflows/related-document-upload'),
+  'file-template': () => import('views/components/workflows/file-template'),
+  'get-selected-monument-details': () =>
+    import('views/components/workflows/fmw-workflow/get-selected-monument-details'),
+  'get-selected-licence-details': () =>
+    import('views/components/workflows/excavation-site-visit-workflow/get-selected-licence-details'),
+  'calculate-composite-score': () =>
+    import('views/components/workflows/fmw-workflow/calculate-composite-score'),
+  'generate-ha-number': () => import('views/components/workflows/generate-ha-number'),
+  'generate-smr-number': () => import('views/components/workflows/generate-smr-number'),
+  'generate-garden-number': () => import('views/components/workflows/generate-garden-number'),
+  'generate-hb-number': () => import('views/components/workflows/generate-hb-number'),
+  'ha-summary': () =>
+    import('views/components/workflows/heritage-asset-designation-workflow/ha-summary'),
+  'approval-summary': () =>
+    import('views/components/workflows/heritage-asset-designation-workflow/approval-summary'),
+  'start-remap-and-merge': () =>
+    import('views/components/workflows/heritage-asset-designation-workflow/start-remap-and-merge'),
+  'pc-summary': () =>
+    import('views/components/workflows/assign-consultation-workflow/pc-summary'),
+  'related-heritage-asset-map': () =>
+    import('views/components/workflows/assign-consultation-workflow/related-heritage-asset-map'),
+  'fetch-latest-tile': () => import('views/components/workflows/fetch-latest-tile'),
+  'show-nodes': () => import('views/components/workflows/show-nodes'),
+  'update-dates': () => import('views/components/workflows/update-dates'),
+  'generate-afc-number': () =>
+    import('views/components/workflows/agriculture-and-forestry-consultation-workflow/generate-afc-number'),
+  'update-deadline': () => import('views/components/workflows/update-deadline'),
+  'generate-ail-number': () =>
+    import('views/components/workflows/daera-workflow/generate-ail-number'),
+  'get-selected-monument-details-with-count': () =>
+    import('views/components/workflows/get-selected-monument-details-with-count'),
+  'get-ha-details': () =>
+    import('views/components/workflows/risk-assessment-workflow/get-ha-details'),
+  'get-ha-smc-details': () =>
+    import('views/components/workflows/risk-assessment-workflow/get-ha-smc-details'),
+  'get-calculated-risk': () =>
+    import('views/components/workflows/risk-assessment-workflow/get-calculated-risk'),
+};
+
+/*
+ * Walks a stepConfig array, returning the unique set of componentName
+ * values used across every layoutSection / componentConfig. Defensive:
+ * stepConfig may be undefined or arrive as nested observables in some
+ * code paths.
+ */
+const collectStepComponentNames = (stepConfig) => {
+  const names = new Set();
+  const steps = ko.unwrap(stepConfig);
+  if (!Array.isArray(steps)) return names;
+  steps.forEach((step) => {
+    const sections = ko.unwrap(step?.layoutSections);
+    if (!Array.isArray(sections)) return;
+    sections.forEach((section) => {
+      const configs = ko.unwrap(section?.componentConfigs);
+      if (!Array.isArray(configs)) return;
+      configs.forEach((config) => {
+        const name = ko.unwrap(config?.componentName);
+        if (name) names.add(name);
+      });
+    });
+  });
+  return names;
+};
+
+const preloadStepComponents = (stepConfig) => {
+  const imports = Array.from(collectStepComponentNames(stepConfig))
+    .map((name) => lazyStepComponentLoaders[name]?.())
+    .filter(Boolean);
+  return Promise.all(imports);
+};
 
 export default ko.components.register('workflow-builder-loader', {
-    viewModel: function (params) {
-      this.componentName = params.plugin.slug;
+  viewModel: function (params) {
+    this.componentName = params.plugin.slug;
 
-      this.stepConfig = params.stepConfig;
+    this.stepConfig = params.stepConfig;
 
-      OpenableWorkflow.apply(this, [params]);
-      this.quitUrl = arches.urls.plugin('init-workflow');
-    },
-    template: workflowTemplate
-  });
+    OpenableWorkflow.apply(this, [params]);
+
+    /*
+     * Gate workflow history resolution on the dynamic step-component
+     * imports for this workflow. updateStepPath() awaits this method
+     * before instantiating any step, and the workflow template hides
+     * activeStep until that completes, so step components are
+     * guaranteed to be ko.components.register-ed before binding.
+     */
+    const originalGetWorkflowHistoryData = this.getWorkflowHistoryData.bind(this);
+    this.getWorkflowHistoryData = async function (key) {
+      const [history] = await Promise.all([
+        originalGetWorkflowHistoryData(key),
+        preloadStepComponents(this.stepConfig),
+      ]);
+      return history;
+    };
+
+    this.quitUrl = arches.urls.plugin('init-workflow');
+  },
+  template: workflowTemplate
+});


### PR DESCRIPTION
## Summary
- Converts `workflow-builder-loader` from 26 eager `import` registrations to webpack dynamic `import()`s keyed off the `componentName` values in the current workflow's `stepConfig`.
- Workflow open paths now parse and `ko.components.register` only the step components the workflow actually uses, instead of every step component in the project.
- `default-card-util` and `workflow-builder-initial-step` remain eagerly imported because every workflow renders them on first paint — making them lazy would force a chunk fetch on the critical path.

## Lazy-loading strategy
Strategy: **dynamic `import()` keyed off `stepConfig`** (fallback option from the task brief).

KO's `{ viewModel: { require: '...' } }` lazy syntax was not used because it relies on a RequireJS/AMD loader; this project bundles with webpack 5 against pure ES6 modules now.

The viewModel walks `params.stepConfig.layoutSections[].componentConfigs[].componentName` and triggers a `Promise.all` of the matching dynamic `import()`s. The preload runs in parallel with the existing `getWorkflowHistoryData` fetch (by wrapping the inherited method from `OpenableWorkflow`), and the workflow template already gates rendering behind `<!-- ko if: ko.unwrap(activeStep) -->`. `activeStep` is only set after `updateStepPath()` awaits `getWorkflowHistoryData()`, so step components are guaranteed registered before KO tries to bind them.

## Components still eagerly imported
- `default-card-util` (used by most workflows on the first step)
- `workflow-builder-initial-step` (the first step of every workflow)

## Components moved to lazy `import()`
All 26 step components previously imported at the top of `workflow-builder-loader.js`:
`show-hierarchy-change`, `enforcement-summary-step`, `related-document-upload`, `file-template`, `get-selected-monument-details`, `get-selected-licence-details`, `calculate-composite-score`, `generate-ha-number`, `generate-smr-number`, `generate-garden-number`, `generate-hb-number`, `ha-summary`, `approval-summary`, `start-remap-and-merge`, `pc-summary`, `related-heritage-asset-map`, `fetch-latest-tile`, `show-nodes`, `update-dates`, `generate-afc-number`, `update-deadline`, `generate-ail-number`, `get-selected-monument-details-with-count`, `get-ha-details`, `get-ha-smc-details`, `get-calculated-risk`.

Each is mapped 1:1 by the `ko.components.register('<name>', ...)` call inside the corresponding module — verified by `grep`ing the registration in every file before writing the map. Any `componentName` not in the map silently passes through (handled by whichever module registers it elsewhere, matching pre-existing behaviour).

## Risk
This is the highest-risk unit of the perf work — a missed registration would render a workflow step blank. The fix takes the conservative path:
- Eager imports for the two universally-needed components.
- All other lazy imports preload in parallel and `await` before `getWorkflowHistoryData` resolves, so binding cannot race the registration.
- Webpack literal-string `import()` constraint respected (no path interpolation).

## Test plan
- [ ] Open one workflow per stepConfig-using plugin (add-ihr, add-garden, hb-planning-consultation, scheduled-monument-consent, excavation-site-visit, respond-to-enforcement, heritage-asset-designation, risk-assessment, daera, agriculture-and-forestry-consultation, assign-consultation, evaluation-meeting, fmw) and confirm every step renders.
- [ ] Verify network tab shows lazy chunks fetched only for components referenced in the opened workflow.
- [ ] Confirm `default-card-util` and `workflow-builder-initial-step` are not separate chunk requests (they remain in the main bundle).
- [ ] Save / progress / back through at least one workflow to confirm step rebinding still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)