### PR TITLE
Fix/500 error for dashboards global group

### DIFF
--- a/coral/views/dashboards/dashboard_register.py
+++ b/coral/views/dashboards/dashboard_register.py
@@ -36,6 +36,7 @@ STRATEGY_MAP = {
     # Excavation Groups
     EXCAVATION_ADMIN_GROUP: ('excavation_dashboard', ExcavationTaskStrategy),
     EXCAVATION_USER_GROUP: ('excavation_dashboard', ExcavationTaskStrategy),
+    EXCAVATION_CUR_D: ('excavation_dashboard', ExcavationTaskStrategy),
     EXCAVATION_CUR_E: ('excavation_dashboard', ExcavationTaskStrategy),
     # Records and Designation Groups
     SECOND_SURVEY_GROUP_USER: ('designation_dashboard', DesignationTaskStrategy),
@@ -52,8 +53,10 @@ STRATEGY_MAP = {
 def get_strategy(groupId):
     config = STRATEGY_MAP.get(groupId)
 
-    if config:
-        name, strategy_class = config
+    if not config:
+        return None
+
+    name, strategy_class = config
     return {
         'name': name,
         'strategy': strategy_class()


### PR DESCRIPTION
# PR - Fix 500 error for dashboards global group

## Description of the Issue
Users belonging to a group not present in `STRATEGY_MAP` (e.g. a general/global group) triggered a 500 error instead of a graceful "no strategy" response. `get_strategy()` only assigned `name` and `strategy_class` inside an `if config:` block, but the `return` statement referencing those variables sat outside the block, so when `config` was `None` the function raised an `UnboundLocalError`. Separately, the `EXCAVATION_CUR_D` group was defined as a constant but never wired into `STRATEGY_MAP`, so users in that group had no matching dashboard strategy. Also that caused infinite loading.

**Related Task:** N/A

---

## Changes Proposed
- Added `EXCAVATION_CUR_D` to `STRATEGY_MAP`, mapping it to `('excavation_dashboard', ExcavationTaskStrategy)` so members of that group are routed to the excavation dashboard like `EXCAVATION_CUR_E` and the other excavation groups.
- Refactored `get_strategy()` to return `None` immediately when no config is found for the given group ID, instead of falling through to a `return` statement that referenced unassigned variables.

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [x] Bug Fix

---

### Bug Fix
- Fixed a 500 error (`UnboundLocalError`) in `get_strategy()` in `coral/views/dashboards/dashboard_register.py` when a user's group had no entry in `STRATEGY_MAP`. The function now returns `None` cleanly, which is already handled by the caller in `coral/views/dashboard.py`.
- Fixed missing dashboard access for the `EXCAVATION_CUR_D` group by adding it to `STRATEGY_MAP`.

---

## Commands
