### PR TITLE
fix: chage component lab to vue components

### DIFF
--- a/coral/settings.py
+++ b/coral/settings.py
@@ -352,7 +352,7 @@ INSTALLED_APPS += (
 if DEBUG:
     INSTALLED_APPS = (*INSTALLED_APPS, "debug_toolbar",)
 
-ARCHES_APPLICATIONS = ("arches_modular_reports", "arches_search",)
+ARCHES_APPLICATIONS = ("arches_vue_components", "arches_modular_reports", "arches_search",)
 
 MIDDLEWARE = [
     "django_hosts.middleware.HostsRequestMiddleware",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -318,7 +318,7 @@ INSTALLED_APPS = (
     "django_hosts",
     "arches_controlled_lists",
     "arches_querysets",
-    "arches_component_lab",
+    "arches_vue_components",
     "arches_modular_reports",
     "arches_search",
     "arches",

--- a/coral/settings.py
+++ b/coral/settings.py
@@ -352,7 +352,7 @@ INSTALLED_APPS += (
 if DEBUG:
     INSTALLED_APPS = (*INSTALLED_APPS, "debug_toolbar",)
 
-ARCHES_APPLICATIONS = ("arches_vue_components", "arches_modular_reports", "arches_search",)
+ARCHES_APPLICATIONS = ("arches_modular_reports", "arches_search",)
 
 MIDDLEWARE = [
     "django_hosts.middleware.HostsRequestMiddleware",

--- a/coral/urls.py
+++ b/coral/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
     path('', include(tf_urls)),
     path('', include('arches.urls')),
     path('', include('arches_controlled_lists.urls')),
-    path('', include('arches_component_lab.urls')),
+    path('', include('arches_vue_components.urls')),
     path('', include('arches_modular_reports.urls')),
     path('', include('arches_search.urls')),
     re_path(r'^user$', UserManagerView.as_view(), name="user_profile_manager"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,19 +7,23 @@
             "name": "coral",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
-                "arches": "archesproject/arches#dev/8.1.x",
-                "arches_controlled_lists": "archesproject/arches-controlled-lists#dev/1.1.x",
+                "arches": "archesproject/arches#dev/8.2.x",
+                "arches_controlled_lists": "archesproject/arches-controlled-lists#1.2.0",
+                "arches_modular_reports": "archesproject/arches-modular-reports#2.0.0",
+                "arches_vue_components": "archesproject/arches-vue-components#2.0.2",
                 "ckeditor4": "4.20.2",
                 "cytoscape-elk": "^2.2.0",
                 "datatables.net-rowgroup-dt": "^1.4.1",
                 "docx-preview": "^0.3.5",
                 "jquery-validation": "^1.20.0",
+                "maplibre-gl": "^4.7.1",
                 "native-file-system-adapter": "^3.0.1",
+                "pinia": "^3.0.4",
                 "select-woo": "jadu/selectWoo",
                 "web-worker": "^1.2.0"
             },
             "devDependencies": {
-                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.1.x"
+                "arches-dev-dependencies": "archesproject/arches-dev-dependencies#dev/8.2.x"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2665,6 +2669,38 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@maplibre/maplibre-gl-style-spec": {
+            "version": "20.4.0",
+            "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+            "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
+            "license": "ISC",
+            "dependencies": {
+                "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+                "@mapbox/unitbezier": "^0.0.1",
+                "json-stringify-pretty-compact": "^4.0.0",
+                "minimist": "^1.2.8",
+                "quickselect": "^2.0.0",
+                "rw": "^1.3.3",
+                "tinyqueue": "^3.0.0"
+            },
+            "bin": {
+                "gl-style-format": "dist/gl-style-format.mjs",
+                "gl-style-migrate": "dist/gl-style-migrate.mjs",
+                "gl-style-validate": "dist/gl-style-validate.mjs"
+            }
+        },
+        "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/@mapbox/unitbezier": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+            "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/rw": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+            "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
             "dev": true,
@@ -4565,6 +4601,15 @@
             "version": "7946.0.8",
             "license": "MIT"
         },
+        "node_modules/@types/geojson-vt": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+            "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/geojson": "*"
+            }
+        },
         "node_modules/@types/glob": {
             "version": "7.2.0",
             "license": "MIT",
@@ -4628,6 +4673,23 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/mapbox__point-geometry": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
+            "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/mapbox__vector-tile": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
+            "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/geojson": "*",
+                "@types/mapbox__point-geometry": "*",
+                "@types/pbf": "*"
+            }
+        },
         "node_modules/@types/mime": {
             "version": "1.3.5",
             "dev": true,
@@ -4654,6 +4716,12 @@
         },
         "node_modules/@types/parse5": {
             "version": "5.0.3",
+            "license": "MIT"
+        },
+        "node_modules/@types/pbf": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+            "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
             "license": "MIT"
         },
         "node_modules/@types/qs": {
@@ -4719,6 +4787,15 @@
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
+            }
+        },
+        "node_modules/@types/supercluster": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+            "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/geojson": "*"
             }
         },
         "node_modules/@types/trusted-types": {
@@ -5197,6 +5274,30 @@
         "node_modules/@vue/devtools-api": {
             "version": "6.6.4",
             "license": "MIT"
+        },
+        "node_modules/@vue/devtools-kit": {
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+            "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-shared": "^7.7.10",
+                "birpc": "^2.3.0",
+                "hookable": "^5.5.3",
+                "mitt": "^3.0.1",
+                "perfect-debounce": "^1.0.0",
+                "speakingurl": "^14.0.1",
+                "superjson": "^2.2.2"
+            }
+        },
+        "node_modules/@vue/devtools-shared": {
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+            "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "rfdc": "^1.4.1"
+            }
         },
         "node_modules/@vue/language-core": {
             "version": "2.2.12",
@@ -5796,6 +5897,71 @@
                 "vue-router": "4.4.3"
             }
         },
