### PR TITLE
Fix: Arches Version Update 8.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags: [ 'v*.*.*-RELEASE' ]
 env:
-  ARCHES_BASE: ghcr.io/flaxandteal/arches-base:coral-7.6
+  ARCHES_BASE: ghcr.io/flaxandteal/arches-base:v8.2.0a4-v4
   ARCHES_PROJECT: coral
 jobs:
   Build-Arches:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docker"]
 	path = docker
 	url = https://github.com/flaxandteal/arches-container-toolkit
-	branch = coral/fix-8.1-static
+	branch = arches/8.1

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ TOOLKIT_REPO = https://github.com/flaxandteal/arches-container-toolkit
 TOOLKIT_FOLDER = docker
 TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= coral
-ARCHES_BASE = ghcr.io/flaxandteal/arches-base:docker-8.1.0-release
+ARCHES_BASE = ghcr.io/flaxandteal/arches-base:v8.2.0a4-v4
 ARCHES_PROJECT_ROOT = $(shell pwd)/
-DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker compose --profile api -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
+DOCKER_COMPOSE_COMMAND =ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
 CMD ?=
 
 create: docker

--- a/README.md
+++ b/README.md
@@ -163,6 +163,43 @@ Initializes the permission table, it allows all of the users within the system t
 make manage CMD="print_permissions_table"
 ```
 
+## Updating Arches Versions
+
+If updating the arches version there are several places to update the version number to ensure arches is synced locally and in the build.
+
+### Local
+You need to update the Make file within the project, not in the docker submodule
+
+`ARCHES_BASE = ghcr.io/flaxandteal/arches-base:v8.2.0a4-v4`
+
+This line can be changed to use the appropriate base image.
+
+The base images are created by Flax and Teal and use an arches base version with additional patches applied to work with our container set up.
+
+Changing this ensures when `make build` is ran, the correct base image is used to build arches
+
+### pyproject.toml
+The `pyproject.toml` also needs to be updated so that you are pinned to the exact version needed
+
+```
+dependencies = [
+    "arches>=8.1.0,<=8.2.0a4"
+]
+```
+
+This can be set to a range or an exact version.
+Here we have pinned to an upper limit that matches our base image. If this is set higher, on a build the latest version will be pulled and may not match our base image.
+
+This step is important, we do not want to drift from the base image version. This will not be immediately apparent as arches will still run.
+
+### Github Action
+The final place to update is within the github actions. These control the builds that are pushed to the environments.
+
+Both `project.yml` and `release.yml` need the `ARCHES_BASE` updated to match the above.
+
+```
+ARCHES_BASE: ghcr.io/flaxandteal/arches-base:v8.2.0a4-v4
+```
 
 ### Contribution 
 

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -193,7 +193,7 @@ LOCALE_PATHS.append(os.path.join(APP_ROOT, 'locale'))
 FILE_TYPE_CHECKING = None
 FILE_TYPES = ["bmp", "gif", "jpg", "jpeg", "pdf", "png", "psd", "rtf", "tif", "tiff", "xlsx", "csv", "zip"]
 FILENAME_GENERATOR = "arches.app.utils.storage_filename_generator.generate_filename"
-UPLOADED_FILES_DIR = "uploadedfiles"
+UPLOADED_FILES_DIR = os.environ.get("UPLOADED_FILES_DIR", "")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '!^1-(*%x1ww9-_qp5qg(+d((3dj!m!w5v^qm#lfkjf*^73_8tf'
@@ -303,6 +303,8 @@ DATABASES = {
 
 SEARCH_THUMBNAILS = False
 
+SAVED_SEARCHES = []
+
 INSTALLED_APPS = (
     "csp",
     "webpack_loader",
@@ -392,6 +394,10 @@ CONTENT_SECURITY_POLICY = {
 }
 
 X_FRAME_OPTIONS = 'DENY'
+
+MAPBOX_API_KEY = os.environ.get("MAPBOX_API_KEY", MAPBOX_API_KEY)
+
+USE_LOCAL_STORAGE = os.environ.get("USE_LOCAL_STORAGE", "False").lower() == "true"
 
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Framework :: Django :: 5.2",
 ]
 dependencies = [
-    "arches>=8.1.0,<8.3.0",
+    "arches>=8.1.0,<=8.2.0a4",
     "arches_controlled_lists",
     "cachetools",
     "django-recaptcha>=4.0.0",


### PR DESCRIPTION
## Description of the Issue
The local build was installing the incorrect version of arches. Several places needed base images updated and dependency versions set.

**Related Task:** N/A

---

## Changes Proposed
- Updated the upper limit of the arches dependency in `pyproject.toml` to v8.2.0a4
- Set the `release.yml` base image to use the latest v8.2.0a4-v4 image
- Updated the make file to use the v8.2.0a4-v4 base image
- Removed the api container from the make file for local builds
- Updated the docker submodule to use the latest arches/8.1 commit
- Set several settings to use environment variables in `settings.py`
- Updated `README.md` with instructions for updating the version

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [x] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix

## Tests
- [ ] Update your docker submodule `git submodule update --remote docker`
- [ ] run `make rebuild-images` to rebuild the images
- [ ] set a `.env` within the docker submodule, set a `MAPBOX_API_KEY` variable with a key
- [ ] run arches `make run`
- [ ] login and go to the search page - check in the sidebar at the bottom the version should be v8.2.0a4
- [ ] The map should also load using your api key

---

## Additional Notes
[Any additional information that might be helpful]
