### PR TITLE
Feat: Migration for Custom Features

### DIFF
--- a/coral/migrations/8013_register_extensions.py
+++ b/coral/migrations/8013_register_extensions.py
@@ -1,0 +1,44 @@
+"""Register coral's extensions from the files in this repo.
+
+These were previously registered by hand (`manage.py widget register -s ...` etc)
+on each environment, so a fresh DB came up missing whatever nobody remembered to
+run. The arches register commands do an upsert when the json/py carries a fixed
+uuid, so this is safe to re-run.
+"""
+
+from pathlib import Path
+
+from django.core.management import call_command
+from django.db import migrations
+
+CORAL = Path(__file__).resolve().parent.parent
+
+# (management command, glob relative to the coral app dir)
+# widgets first: the datatype modules do Widget.objects.get(...) at import time
+EXTENSIONS = [
+    ("widget", "widgets/*.json"),
+    ("datatype", "datatypes/*.py"),
+    ("card_component", "pkg/card_components/*.json"),
+    ("fn", "functions/*.py"),
+    ("report", "reports/*.json"),
+    ("plugin", "plugins/*.json"),
+]
+
+
+def register(apps, schema_editor):
+    for command, pattern in EXTENSIONS:
+        for source in sorted(CORAL.glob(pattern)):
+            if source.name == "__init__.py":
+                continue
+            call_command(command, "register", "--source", str(source))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("coral", "8012_smm_notif_type"),
+    ]
+
+    operations = [
+        migrations.RunPython(register, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Description of the Issue
Not all the functions, widgets, datatypes, components etc. were being imported on a fresh build

---

## Changes Proposed
- Add a migration to that imports the custom features made in the project on a fresh start of the db

### Types of Changes
- [ ] Model Changes
- [ ] Added Functions
- [ ] Added Concepts
- [ ] Workflows Updated
- [ ] Reports Updated
- [ ] Added/Updated Dependencies
- [ ] Features Added
- [ ] Bug Fix
- [x] Other - added migration

---
## Commands
```
make manage CMD="migrate"
```

## Tests
- Run the migration - the migration should pass
- Should have all widgets and datatypes installed

---