+        "node_modules/arches_modular_reports": {
+            "resolved": "git+ssh://git@github.com/archesproject/arches-modular-reports.git#e718fd219088a3dc9cba94f1b6ef10a42acc1700",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "arches": "archesproject/arches#dev/7.6.x",
+                "arches-vue-components": "archesproject/arches-vue-components#dev/1.1.x",
+                "es-toolkit": "^1.39.10",
+                "numeral": "^2.0.6"
+            }
+        },
+        "node_modules/arches_vue_components": {
+            "version": "2.0.2",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-vue-components.git#6009f693eaf0a73982e7f1e6ecd4202d46094797",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "@mapbox/geojson-extent": "^1.0.1",
+                "@mapbox/mapbox-gl-draw": "^1.4.3",
+                "@primeuix/themes": "1.0.1",
+                "@primevue/forms": "4.3.9",
+                "@types/geojson": "^7946.0.16",
+                "arches": "archesproject/arches#stable/8.1.3",
+                "dayjs": "^1.11.13",
+                "dompurify": "^3.2.6",
+                "es-toolkit": "^1.44.0",
+                "maplibre-gl": "^4.7.1",
+                "pinia": "^3.0.4",
+                "quill": "2.0.3"
+            }
+        },
+        "node_modules/arches_vue_components/node_modules/@primeuix/styled": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.5.1.tgz",
+            "integrity": "sha512-5Ftw/KSauDPClQ8F2qCyCUF7cIUEY4yLNikf0rKV7Vsb8zGYNK0dahQe7CChaR6M2Kn+NA2DSBSk76ZXqj6Uog==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.5.3"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches_vue_components/node_modules/@primeuix/themes": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.0.1.tgz",
+            "integrity": "sha512-RllttI3oGTZa66UQDCIA2lPnJvO/xqtNpy+0eNql6fIxdS2AUg5n7L81jTZrHNZ+31T5OBzL/SGFCDycmHTz2g==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.5.1"
+            }
+        },
+        "node_modules/arches_vue_components/node_modules/@primeuix/utils": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.5.4.tgz",
+            "integrity": "sha512-8LggV3Jz59pymHQD10e/u63z/GemQ22RBeu2Gb1eJgBYVwn1iOb82LR+daeAc/LxrXCC5pHnftnCmnZO6vInLA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches_vue_components/node_modules/@types/geojson": {
+            "version": "7946.0.16",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+            "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+            "license": "MIT"
+        },
         "node_modules/arches-component-lab": {
             "name": "arches_component_lab",
             "resolved": "git+ssh://git@github.com/archesproject/arches-component-lab.git#16af9137ae219fced68ae2705392a7298fa12fa9",
@@ -5908,6 +6074,86 @@
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
+        },
+        "node_modules/arches-vue-components": {
+            "name": "arches_vue_components",
+            "resolved": "git+ssh://git@github.com/archesproject/arches-vue-components.git#62bf43b2b6ced82da6d83ce8e44e8fa90e9cb4d1",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "@mapbox/geojson-extent": "1.0.1",
+                "@mapbox/mapbox-gl-draw": "1.4.3",
+                "@primeuix/themes": "1.0.1",
+                "@primevue/forms": "4.3.9",
+                "@types/geojson": "7946.0.16",
+                "arches": "archesproject/arches#dev/7.6.x",
+                "dayjs": "1.11.13",
+                "dompurify": "3.2.6",
+                "es-toolkit": "1.44.0",
+                "maplibre-gl": "4.7.1",
+                "pinia": "3.0.4",
+                "quill": "2.0.3"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primeuix/styled": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.5.1.tgz",
+            "integrity": "sha512-5Ftw/KSauDPClQ8F2qCyCUF7cIUEY4yLNikf0rKV7Vsb8zGYNK0dahQe7CChaR6M2Kn+NA2DSBSk76ZXqj6Uog==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/utils": "^0.5.3"
+            },
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primeuix/themes": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@primeuix/themes/-/themes-1.0.1.tgz",
+            "integrity": "sha512-RllttI3oGTZa66UQDCIA2lPnJvO/xqtNpy+0eNql6fIxdS2AUg5n7L81jTZrHNZ+31T5OBzL/SGFCDycmHTz2g==",
+            "license": "MIT",
+            "dependencies": {
+                "@primeuix/styled": "^0.5.1"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@primeuix/utils": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.5.4.tgz",
+            "integrity": "sha512-8LggV3Jz59pymHQD10e/u63z/GemQ22RBeu2Gb1eJgBYVwn1iOb82LR+daeAc/LxrXCC5pHnftnCmnZO6vInLA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.11.0"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/@types/geojson": {
+            "version": "7946.0.16",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+            "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+            "license": "MIT"
+        },
+        "node_modules/arches-vue-components/node_modules/dayjs": {
+            "version": "1.11.13",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+            "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+            "license": "MIT"
+        },
+        "node_modules/arches-vue-components/node_modules/dompurify": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
+        },
+        "node_modules/arches-vue-components/node_modules/es-toolkit": {
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+            "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
         },
         "node_modules/arches/node_modules/ckeditor4": {
             "version": "4.22.1",
@@ -6146,6 +6392,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/birpc": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+            "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/body-parser": {
@@ -6885,6 +7140,21 @@
             "version": "1.0.7",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/copy-anything": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+            "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+            "license": "MIT",
+            "dependencies": {
+                "is-what": "^5.2.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
         },
         "node_modules/core-js": {
             "version": "3.45.1",
@@ -10005,6 +10275,12 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/hookable": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+            "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+            "license": "MIT"
+        },
         "node_modules/hookified": {
             "version": "1.15.1",
             "dev": true,
@@ -10913,6 +11189,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-what": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+            "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/mesqueeb"
+            }
+        },
         "node_modules/is-wsl": {
             "version": "3.1.1",
             "dev": true,
@@ -11268,6 +11556,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/json-stringify-pretty-compact": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+            "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+            "license": "MIT"
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "dev": true,
@@ -11618,6 +11912,151 @@
             "version": "2.0.3",
             "license": "ISC"
         },
+        "node_modules/maplibre-gl": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+            "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@mapbox/geojson-rewind": "^0.5.2",
+                "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+                "@mapbox/point-geometry": "^0.1.0",
+                "@mapbox/tiny-sdf": "^2.0.6",
+                "@mapbox/unitbezier": "^0.0.1",
+                "@mapbox/vector-tile": "^1.3.1",
+                "@mapbox/whoots-js": "^3.1.0",
+                "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+                "@types/geojson": "^7946.0.14",
+                "@types/geojson-vt": "3.2.5",
+                "@types/mapbox__point-geometry": "^0.1.4",
+                "@types/mapbox__vector-tile": "^1.3.4",
+                "@types/pbf": "^3.0.5",
+                "@types/supercluster": "^7.1.3",
+                "earcut": "^3.0.0",
+                "geojson-vt": "^4.0.2",
+                "gl-matrix": "^3.4.3",
+                "global-prefix": "^4.0.0",
+                "kdbush": "^4.0.2",
+                "murmurhash-js": "^1.0.0",
+                "pbf": "^3.3.0",
+                "potpack": "^2.0.0",
+                "quickselect": "^3.0.0",
+                "supercluster": "^8.0.1",
+                "tinyqueue": "^3.0.0",
+                "vt-pbf": "^3.1.3"
+            },
+            "engines": {
+                "node": ">=16.14.0",
+                "npm": ">=8.1.0"
+            },
+            "funding": {
+                "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+            }
+        },
+        "node_modules/maplibre-gl/node_modules/@mapbox/tiny-sdf": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+            "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+            "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/maplibre-gl/node_modules/@types/geojson": {
+            "version": "7946.0.16",
+            "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+            "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+            "license": "MIT"
+        },
+        "node_modules/maplibre-gl/node_modules/earcut": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+            "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+            "license": "ISC"
+        },
+        "node_modules/maplibre-gl/node_modules/geojson-vt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.3.tgz",
+            "integrity": "sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==",
+            "license": "ISC"
+        },
+        "node_modules/maplibre-gl/node_modules/global-prefix": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
+            "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^4.1.3",
+                "kind-of": "^6.0.3",
+                "which": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/maplibre-gl/node_modules/ini": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+            "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/maplibre-gl/node_modules/isexe": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+            "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/maplibre-gl/node_modules/kdbush": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+            "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+            "license": "ISC"
+        },
+        "node_modules/maplibre-gl/node_modules/potpack": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+            "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+            "license": "ISC"
+        },
+        "node_modules/maplibre-gl/node_modules/quickselect": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+            "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+            "license": "ISC"
+        },
+        "node_modules/maplibre-gl/node_modules/supercluster": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+            "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+            "license": "ISC",
+            "dependencies": {
+                "kdbush": "^4.0.2"
+            }
+        },
+        "node_modules/maplibre-gl/node_modules/which": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+            "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^3.1.1"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "license": "MIT",
@@ -11864,6 +12303,12 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
+        },
+        "node_modules/mitt": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+            "license": "MIT"
         },
         "node_modules/mlly": {
             "version": "1.8.2",
@@ -12594,6 +13039,12 @@
                 "pbf": "bin/pbf"
             }
         },
+        "node_modules/perfect-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "license": "MIT"
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "license": "ISC"
@@ -12615,6 +13066,36 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pinia": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+            "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-api": "^7.7.7"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.5.0",
+                "vue": "^3.5.11"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/pinia/node_modules/@vue/devtools-api": {
+            "version": "7.7.10",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+            "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-kit": "^7.7.10"
             }
         },
         "node_modules/pinkie": {
@@ -13665,6 +14146,12 @@
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/rfdc": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "license": "MIT"
         },
         "node_modules/rimraf": {
             "version": "5.0.10",
@@ -14825,6 +15312,15 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/speakingurl": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+            "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/splaytree": {
             "version": "3.2.3",
             "license": "MIT",
@@ -15343,6 +15839,18 @@
             "license": "ISC",
             "dependencies": {
                 "kdbush": "^3.0.0"
+            }
+        },
+        "node_modules/superjson": {
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+            "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+            "license": "MIT",
+            "dependencies": {
+                "copy-anything": "^4"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     },
     "dependencies": {
         "arches": "archesproject/arches#dev/8.2.x",
-        "arches_controlled_lists": "archesproject/arches-controlled-lists#dev/1.1.x",
-        "arches_modular_reports": "archesproject/arches-modular-reports#dev/1.1.x",
+        "arches_controlled_lists": "archesproject/arches-controlled-lists#1.2.0",
+        "arches_modular_reports": "archesproject/arches-modular-reports#2.0.0",
+        "arches_vue_components": "archesproject/arches-vue-components#2.0.2",
         "ckeditor4": "4.20.2",
         "cytoscape-elk": "^2.2.0",
         "datatables.net-rowgroup-dt": "^1.4.1",

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -345,6 +345,7 @@ module.exports = () => {
             ],
             resolve: {
                 modules: [Path.resolve(__dirname, PROJECT_RELATIVE_NODE_MODULES_PATH)],
+                extensions: ['.js', '.json', '.wasm', '.ts'],
                 alias: {
                     ...javascriptRelativeFilepathToAbsoluteFilepathLookup,
                     ...templateFilepathLookup,


### PR DESCRIPTION
## Description of the Issue
They changed the name of the arches-component-lab to arches-vue-components
This introduced some issues with webpack compiling as well as just updating dependencies.
They have refactored the defineProps to a generic type which foces a compile time type resolution which requires a tsconfig.json. This was not accessibly to any of the extensions in our current setup.
This links to a PR to update the arches container toolkit https://github.com/flaxandteal/arches-container-toolkit/pull/20 which adds a function to resolve to the project tsconfig.json file.

**Related Task:** [Link to task/issue]

---

## Changes Proposed
- Change installed apps
- Change urls

---

## Tests
- `git submodule update` or checkout the `fix/coral-setup` branch within docker
- run `make docker-compose CMD="build"
- start the app `make run` - should load
- `make webpack` should resolve without errors

---

## Additional Notes
[Any additional information that might be helpful]
